### PR TITLE
Fixes empty lines in Notes

### DIFF
--- a/src/styles/all.css
+++ b/src/styles/all.css
@@ -151,7 +151,9 @@ div.team_complete_hidden div.list-group div.team_complete div.row.clearfix {
 }
 
 
-
+div[data-bind="text: $data"] {
+  min-height: 1em;
+}
 .lighthouseKeeper-modified abbr {
   font-weight: bold;
 }


### PR DESCRIPTION
Empty lines (empty divs) now have a minimum height of 1em

**BEFORE**
![image](https://cloud.githubusercontent.com/assets/126774/19221889/e3183bf6-8e97-11e6-90ff-9b419699d577.png)

**AFTER**
![image](https://cloud.githubusercontent.com/assets/126774/19221894/edf9876e-8e97-11e6-968f-65af3dba6dc4.png)
