### PR TITLE
BUG FIX - Instant Task Dropdown Positioning

### DIFF
--- a/src/injectscripts/jobs/view.js
+++ b/src/injectscripts/jobs/view.js
@@ -570,9 +570,7 @@ $(document).ready(function() {
 
 function return_quicktaskbutton() {
   return (
-    <div style="position: relative;
-    display: inline-block;
-    vertical-align: middle;" class="dropdown">
+    <div id="lighthouse_instanttask" style="position:relative;display:inline-block;vertical-align:middle" class="dropdown">
     <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="lhtaskbutton"><img width="14px" style="vertical-align:top;margin-right:5px;float:left" src={lighthouseUrl+"icons/lh.png"}></img>Instant Task
     <span class="caret"></span></button>
     <ul class="dropdown-menu">

--- a/src/styles/all.css
+++ b/src/styles/all.css
@@ -145,6 +145,11 @@ div.team_complete_hidden div.list-group div.team_complete div.row.clearfix {
   cursor: pointer;
 }
 
+#lighthouse_instanttask .dropdown-menu {
+  left: auto;
+  right: 0;
+}
+
 
 
 .lighthouseKeeper-modified abbr {


### PR DESCRIPTION
Modifies the positioning of the dropdown shown by the "Instant Task" button on a Job Screen. Originally, it was positioned off the left side of the button (possibly overflowing from the screen). This change positions it aligned to the right side of the button, with the options being shown under the other buttons in this section.

After
![image](https://cloud.githubusercontent.com/assets/126774/18419537/adb47f68-78a0-11e6-9c50-d0a10f68372b.png)

