### PR TITLE
BUG FIX - #78 - Team List - Active Teams Collapsing

### DIFF
--- a/src/injectscripts/jobs/view.js
+++ b/src/injectscripts/jobs/view.js
@@ -148,9 +148,11 @@ function taskingItems_switch(){
 }
 
 function taskingItems_individual(e){
-  //console.log('e', e);
+  // Tasked Team Clicked On
   var $t = $(e.currentTarget);
-  $('div.row.clearfix:not(:contains("Set"))', $t).slideToggle();
+  // Only Toggle Content if the Clicked Team is Complete
+  if( $t.hasClass('team_complete') )
+    $('div.row.clearfix:not(:contains("Set"))', $t).slideToggle();
 }
 
 


### PR DESCRIPTION
Added check to code which is triggered when a Tasked Team is Clicked. Now will only operate when the Team being Clicked has a "Complete" status.