### PR TITLE
Export Hardcopy from Jobs Register

### DIFF
--- a/pages/exporthardcopy.html
+++ b/pages/exporthardcopy.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Advanced Export</title>
+</head>
+<body class="small_foot_body">
+<div id="loading" style="display:none" class="hidden-print">
+  <div id="loadmiddle">
+    <div id="loadinner">
+      <p>Loading<span class="dots"><span>.</span><span>.</span><span>.</span></span></p>
+      <div class="loadprogress" role="button" aria-label="progress"></div>
+    </div>
+  </div>
+</div>
+<div id="form" class="hidden-print" style="display:none">
+  <div>
+    <form role="form" class="form-horizontal" onsubmit="return false">
+      <fieldset>
+        <legend>Export Hardcopy</legend>
+        <div class="form-group">
+          <label class="col-md-4 control-label" for="tasker">Tasking Unit/Operations Centre</label>  
+          <div class="col-md-4">
+            <input id="tasker" name="tasker" type="text" placeholder="Heresville SES" class="form-control input-md" required="">            
+          </div>
+        </div>
+
+        <!-- Text input-->
+        <div class="form-group">
+          <label class="col-md-4 control-label" for="tasker_email">SES Contact Email</label>  
+          <div class="col-md-4">
+            <input id="tasker_email" name="tasker_email" type="text" placeholder="eg unit.ops@ses.nsw.gov.au" class="form-control input-md">
+            <span class="help-block">Ensure this email address is monitored</span>
+          </div>
+        </div>
+
+        <!-- Text input-->
+        <div class="form-group">
+          <label class="col-md-4 control-label" for="tasker_phone">SES Contact Phone</label>  
+          <div class="col-md-4">
+            <input id="tasker_phone" name="tasker_phone" type="text" placeholder="eg 0242516111" class="form-control input-md">
+            <span class="help-block">Ensure this phone number is contactable</span>  
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-md-4 control-label" for="tasker_fax">SES Contact Fax</label>  
+          <div class="col-md-4">
+            <input id="tasker_fax" name="tasker_fax" type="text" placeholder="eg 0242516222" class="form-control input-md">
+            <span class="help-block">(Optional) Ensure this fax number is monitored</span>
+          </div>
+        </div>
+        <!-- Button (Double) -->
+        <div class="form-group">
+          <div class="col-md-8">
+            <button id="goButton" name="goButton" class="btn btn-success">Create Jobsheets for Print/Fax</button>
+          </div>
+        </div>
+      </fieldset>
+    </form>
+  </div>
+</div>
+<div id="results">
+  <div class="hidden-print">
+    <h1>Export Job Hardcopies</h1>
+    <p>Print this page, or save it as a PDF to get these jobs, one job per page, for use in the field or with other agencies.</p>
+  </div>
+</div>
+<footer class="small_foot hidden-print">
+  Designed &amp; developed by volunteers of the NSW SES.
+  <a href="https://github.com/NSWSESMembers/Lighthouse" target="_blank">Lighthouse</a>
+  is distributed under an
+  <a href= "https://github.com/NSWSESMembers/Lighthouse/blob/master/LICENSE.md" rel="license" target="_blank">MIT Licence</a>.
+</footer>
+<script src="vendors/greensock-js/src/minified/TweenMax.min.js"></script>
+<script src="scripts/exporthardcopy.js" type="text/javascript"></script>
+</body>
+</html>

--- a/pages/exporthardcopy.html
+++ b/pages/exporthardcopy.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>Advanced Export</title>
+<title>Export Hardcopy</title>
 </head>
 <body class="small_foot_body">
 <div id="loading" style="display:none" class="hidden-print">

--- a/pages/scripts/exporthardcopy.js
+++ b/pages/scripts/exporthardcopy.js
@@ -1,0 +1,269 @@
+var DOM = require('jsx-dom-factory');
+var _ = require('underscore');
+var $ = require('jquery');
+global.jQuery = $;
+var ElasticProgress = require('elastic-progress');
+
+var LighthouseJob = require('../lib/shared_job_code.js');
+var LighthouseUnit = require('../lib/shared_unit_code.js');
+var LighthouseJson = require('../lib/shared_json_code.js');
+
+// inject css c/o browserify-css
+require('../styles/exporthardcopy.css');
+
+var timeoverride = null;
+
+window.onerror = function(message, url, lineNumber) {
+  $('#loading')
+    .html('Error loading page<br>' + message + ' Line ' + lineNumber)
+    .show();
+  return true;
+};
+
+
+var selectedcolumns = [
+  'Identifier' ,  // Beacon Job ID
+  'JobReceived' , // Job Recieved Date/Time
+
+  'JobPriorityType.Name' , // Priority
+
+  'Address.PrettyAddress' ,         // Address
+  'Address.AdditionalAddressInfo' , // Additional Address Info
+
+  'PermissionToEnterPremises' , // Permission to Enter
+  'howToEnterPremises' ,        // How to Enter
+
+  'SituationOnScene' , // Situation On Scene
+  'Tags' ,             // Tags
+
+  'CallerFirstName' ,   // Caller - First Name
+  'CallerLastName' ,    // Caller - Last Name
+  'CallerPhoneNumber' , // Caller - Phone Number
+  'ContactFirstName' ,  // Job Contact - First Name
+  'ContactLastName' ,   // Job Contact - Last Name
+  'ContactPhoneNumber'  // Job Contact - Phone Number
+];
+
+
+var timeperiod;
+var unit = [];
+
+var params = getSearchParameters();
+
+
+/*
+var element = document.querySelector('.loadprogress');
+var mp = new ElasticProgress(element, {
+  buttonSize: 60,
+  fontFamily: 'Montserrat',
+  colorBg:    '#edadab',
+  colorFg:    '#d2322d',
+  onClose:function(){
+    $('#loading')
+    .hide();
+  }
+});
+*/
+RunForestRun();
+
+
+function getSearchParameters() {
+  var prmstr = window.location.search.substr(1);
+  return prmstr != null && prmstr != '' ? transformToAssocArray(prmstr) : {};
+}
+
+function transformToAssocArray(prmstr) {
+  var params = {};
+  var prmarr = prmstr.split('&');
+  for (var i = 0; i < prmarr.length; i++) {
+    var tmparr = prmarr[i].split('=');
+    params[tmparr[0]] = tmparr[1];
+  }
+  return params;
+}
+
+
+//Get times vars for the call
+function RunForestRun(mp) {
+  mp && mp.open();
+  $('#loading')
+    .show();
+  HackTheMatrix(params.hq, params.host, mp);
+}
+
+
+var jobTemplate = '<table class="jobHardcopy">'+
+                    '<tr><th class="lh_jhc_ref">Job Reference #++Identifier++++JobPriorityType.Name++</th></tr>'+
+                    '<tr><td class="lh_jhc_recd">Job Reported: ++JobReceived++</td></tr>'+
+                    '<tr><td colspan="2" class="lh_jhc_addr">++Address.PrettyAddress++</td></tr>'+
+                    '<tr><td colspan="2" class="lh_jhc_addr_addl">++Address.AdditionalAddressInfo++</td></tr>'+
+                    '<tr><td height="30">&nbsp;</td></tr>'+
+                    '<tr><td class="lh_jhc_sos"><strong>Situation On Scene:</strong><br/>++SituationOnScene++</td></tr>'+
+                    '<tr><td height="30">&nbsp;</td></tr>'+
+                    '<tr><td class="lh_jhc_tags"><strong>Tags:</strong><br/>++Tags++</td></tr>'+
+                    '<tr><td height="30">&nbsp;</td></tr>'+
+                    '<tr><td class="lh_jhc_caller"><strong>Caller:</strong> ++CallerFirstName++ ++CallerLastName++ ++CallerPhoneNumber++</td></tr>'+
+                    '<tr><td class="lh_jhc_contact"><strong>Job Contact:</strong> ++ContactFirstName++ ++ContactLastName++ ++ContactPhoneNumber++</td></tr>'+
+                    '<tr><td class="lh_jhc_access"><strong>Property Access:</strong> ++PermissionToEnterPremises++++howToEnterPremises++</td></tr>'+
+                    '<tr><td height="30">&nbsp;</td></tr>'+
+                    '<tr><th class="lh_jhc_attend_head">Attendance Details</th></tr>'+
+                    '<tr class="lh_jhc_form"><td>Team or Team Leader Name:</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>Date &amp; Time Of Arrival:</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>Date &amp; Time Of Departure:</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>Description of Situation:</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>&nbsp;</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>&nbsp;</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>Work Performed:</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>&nbsp;</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>&nbsp;</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>&nbsp;</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>Any Further Work Needed:</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>&nbsp;</td></tr>'+
+                    '<tr class="lh_jhc_form"><td>&nbsp;</td></tr>'+
+                      /*
+                    '<tr>'+
+                      '<td>'+
+                        '<table class="jobHardcopy_tasker">'+
+                          '<tr><td>++tasker++<br/>Email: ++tasker_email++<br/>Phone: ++tasker_phone++<br/>Fax: ++tasker_fax++</td></tr>'+
+                          '<tr><td></td></tr>'+
+                        '</table>'+
+                      '</td>'+
+                    '</tr>'+
+                      */
+                  '</table>'+
+                  '<hr/>';
+
+//make the call to beacon
+function HackTheMatrix(id, host, progressBar) {
+  console.log('HackTheMatrix( %s , %s , %o )',id, host, progressBar);
+  var unit = [];
+  var start = new Date(decodeURIComponent(params.start));
+  var end = new Date(decodeURIComponent(params.end));
+
+  if(selectedcolumns.length == 0){
+    console.log('No Fields Selected');
+    return false;
+  }else{
+    console.log('selectedcolumns = %o' , selectedcolumns);
+  }
+
+  if (typeof id !== 'undefined') {
+    id.split(',').forEach(function(d){
+      var newObj = {'Id': d};
+      unit.push(newObj);
+    });
+  }
+
+  if(unit.length == 0){
+    console.log('No Units Selected');
+  }else{
+    console.log(unit);
+  }
+
+
+  LighthouseJob.get_json(unit, host, start, end, function(jobs) {
+
+    $.each(jobs.Results , function(k,v){
+      var thisJob = jobTemplate;
+      _.each(selectedcolumns, function(key){
+        // Raw Value
+        var rawValue = key.split('.').reduce(function(obj,i) {return obj[i]}, v);
+        // Special Cases
+        switch(key){
+          case 'JobReceived':
+            var rawDate = new Date(v.JobReceived);
+            rawDate = new Date(rawDate.getTime() + ( rawDate.getTimezoneOffset() * 60000 ));
+            rawValue = (''+rawDate).split( ' GMT' )[0];
+            break;
+          case 'Tags':
+            rawValue = v.Tags.map(function(v){return v.Name}).join(' , ');
+            break;
+          case 'JobPriorityType.Name':
+            rawValue = ( rawValue == 'General' ? '' : ' ('+rawValue+')' );
+            break;
+          case 'PermissionToEnterPremises':
+            rawValue = ( rawValue ? 'P' : '<strong>NO</strong> P' )+'ermission granted to access premises if resident is absent';
+            break;
+        }
+        if( rawValue == null )
+          rawValue = '';
+        thisJob = thisJob.replace( '++' + key + '++' , rawValue );
+      });
+      thisJob = thisJob.replace( /\+\+[^\+]+\+\+/g , '<em>Unknown or Unavailable</em>' );
+      $('#results').append(thisJob);
+    });
+
+    //progressBar && progressBar.setValue(1);
+    //progressBar && progressBar.close();
+    //downloadCSV("LighthouseExport.csv", beacon_jobs, selectedcolumns);
+
+    //progressBar && progressBar.close();
+    
+    window.print();
+
+  },function(val,total){
+    progressBar && progressBar.setValue(val/total);
+  });
+}
+
+function convertArrayOfObjectsToCSV(data, selectedcolumns) {  
+
+  var result, ctr, keys, columnDelimiter, lineDelimiter, data;
+
+  if (data == null || !data.length) {
+    return null;
+  }
+
+  //console.log('data', data);
+
+  var rows = [];
+  var delimCellL = '"=""';
+  var delimCellR = '"""';
+  var delimCol   = delimCellR + ',' + delimCellL;
+  var delimLine  = '\n';
+
+  // Getting Column Headings
+  var fieldKeys = fieldLabels = [];
+  _.each(lighthouse_fieldArray, function(fields, section){
+    _.each(fields, function(label, key){
+      fieldKeys.push(key);
+      fieldLabels.push(label);
+    });
+  });
+  selectedcolumns.map(function(v, k){
+    return fieldLabels[fieldKeys.indexOf(v)];
+  })
+
+  rows.push( delimCellL + selectedcolumns.join( delimCol ) + delimCellR );
+
+  data.forEach(function(item){
+    rows.push( delimCellL + item.join( delimCol ) + delimCellR );
+  });
+
+  return rows.join( delimLine );
+}
+
+
+function downloadCSV(file, dataIn, keyIn) {  
+  var csv = convertArrayOfObjectsToCSV(dataIn, keyIn);
+  if (csv == null)
+    return;
+
+var saveData = (function () {
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.style = "display: none";
+    return function (data, fileName) {
+            blob = new Blob([data], {type: "octet/stream"}),
+            url = window.URL.createObjectURL(blob);
+        a.href = url;
+        a.download = fileName;
+        a.click();
+        window.URL.revokeObjectURL(url);
+    };
+}());
+
+
+saveData(csv, file);
+
+}

--- a/pages/scripts/exporthardcopy.js
+++ b/pages/scripts/exporthardcopy.js
@@ -198,7 +198,9 @@ function HackTheMatrix(id, host, progressBar) {
     //downloadCSV("LighthouseExport.csv", beacon_jobs, selectedcolumns);
 
     //progressBar && progressBar.close();
-    
+
+    $('#loadinner p').text('Loaded');
+
     window.print();
 
   },function(val,total){

--- a/pages/styles/exporthardcopy.css
+++ b/pages/styles/exporthardcopy.css
@@ -1,0 +1,65 @@
+@import url("include/common.css");
+
+.small_foot_body {
+  min-width: auto;
+}
+
+fieldset {
+  max-width: 800px;
+  padding: .35em .625em .75em;
+  margin: 2em auto 0;
+}
+legend {
+  padding: .35em 0 0 0;
+  margin-bottom: 0;
+}
+label.checkbox-inline {
+  display: block;
+  padding: 3px 3px 3px 5px;
+  margin: 10px;
+  border-radius: 3px;
+  background: #F0F0F0;
+}
+label.checkbox-inline input[type="checkbox"] {
+  position: relative;
+  margin-left: 0;
+  margin-right: 5px;
+}
+#button_holder {
+  clear: both;
+  padding: 30px 20px 0;
+  text-align: right;
+}
+
+hr {
+  page-break-after: always;
+  visibility: hidden;
+}
+table.jobHardcopy {
+  width: 100%;
+}
+table.jobHardcopy .lh_jhc_ref {
+  font-size: 1.1em;
+  font-weight: bold;
+}
+table.jobHardcopy .lh_jhc_recd {
+  text-align: right;
+}
+table.jobHardcopy .lh_jhc_addr {
+  font-size: 2em;
+  font-weight: bold;
+}
+table.jobHardcopy .lh_jhc_addr_addl {
+  font-size: 1.2em;
+  font-weight: bold;
+}
+table.jobHardcopy .lh_jhc_attend_head {
+  font-size: 1.2em;
+  text-align: center;
+}
+table.jobHardcopy .lh_jhc_form th ,
+table.jobHardcopy .lh_jhc_form td {
+  font-weight: bold;
+  height: 40px;
+  border-bottom: 1px solid #CCC;
+}

--- a/pages/styles/exporthardcopy.css
+++ b/pages/styles/exporthardcopy.css
@@ -1,5 +1,9 @@
 @import url("include/common.css");
 
+body {
+  overflow: hidden;
+}
+
 .small_foot_body {
   min-width: auto;
 }

--- a/src/contentscripts/jobs/jobs.js
+++ b/src/contentscripts/jobs/jobs.js
@@ -5,12 +5,15 @@ var DOM = require('jsx-dom-factory');
 // Add buttons to top of job screen for summary, statistics and advanced export
 var buttonBar = $('.job-page .job-reg-widget .btn-group.pull-left.text-left');
 
-function makeButton(id, background, border, text) {
+function makeButton(id, page, background, border, text) {
   return $(
     <a href="#"
+       data-page={page}
        id={id}
        class="btn btn-sm btn-default"
-       style={'margin-left: 20px; background: ' + background + '; border-color: ' + border + '; color: white;'}>
+       style={'margin-left: 20px; background: ' + background + '; border-color: ' + border + '; color: white;'}
+       title={'[Lighthouse] ' + text + ' (Filtered)'}
+       target="_blank">
       <img style="width: 16px; vertical-align: top; margin-right: 5px"
            src={chrome.extension.getURL("icons/lh.png")} />{text}
     </a>
@@ -18,9 +21,10 @@ function makeButton(id, background, border, text) {
   .appendTo(buttonBar);
 }
 
-makeButton("lighthouseSummaryButton", "#175781", "#0f3a57", "Summary (Filtered)");
-makeButton("lighthouseStatsButton", "rebeccapurple", "#4c2673", "Statistics (Filtered)");
-makeButton("lighthouseExportButton", "#d2322d", "#edadab", "Advanced Export (Filtered)");
+makeButton("lighthouseSummaryButton",  'summary',        "#175781",       "#0f3a57", "Summary");
+makeButton("lighthouseStatsButton",    'stats',          "rebeccapurple", "#4c2673", "Statistics");
+makeButton("lighthouseExportButton",   'advexport',      "#d2322d",       "#edadab", "Advanced Export");
+makeButton("lighthouseHardcopyButton", 'exporthardcopy', "#175781",       "#0f3a57", "Export Hardcopy");
 
 //inject our JS resource
 inject('jobs/jobs.js');

--- a/src/injectscripts/jobs/jobs.js
+++ b/src/injectscripts/jobs/jobs.js
@@ -9,60 +9,18 @@ window.FinaliseSelected = function FinaliseSelected(words,beaconStringDate) { //
 }
 
 
-$("#lighthouseSummaryButton").mouseenter(function(ev){
-  summary();
-});
-
-document.getElementById("lighthouseSummaryButton").onclick = function() {
-  summary();
-}
-
-
-function summary() {
+function updateFilterParameters(event){
+  var $t = $(event.target);
   var exports = JSON.parse(filterDataForExport());
-  if (exports.hasOwnProperty("Hq")) {
-    $("#lighthouseSummaryButton").attr("href",lighthouseUrl+"pages/summary.html?host="+location.hostname+"&hq="+exports.Hq+"&start="+encodeURIComponent(exports.StartDate)+"&end="+encodeURIComponent(exports.EndDate));
-  } else {
-    $("#lighthouseSummaryButton").attr("href",lighthouseUrl+"pages/summary.html?host="+location.hostname+"&start="+encodeURIComponent(exports.StartDate)+"&end="+encodeURIComponent(exports.EndDate));
-  }
+  var page = lighthouseUrl + 'pages/' + $t.data('page') + '.html';
+  var queryString = 'host='+location.hostname+'&start='+encodeURIComponent(exports.StartDate)+'&end='+encodeURIComponent(exports.EndDate);
+  if (exports.hasOwnProperty("Hq"))
+    queryString += '&hq='+exports.Hq;
+  $t.attr( 'href' , page + '?' + queryString );
 }
 
-$("#lighthouseStatsButton").mouseenter(function(ev){
-  stats();
-});
-
-document.getElementById("lighthouseStatsButton").onclick = function() {
-  stats();
-}
-
-
-function stats(){
-  var exports = JSON.parse(filterDataForExport());
-  if (exports.hasOwnProperty("Hq")){
-    $("#lighthouseStatsButton").attr("href",lighthouseUrl+"pages/stats.html?host="+location.hostname+"&hq="+exports.Hq+"&start="+encodeURIComponent(exports.StartDate)+"&end="+encodeURIComponent(exports.EndDate));
-  } else {
-    $("#lighthouseStatsButton").attr("href",lighthouseUrl+"pages/stats.html?host="+location.hostname+"&start="+encodeURIComponent(exports.StartDate)+"&end="+encodeURIComponent(exports.EndDate));
-  }
-}
-
-
-$("#lighthouseExportButton").mouseenter(function(ev){
-  advexport();
-});
-
-document.getElementById("lighthouseExportButton").onclick = function() {
-  summary();
-}
-
-
-function advexport() {
-  var exports = JSON.parse(filterDataForExport());
-  if (exports.hasOwnProperty("Hq")){
-    $("#lighthouseExportButton").attr("href",lighthouseUrl+"pages/advexport.html?host="+location.hostname+"&hq="+exports.Hq+"&start="+encodeURIComponent(exports.StartDate)+"&end="+encodeURIComponent(exports.EndDate));
-  } else {
-    $("#lighthouseExportButton").attr("href",lighthouseUrl+"pages/advexport.html?host="+location.hostname+"&start="+encodeURIComponent(exports.StartDate)+"&end="+encodeURIComponent(exports.EndDate));
-  }
-}
+$('#lighthouseSummaryButton , #lighthouseStatsButton , #lighthouseExportButton , #lighthouseHardcopyButton')
+  .on('mouseenter click',updateFilterParameters);
 
 
 //More pageination choices!


### PR DESCRIPTION
Adds Export Hardcopy button to Jobs Register
![image](https://cloud.githubusercontent.com/assets/126774/18712419/ae15a802-8051-11e6-83f4-bc5f8486c4be.png)

Clicking that button compiles the details for the Filtered Jobs into HTML, with CSS page breaks, and triggers the Browser to Print. The User can then select whether to print to a PDF file which can be emailed to Other Agencies/Liaison Officers, or printed on paper for the same purposes, or for Crews who are not managing their tasking via Beacon.

Also possibly handy for instances where internet access is unavailable and the IMT have to revert to WOC.
