### PR TITLE
Expanding cleanupBR and ICEMS Translator

### DIFF
--- a/src/styles/all.css
+++ b/src/styles/all.css
@@ -111,3 +111,7 @@
   cursor: pointer;
 }
 
+.lighthouseKeeper-modified abbr {
+  font-weight: bold;
+}
+


### PR DESCRIPTION
Against #63.

Replaced "cleanupBR()" with "lighthouseKeeper()" to reflect extended usage
Now performs a number of replacements
- "&lt;br&gt;" becomes a HTML Linebreak (as with cleanupBR)
- "\n" does the same (affects Timeline Entries)
- Performs translation of ICEMS abbreviations, using HTML <abbr> tags

The ICEMS Translation is not the complete list, as the provided Excel file showed some abbreviations with different meaning for different services ("AA" = "As Above" to NSWPF, and "Air Ambulance" to NSW Ambulance).

Further Work Needed
- Appears to be some difficulty with abbreviations at the extreme end of the content string.
- Extend ICEMS dictionary to cover other commonly used terms
- Investigate ICEMS abbreviations containing ampersands
- Remove or adjust styling of <abbr> tags. Currently they are quite prominent for testing purposes