### PR TITLE
Team message.wip

### DIFF
--- a/lib/getteams.js
+++ b/lib/getteams.js
@@ -11,7 +11,7 @@ var ReturnTeamsActiveAtLHQ = function(hq,sector,cb) {
 		$.ajax({
 			type: 'GET'
 			, url: '/Api/v1/Entities/'+hq.Id+'/Children'
-			, data: {LighthouseFunction: 'QuickTaskResolveChildrenOfEntity'}
+			, data: {LighthouseFunction: 'ResolveChildrenOfEntity'}
 			, cache: false
 			, dataType: 'json'
 			, complete: function(response, textStatus) {

--- a/lib/getteams.js
+++ b/lib/getteams.js
@@ -38,7 +38,7 @@ var ReturnTeamsActiveAtLHQ = function(hq,sector,cb) {
 
 
 
-		theData = {
+		var theData = {
 			'StartDate':          end.toISOString()
 			, 'EndDate':            now.toISOString()
 			, 'TypeIds[]':          1

--- a/lib/getteams.js
+++ b/lib/getteams.js
@@ -4,7 +4,7 @@ var ReturnTeamsActiveAtLHQ = function(hq,sector,cb) {
 	var end = moment();
 	end.subtract(1, 'y');
 
-	UnitsToSearch = []
+	var UnitsToSearch = []
 
 	if (hq.EntityTypeId != 1) {
 		console.log("HQ Entity is not a unit, will resolve group")
@@ -51,8 +51,8 @@ var ReturnTeamsActiveAtLHQ = function(hq,sector,cb) {
 			,'LighthouseFunction': 'getteams' 
 		}
 
-		AssignedToId = []
-		CreatedAtId = []
+		var AssignedToId = []
+		var CreatedAtId = []
 		$.each(UnitsToSearch, function(k,v){
 			AssignedToId.push(v)
 			CreatedAtId.push(v)

--- a/lib/getteams.js
+++ b/lib/getteams.js
@@ -10,7 +10,7 @@ var ReturnTeamsActiveAtLHQ = function(hq,sector,cb) {
 		console.log("HQ Entity is not a unit, will resolve group")
 		$.ajax({
 			type: 'GET'
-			, url: '/Api/v1/Entities/'+user.hq.Id+'/Children'
+			, url: '/Api/v1/Entities/'+hq.Id+'/Children'
 			, data: {LighthouseFunction: 'QuickTaskResolveChildrenOfEntity'}
 			, cache: false
 			, dataType: 'json'

--- a/lib/getteams.js
+++ b/lib/getteams.js
@@ -1,0 +1,89 @@
+var ReturnTeamsActiveAtLHQ = function(hq,sector,cb) {
+
+	var now = moment();
+	var end = moment();
+	end.subtract(1, 'y');
+
+	UnitsToSearch = []
+
+	if (hq.EntityTypeId != 1) {
+		console.log("HQ Entity is not a unit, will resolve group")
+		$.ajax({
+			type: 'GET'
+			, url: '/Api/v1/Entities/'+user.hq.Id+'/Children'
+			, data: {LighthouseFunction: 'QuickTaskResolveChildrenOfEntity'}
+			, cache: false
+			, dataType: 'json'
+			, complete: function(response, textStatus) {
+				console.log('textStatus = "%s"', textStatus, response);
+				if(textStatus == 'success')
+				{
+					if(response.responseJSON.length) {
+						$.each(response.responseJSON, function(k,v){
+							UnitsToSearch.push(v.Id);
+						})
+					}
+					GetTeams(UnitsToSearch)
+				}
+			}
+		})
+
+	} else {
+		UnitsToSearch.push(hq.Id)
+		GetTeams(UnitsToSearch)
+
+	}
+
+	function GetTeams(UnitsToSearch) {
+
+
+
+		theData = {
+			'StartDate':          end.toISOString()
+			, 'EndDate':            now.toISOString()
+			, 'TypeIds[]':          1
+			, 'IncludeDeleted':     false
+			, 'StatusTypeId[]':     3
+			, 'PageIndex':          1
+			, 'PageSize':           1000
+			, 'SortField':          'Callsign'
+			, 'SortOrder':          'asc'
+			,'LighthouseFunction': 'getteams' 
+		}
+
+		AssignedToId = []
+		CreatedAtId = []
+		$.each(UnitsToSearch, function(k,v){
+			AssignedToId.push(v)
+			CreatedAtId.push(v)
+		})
+
+		theData.AssignedToId = AssignedToId
+		theData.CreatedAtId = CreatedAtId
+
+		if (sector !== null)
+		{
+			theData.SectorIds = sector
+			theData.Unsectorised = true
+		}
+
+		$.ajax({
+			type: 'GET'
+			, url: '/Api/v1/Teams/Search'
+			, data: theData
+			, cache: false
+			, dataType: 'json'
+			, complete: function(response, textStatus) {
+				console.log('textStatus = "%s"', textStatus, response);
+				if(textStatus == 'success')
+				{
+					cb(response)
+				}
+
+			}
+		})
+
+	}
+}
+
+module.exports = ReturnTeamsActiveAtLHQ;

--- a/pages/styles/include/common.css
+++ b/pages/styles/include/common.css
@@ -250,9 +250,9 @@ p {
 }
 
 footer {
-	position: fixed;
+	position: relative;
 	background-color: white;
-	bottom: 0px;
+	bottom: -20px;
 	width: 100%;
 	height: 55px;
 	font-size: 12px;

--- a/src/background.js
+++ b/src/background.js
@@ -5,7 +5,6 @@
 //block message js core requests
 chrome.webRequest.onBeforeRequest.addListener(
 	function (details) {
-		console.log(details)
 		var javascriptCode = loadSynchronously(details.url);
 		var replaced = "var msgsystem;"+javascriptCode.replace("CreateMessageViewModel,f,t,i,r,u;","CreateMessageViewModel,f,t,i,r,u;msgsystem = n;");
 		return { redirectUrl: "data:text/javascript,"+encodeURIComponent(replaced) };
@@ -16,10 +15,9 @@ chrome.webRequest.onBeforeRequest.addListener(
 
 function loadSynchronously(url) {
 	var request = new XMLHttpRequest();
-request.open('GET', url, false);  // `false` makes the request synchronous
-request.send(null);
-
-if (request.status === 200) {
-	return(request.responseText);
-}
+	request.open('GET', url, false);  // `false` makes the request synchronous
+	request.send(null);
+	if (request.status === 200) {
+		return(request.responseText);
+	}
 }

--- a/src/background.js
+++ b/src/background.js
@@ -4,8 +4,22 @@
 
 //block message js core requests
 chrome.webRequest.onBeforeRequest.addListener(
-  function (details) {
-    return {cancel: true};
-  },
-  { urls: ["https://*.ses.nsw.gov.au/js/messages/create?v=*"] },
-  ["blocking"]);
+	function (details) {
+		console.log(details)
+		var javascriptCode = loadSynchronously(details.url);
+		var replaced = "var msgsystem;"+javascriptCode.replace("CreateMessageViewModel,f,t,i,r,u;","CreateMessageViewModel,f,t,i,r,u;msgsystem = n;");
+		return { redirectUrl: "data:text/javascript,"+encodeURIComponent(replaced) };
+	},
+	{ urls: ["https://*.ses.nsw.gov.au/js/messages/create?v=*"] },
+	["blocking"]);
+
+
+function loadSynchronously(url) {
+	var request = new XMLHttpRequest();
+request.open('GET', url, false);  // `false` makes the request synchronous
+request.send(null);
+
+if (request.status === 200) {
+	return(request.responseText);
+}
+}

--- a/src/background.js
+++ b/src/background.js
@@ -2,7 +2,7 @@
 // separate to all other pages.
 
 
-//block message js core requests
+//block message js core request, fetch the file, inject our vars then serve it back to the requestor. :-)
 chrome.webRequest.onBeforeRequest.addListener(
 	function (details) {
 		var javascriptCode = loadSynchronously(details.url);
@@ -12,7 +12,8 @@ chrome.webRequest.onBeforeRequest.addListener(
 	{ urls: ["https://*.ses.nsw.gov.au/js/messages/create?v=*"] },
 	["blocking"]);
 
-
+//block so that the code can come back before letting the page load
+//possibly should rewrite this so its not blocking but that will have ramifications
 function loadSynchronously(url) {
 	var request = new XMLHttpRequest();
 	request.open('GET', url, false);  // `false` makes the request synchronous

--- a/src/contentscripts/messages/create.js
+++ b/src/contentscripts/messages/create.js
@@ -36,6 +36,26 @@ function recipientsButtons() {
 
 $('#content div.row div.col-md-10.col-lg-9 div fieldset:nth-child(2) div.panel.panel-default').append(recipientsButtons);
 
+function renderHQTeams() {
+	return (
+		<fieldset id="HQTeamsSet" >
+		<legend><img style="width:16px;vertical-align:baseline;margin-right:5px;margin-left:5px"
+		src={chrome.extension.getURL("icons/lh-black.png")} />Teams Attached to HQ</legend>
+		<div class="panel panel-default">
+		<div class="panel-heading"><span id="teamshq">HQ Teams</span><span id="teamscount" class="pull-right badge">0</span></div>
+		<div id="lighthouseteams" class="panel-body">
+		</div>
+		</div>
+		</fieldset>
+		);
+}
+
+hqgroup = renderHQTeams()
+$(hqgroup).hide()
+
+
+$('#content div.row div.col-md-10.col-lg-9 div fieldset:nth-child(1)').after(hqgroup);
+
 function renderCollections() {
 	return (
 		<fieldset>
@@ -51,6 +71,8 @@ function renderCollections() {
 }
 
 $('#content div.row div.col-md-10.col-lg-9 div fieldset:nth-child(2)').after(renderCollections);
+
+
 
 
 

--- a/src/contentscripts/messages/create.js
+++ b/src/contentscripts/messages/create.js
@@ -2,37 +2,7 @@ var inject = require('../../../lib/inject.js');
 var DOM = require('jsx-dom-factory');
 var $ = require('jquery');
 
-var xhttp = new XMLHttpRequest();
-
-
-xhttp.onreadystatechange = function() {
-	if (xhttp.readyState == 4 && xhttp.status == 200) {
-		var result = xhttp.responseText;
-		var replaced = result.replace("CreateMessageViewModel,f,t,i,r,u;","CreateMessageViewModel,f,t,i,r,u;msgsystem = n;");
-		var script = document.createElement("script");
-		script.innerHTML = "var msgsystem;"+replaced;
-		document.head.appendChild(script);
-		//inject our JS resource
-		inject('messages/create.js');
-	}
-};
-
-function findMessageUrl(cb) {
-	$('script').each(function(){
-		if(this.src.indexOf("/js/messages/create?v=") != -1){
-			cb(this.src.replace(/^[^\?]+\??/,''));
-		}
-	});
-}
-
-findMessageUrl(function(url){
-	console.log("Fetching "+window.location.origin+"/js/messages/create#?"+url);
-	xhttp.open("GET", window.location.origin+"/js/messages/create#?"+url, true);
-	xhttp.send();
-})
-
-
-
+inject('messages/create.js');
 
 function renderCheckBox() {
 	var selected = (localStorage.getItem("LighthouseMessagesEnabled") == "true" || localStorage.getItem("LighthouseMessagesEnabled") == null) ? "fa-check-square-o" : "fa-square-o";

--- a/src/contentscripts/messages/create.js
+++ b/src/contentscripts/messages/create.js
@@ -50,7 +50,7 @@ function renderHQTeams() {
 		);
 }
 
-hqgroup = renderHQTeams()
+var hqgroup = renderHQTeams()
 $(hqgroup).hide()
 
 

--- a/src/injectscripts/jobs/view.js
+++ b/src/injectscripts/jobs/view.js
@@ -260,7 +260,7 @@ masterViewModel.completeTeamViewModel.primaryActivity.subscribe(function(newValu
   function InstantTaskButton() {
 
 
-    alreadyTasked = []
+    var alreadyTasked = []
     $.each(masterViewModel.teamsViewModel.taskedTeams.peek(), function(k,v){
       if(v.CurrentStatusId != 6)
       {

--- a/src/injectscripts/jobs/view.js
+++ b/src/injectscripts/jobs/view.js
@@ -268,13 +268,13 @@ masterViewModel.completeTeamViewModel.primaryActivity.subscribe(function(newValu
       }
     })
     $(quickTask).find('ul').empty();
-    loading = (<li><a href="#"><i class="fa fa-refresh fa-spin fa-2x fa-fw"></i></a></li>)
+    var loading = (<li><a href="#"><i class="fa fa-refresh fa-spin fa-2x fa-fw"></i></a></li>)
     $(quickTask).find('ul').append(loading)
 
     lh_SectorFilterEnabled = !( localStorage.getItem('LighthouseSectorFilterEnabled') == 'true' || localStorage.getItem('LighthouseSectorFilterEnabled') == null );
 
 
-    sectorFilter = null
+    var sectorFilter = null
     if (masterViewModel.sector.peek() !== null && lh_SectorFilterEnabled === true )
     {
      sectorFilter = masterViewModel.sector.peek().Id
@@ -325,7 +325,7 @@ masterViewModel.completeTeamViewModel.primaryActivity.subscribe(function(newValu
             $.each(response.responseJSON.Results, function(k, v) { //for every team that came back
           if ($.inArray(v.Id,alreadyTasked) == -1) //not a currently active team on this job, so we can task them
           {
-            var item;
+            var item = null;
             if (v.Members.length == 0)
             {
               item = return_li(v.Id,v.Callsign.toUpperCase(),null,v.TaskedJobCount+"");
@@ -339,7 +339,7 @@ masterViewModel.completeTeamViewModel.primaryActivity.subscribe(function(newValu
               })
             }
             //still create teams that have no TL
-            if (typeof(item) == "undefined") {
+            if (item === null) {
               item = return_li(v.Id,v.Callsign.toUpperCase(),"No TL",v.TaskedJobCount+"");
             }
 

--- a/src/injectscripts/messages/create.js
+++ b/src/injectscripts/messages/create.js
@@ -155,16 +155,24 @@ DoTour()
 
 
 function LoadTeams() {
-    console.log(msgsystem.selectedHeadquarters.peek())
     ReturnTeamsActiveAtLHQ(msgsystem.selectedHeadquarters.peek(),null,function(response){
         console.log(response);
         $('#teamscount').text(response.responseJSON.Results.length)
         if(response.responseJSON.Results.length) {
-            $('#lighthouseteams').empty()
+            $('#lighthouseteams').empty() //empty to prevent dupes
             $.each(response.responseJSON.Results, function(k, v) {
-                if (v.Members.length > 0)
+                if (v.Members.length > 0) //only show teams with members
             {
-                var $button = make_team_button(v.Callsign,v.Members.length+"")
+                TL = ""
+                $.each(v.Members,function(kk,vv) {
+                    console.log(vv)
+                    if (vv.TeamLeader == true)
+                    {
+                        TL = vv.Person.FirstName+" "+vv.Person.LastName
+                    }
+                })
+                //length + "" to make it a string
+                var $button = make_team_button(v.Callsign,TL,v.Members.length+"")
                 $($button).click(function() { 
                     var $spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
                     var nodes = $button.childNodes;
@@ -429,11 +437,11 @@ function make_collection_button(name, description,count) {
         )
 }
 
-function make_team_button(name,count) {
+function make_team_button(name,TL,counts) {
     return (
         <span class="label label tag-darkgoldenrod">
-        <span><p  style="margin-bottom:5px"><i class="fa fa-users" aria-hidden="true" style="padding-right: 5px;"></i>{name}<span class="delbutton"></span></p></span>
-        <span>{count} recipients</span>
+        <span><p  style="margin-bottom:5px"><i class="fa fa-users" aria-hidden="true" style="padding-right: 5px;"></i>{name}</p></span>
+        <span><p>{TL}<sup>TL</sup></p>{counts} Members</span>
         </span>
         )
 }

--- a/src/injectscripts/messages/create.js
+++ b/src/injectscripts/messages/create.js
@@ -150,9 +150,9 @@ $(document).ready(function() {
 function LoadTeams() {
     $('#lighthouseteams').empty() //empty to prevent dupes
 
-    var $spinner = (<i style="width:100%; margin-top:4px; margin-left:auto; margin-right:auto" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
+    var spinner = $(<i style="width:100%; margin-top:4px; margin-left:auto; margin-right:auto" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
 
-    $($spinner).appendTo($('#lighthouseteams'));
+    spinner.appendTo($('#lighthouseteams'));
     $('#teamshq').text("Active Teams (With Members) At " + msgsystem.selectedHeadquarters.peek().Name)
     $('#HQTeamsSet').show()
     ReturnTeamsActiveAtLHQ(msgsystem.selectedHeadquarters.peek(), null, function(response) {
@@ -164,7 +164,7 @@ function LoadTeams() {
             $.each(response.responseJSON.Results, function(k, v) {
                 if (v.Members.length > 0) //only show teams with members
                 {
-                    TL = ""
+                    var TL = ""
                     $.each(v.Members, function(kk, vv) {
                         if (vv.TeamLeader == true) {
                             TL = vv.Person.FirstName + " " + vv.Person.LastName
@@ -173,12 +173,10 @@ function LoadTeams() {
                     //length + "" to make it a string
                     var button = make_team_button(v.Callsign, TL, v.Members.length + "")
                     $(button).click(function() {
-                        var spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
-                        var nodes = button.childNodes;
-                        for (i = 0; i < nodes.length; i++) {
-                            nodes[i].style.display = "none";
-                        }
-                        $(spinner).appendTo(button);
+                        var spinner = $(<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
+
+                        $(button).children().css('display','none')
+                        spinner.appendTo(button);
                         console.log("clicked " + v.Callsign)
                         $.each(v.Members, function(kk, vv) {
                             $.ajax({
@@ -194,7 +192,7 @@ function LoadTeams() {
                                         if (response.responseJSON.Results.length) {
                                             $.each(response.responseJSON.Results, function(k, v) {
                                                 if (v.ContactTypeId == 2) {
-                                                    BuildNew = {};
+                                                    var BuildNew = {};
                                                     BuildNew.Contact = v;
                                                     BuildNew.ContactTypeId = v.ContactTypeId
                                                     if (vv.TeamLeader) {
@@ -210,12 +208,9 @@ function LoadTeams() {
                                             })
                                         }
                                     }
-                                    button.removeChild(spinner);
+                                    spinner.remove();
                                     //cb for when they are loaded
-                                    var nodes = button.childNodes;
-                                    for (i = 0; i < nodes.length; i++) {
-                                        nodes[i].removeAttribute("style");
-                                    }
+                                    $(button).children().css('display','')
                                 }
                             })
                         })
@@ -236,7 +231,6 @@ function LoadTeams() {
 
 
 function LoadAllCollections() {
-    collectionscount
 
     $("#lighthousecollections").empty();
 
@@ -246,17 +240,17 @@ function LoadAllCollections() {
         $("#collectionscount").text(theLoadedCollection.length);
         theLoadedCollection.forEach(function(item) {
             var $button = make_collection_button(item.name, item.description, item.items.length + "")
-            var $spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
+            var spinner = $(<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
 
             $($button).click(function() {
                 var nodes = $button.childNodes;
                 for (i = 0; i < nodes.length; i++) {
                     nodes[i].style.display = "none";
                 }
-                $($spinner).appendTo($button);
+                spinner.appendTo($button);
                 LoadCollection(item, function() {
                     console.log("collection load complete")
-                    $button.removeChild($spinner);
+                    $button.removeChild(spinner);
                     //cb for when they are loaded
                     var nodes = $button.childNodes;
                     for (i = 0; i < nodes.length; i++) {

--- a/src/injectscripts/messages/create.js
+++ b/src/injectscripts/messages/create.js
@@ -467,7 +467,7 @@ function DoTour() {
         onShown: function (tour) {
           $('#HQTeamsSet').show();
         },
-        content: "All active teams at the selected HQ will be shown here. Click the team to message the members. Team leader of the clicked team will have (TL) in his name in the Selected Receipients box.",
+        content: "All active teams at the selected HQ will be shown here. Click the team to SMS the members. Team leader of the clicked team will have (TL) in his name in the Selected Receipients box.",
     },
     {
         element: "#lighthousecollections",

--- a/src/injectscripts/messages/create.js
+++ b/src/injectscripts/messages/create.js
@@ -56,8 +56,8 @@ $(document).ready(function() {
         })
 
     } else {
-     console.log("Not running due to preference setting")
- }
+       console.log("Not running due to preference setting")
+   }
 
     //Operational = true
     msgsystem.operational(true);
@@ -162,6 +162,8 @@ function LoadTeams() {
         if(response.responseJSON.Results.length) {
             $('#lighthouseteams').empty()
             $.each(response.responseJSON.Results, function(k, v) {
+                if (v.Members.length > 0)
+            {
                 var $button = make_team_button(v.Callsign,v.Members.length+"")
                 $($button).click(function() { 
                     var $spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
@@ -212,9 +214,9 @@ $button.removeChild($spinner);
 })
 })
 $($button).appendTo('#lighthouseteams');
-
+}
 })
-$('#teamshq').text("Teams Active At "+msgsystem.selectedHeadquarters.peek().Name)
+$('#teamshq').text("Active Teams (With Members) At "+msgsystem.selectedHeadquarters.peek().Name)
 $('#HQTeamsSet').show()
 
 }
@@ -430,7 +432,7 @@ function make_collection_button(name, description,count) {
 function make_team_button(name,count) {
     return (
         <span class="label label tag-darkgoldenrod">
-        <span><p  style="margin-bottom:5px"><i class="fa fa-users" aria-hidden="true" style="padding-right: 5px;"></i>{name}<span class="delbutton"><sup style="margin-left: 10px;margin-right: -5px;">X</sup></span></p></span>
+        <span><p  style="margin-bottom:5px"><i class="fa fa-users" aria-hidden="true" style="padding-right: 5px;"></i>{name}<span class="delbutton"></span></p></span>
         <span>{count} recipients</span>
         </span>
         )

--- a/src/injectscripts/messages/create.js
+++ b/src/injectscripts/messages/create.js
@@ -11,10 +11,9 @@ $(document).ready(function() {
 
         whenWeAreReady(msgsystem, function() {
 
-            msgsystem.selectedHeadquarters.subscribe(function(status){
+            msgsystem.selectedHeadquarters.subscribe(function(status) {
                 console.log("Picked something")
-                if (status !== null)
-                {
+                if (status !== null) {
                     LoadTeams()
                 } else {
                     console.log("Not a HQ. Cleaning up")
@@ -56,8 +55,8 @@ $(document).ready(function() {
         })
 
     } else {
-       console.log("Not running due to preference setting")
-   }
+        console.log("Not running due to preference setting")
+    }
 
     //Operational = true
     msgsystem.operational(true);
@@ -84,8 +83,7 @@ $(document).ready(function() {
     })
 
     $("#collectionsave").click(function() {
-        if (msgsystem.selectedRecipients.peek().length > 0)
-        {
+        if (msgsystem.selectedRecipients.peek().length > 0) {
             var SaveName = prompt("Please enter a name for the collection. If the name already exists it will be overwritten.", "");
             if (SaveName !== null && SaveName != "") {
 
@@ -95,21 +93,17 @@ $(document).ready(function() {
                 CollectionParent = {};
                 theSelected.forEach(function(item) {
                     thisItem = {};
-                    if (item.Contact === null)
-                    {
+                    if (item.Contact === null) {
                         thisItem.type = "group";
                         thisItem.OwnerId = item.ContactGroup.Entity.Id;
                         thisItem.Id = item.ContactGroup.Id;
 
-                    } else if (item.ContactGroup === null)
-                    {
-                        if (item.Contact.PersonId === null)
-                        {
+                    } else if (item.ContactGroup === null) {
+                        if (item.Contact.PersonId === null) {
                             thisItem.type = "entity";
                             thisItem.OwnerId = item.Contact.EntityId;
                             thisItem.Id = item.Contact.Id;
-                        } else
-                        {
+                        } else {
                             thisItem.type = "person";
                             thisItem.OwnerId = item.Contact.PersonId;
                             thisItem.Id = item.Contact.Id;
@@ -123,12 +117,11 @@ $(document).ready(function() {
                 CollectionParent.description = SaveName;
                 CollectionParent.items = theCollection;
                 currentCollections = JSON.parse(localStorage.getItem("lighthouseContactCollections"));
-                if (currentCollections === null)
-                {
+                if (currentCollections === null) {
                     currentCollections = [];
                 }
                 newcurrentCollections = []
-                $.each(currentCollections,function(k,v){
+                $.each(currentCollections, function(k, v) {
                     if (v.name != CollectionParent.name) //catch the dupes
                     {
                         newcurrentCollections.push(v) //delete the duplicate
@@ -138,16 +131,16 @@ $(document).ready(function() {
                 currentCollections.push(CollectionParent);
                 localStorage.setItem("lighthouseContactCollections", JSON.stringify(currentCollections));
                 LoadAllCollections();
-            }            
+            }
         }
     })
 
 
-//Load all the Collections on page load
+    //Load all the Collections on page load
 
-LoadAllCollections();
+    LoadAllCollections();
 
-DoTour()
+    DoTour()
 
 
 
@@ -160,140 +153,138 @@ function LoadTeams() {
     var $spinner = (<i style="width:100%; margin-top:4px; margin-left:auto; margin-right:auto" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
 
     $($spinner).appendTo($('#lighthouseteams'));
-    $('#teamshq').text("Active Teams (With Members) At "+msgsystem.selectedHeadquarters.peek().Name)
+    $('#teamshq').text("Active Teams (With Members) At " + msgsystem.selectedHeadquarters.peek().Name)
     $('#HQTeamsSet').show()
-    ReturnTeamsActiveAtLHQ(msgsystem.selectedHeadquarters.peek(),null,function(response){
+    ReturnTeamsActiveAtLHQ(msgsystem.selectedHeadquarters.peek(), null, function(response) {
         console.log(response);
         $('#teamscount').text(response.responseJSON.Results.length)
-        if(response.responseJSON.Results.length) {
-                $('#lighthouseteams').empty() //empty to prevent dupes
+        if (response.responseJSON.Results.length) {
+            $('#lighthouseteams').empty() //empty to prevent dupes
 
-                $.each(response.responseJSON.Results, function(k, v) {
+            $.each(response.responseJSON.Results, function(k, v) {
                 if (v.Members.length > 0) //only show teams with members
                 {
                     TL = ""
-                    $.each(v.Members,function(kk,vv) {
-                        if (vv.TeamLeader == true)
-                        {
-                            TL = vv.Person.FirstName+" "+vv.Person.LastName
+                    $.each(v.Members, function(kk, vv) {
+                        if (vv.TeamLeader == true) {
+                            TL = vv.Person.FirstName + " " + vv.Person.LastName
                         }
                     })
-                //length + "" to make it a string
-                var button = make_team_button(v.Callsign,TL,v.Members.length+"")
-                $(button).click(function() { 
-                    var spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
-                    var nodes = button.childNodes;
-                    for(i=0; i<nodes.length; i++) {
-                        nodes[i].style.display="none";
-                    }
-                    $(spinner).appendTo(button);
-                    console.log("clicked "+v.Callsign)
-                    $.each(v.Members, function(kk,vv) {
-                        $.ajax({
-                            type: 'GET'
-                            , url: '/Api/v1/People/'+vv.Person.Id+'/Contacts'
-                            , data: {LighthouseFunction: 'LoadPerson'}
-                            , cache: false
-                            , dataType: 'json'
-                            , complete: function(response, textStatus) {
-                                if(textStatus == 'success')
-                                {
-                                    if(response.responseJSON.Results.length) {
-                                        $.each(response.responseJSON.Results, function(k, v) { 
-                                            if (v.ContactTypeId == 2)
-                                            {
-                                                BuildNew = {};
-                                                BuildNew.Contact = v;
-                                                BuildNew.ContactTypeId = v.ContactTypeId
-                                                if (vv.TeamLeader) {
-                                                    BuildNew.Description = v.FirstName+" "+v.LastName+" (TL)";
+                    //length + "" to make it a string
+                    var button = make_team_button(v.Callsign, TL, v.Members.length + "")
+                    $(button).click(function() {
+                        var spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
+                        var nodes = button.childNodes;
+                        for (i = 0; i < nodes.length; i++) {
+                            nodes[i].style.display = "none";
+                        }
+                        $(spinner).appendTo(button);
+                        console.log("clicked " + v.Callsign)
+                        $.each(v.Members, function(kk, vv) {
+                            $.ajax({
+                                type: 'GET',
+                                url: '/Api/v1/People/' + vv.Person.Id + '/Contacts',
+                                data: {
+                                    LighthouseFunction: 'LoadPerson'
+                                },
+                                cache: false,
+                                dataType: 'json',
+                                complete: function(response, textStatus) {
+                                    if (textStatus == 'success') {
+                                        if (response.responseJSON.Results.length) {
+                                            $.each(response.responseJSON.Results, function(k, v) {
+                                                if (v.ContactTypeId == 2) {
+                                                    BuildNew = {};
+                                                    BuildNew.Contact = v;
+                                                    BuildNew.ContactTypeId = v.ContactTypeId
+                                                    if (vv.TeamLeader) {
+                                                        BuildNew.Description = v.FirstName + " " + v.LastName + " (TL)";
 
-                                                } else {
-                                                    BuildNew.Description = v.FirstName+" "+v.LastName;
+                                                    } else {
+                                                        BuildNew.Description = v.FirstName + " " + v.LastName;
 
+                                                    }
+                                                    BuildNew.Recipient = v.Detail;
+                                                    msgsystem.selectedRecipients.push(BuildNew)
                                                 }
-                                                BuildNew.Recipient = v.Detail;
-                                                msgsystem.selectedRecipients.push(BuildNew)
-                                            }
-                                        })
-}
-}
-button.removeChild(spinner);
- //cb for when they are loaded
- var nodes = button.childNodes;
- for(i=0; i<nodes.length; i++) {
-   nodes[i].removeAttribute("style");
-}
-}
-})
-})
-})
+                                            })
+                                        }
+                                    }
+                                    button.removeChild(spinner);
+                                    //cb for when they are loaded
+                                    var nodes = button.childNodes;
+                                    for (i = 0; i < nodes.length; i++) {
+                                        nodes[i].removeAttribute("style");
+                                    }
+                                }
+                            })
+                        })
+                    })
 
-$(button).appendTo('#lighthouseteams');
-button.style.width = button.offsetWidth+"px";
-button.style.height = button.offsetHeight+"px";
-}
-})
-} else {
-    //nothing found
-     $('#lighthouseteams').empty() //empty to prevent dupes
+                    $(button).appendTo('#lighthouseteams');
+                    button.style.width = button.offsetWidth + "px";
+                    button.style.height = button.offsetHeight + "px";
+                }
+            })
+        } else {
+            //nothing found
+            $('#lighthouseteams').empty() //empty to prevent dupes
 
- }
-});
+        }
+    });
 }
 
 
-function LoadAllCollections() {collectionscount
+function LoadAllCollections() {
+    collectionscount
 
     $("#lighthousecollections").empty();
 
-        //Load the saved Collections
-        theLoadedCollection = JSON.parse(localStorage.getItem("lighthouseContactCollections"));
-        if (theLoadedCollection) {
-            $("#collectionscount").text(theLoadedCollection.length);
-            theLoadedCollection.forEach(function(item) {
-                var $button = make_collection_button(item.name,item.description,item.items.length+"")
-                var $spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
+    //Load the saved Collections
+    theLoadedCollection = JSON.parse(localStorage.getItem("lighthouseContactCollections"));
+    if (theLoadedCollection) {
+        $("#collectionscount").text(theLoadedCollection.length);
+        theLoadedCollection.forEach(function(item) {
+            var $button = make_collection_button(item.name, item.description, item.items.length + "")
+            var $spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
 
-                $($button).click(function() {
+            $($button).click(function() {
+                var nodes = $button.childNodes;
+                for (i = 0; i < nodes.length; i++) {
+                    nodes[i].style.display = "none";
+                }
+                $($spinner).appendTo($button);
+                LoadCollection(item, function() {
+                    console.log("collection load complete")
+                    $button.removeChild($spinner);
+                    //cb for when they are loaded
                     var nodes = $button.childNodes;
-                    for(i=0; i<nodes.length; i++) {
-                        nodes[i].style.display="none";
+                    for (i = 0; i < nodes.length; i++) {
+                        nodes[i].removeAttribute("style");
                     }
-                    $($spinner).appendTo($button);
-                    LoadCollection(item, function() {
-                        console.log("collection load complete")
-                        $button.removeChild($spinner);
-                        //cb for when they are loaded
-                        var nodes = $button.childNodes;
-                        for(i=0; i<nodes.length; i++) {
-                            nodes[i].removeAttribute("style");
-                        }
 
-                    });
-                })
-                $($button).find('span.delbutton').click(function() {
-                    event.stopImmediatePropagation();
-                    var r = confirm("Are you sure you want to delete this collection?");
-                    if (r == true) {
-                        DeleteCollection(item);
-                    }
-                })
-                $($button).appendTo('#lighthousecollections');
-                $button.style.width = $button.offsetWidth+"px";
-                $button.style.height = $button.offsetHeight+"px";
-            });
-}
+                });
+            })
+            $($button).find('span.delbutton').click(function() {
+                event.stopImmediatePropagation();
+                var r = confirm("Are you sure you want to delete this collection?");
+                if (r == true) {
+                    DeleteCollection(item);
+                }
+            })
+            $($button).appendTo('#lighthousecollections');
+            $button.style.width = $button.offsetWidth + "px";
+            $button.style.height = $button.offsetHeight + "px";
+        });
+    }
 }
 
 function DeleteCollection(col) {
     theLoadedCollection = JSON.parse(localStorage.getItem("lighthouseContactCollections"));
-    theLoadedCollection.forEach(function(item)
-    {
-        if (JSON.stringify(col) == JSON.stringify(item))
-        {
+    theLoadedCollection.forEach(function(item) {
+        if (JSON.stringify(col) == JSON.stringify(item)) {
             console.log("This one")
-            theLoadedCollection.splice(theLoadedCollection.indexOf(item),1)
+            theLoadedCollection.splice(theLoadedCollection.indexOf(item), 1)
         } else {
             console.log("NOT This one")
 
@@ -304,166 +295,164 @@ function DeleteCollection(col) {
 
 }
 
-function LoadCollection(col,cb) {
+function LoadCollection(col, cb) {
     $total = col.items.length;
     msgsystem.selectedRecipients.removeAll();
     col.items.forEach(function(itm) {
         switch (itm.type) {
             case "group":
-            var groupOwner;
-            $.ajax({
-                type: 'GET'
-                , url: '/Api/v1/Entities/'+itm.OwnerId
-                , data: {LighthouseFunction: 'CollectionLoadCollection'}
-                , cache: false
-                , dataType: 'json'
-                , complete: function(response, textStatus) {
-                    switch(textStatus){
-                        case 'success':
-                        groupOwner = response.responseJSON.Name;
-                        $.ajax({
-                            type: 'GET'
-                            , url: '/Api/v1/ContactGroups/headquarters/'+itm.OwnerId
-                            , data: {LighthouseFunction: 'CollectionLoadHQ'}
-                            , cache: false
-                            , dataType: 'json'
-                            , complete: function(response, textStatus) {
-                                if(textStatus == 'success')
-                                {
-                                    if(response.responseJSON.Results.length) {
-                                        $.each(response.responseJSON.Results, function(k, v) { 
-                                            if (v.Id == itm.Id)
-                                            {
+                var groupOwner;
+                $.ajax({
+                    type: 'GET',
+                    url: '/Api/v1/Entities/' + itm.OwnerId,
+                    data: {
+                        LighthouseFunction: 'CollectionLoadCollection'
+                    },
+                    cache: false,
+                    dataType: 'json',
+                    complete: function(response, textStatus) {
+                        switch (textStatus) {
+                            case 'success':
+                                groupOwner = response.responseJSON.Name;
+                                $.ajax({
+                                    type: 'GET',
+                                    url: '/Api/v1/ContactGroups/headquarters/' + itm.OwnerId,
+                                    data: {
+                                        LighthouseFunction: 'CollectionLoadHQ'
+                                    },
+                                    cache: false,
+                                    dataType: 'json',
+                                    complete: function(response, textStatus) {
+                                        if (textStatus == 'success') {
+                                            if (response.responseJSON.Results.length) {
+                                                $.each(response.responseJSON.Results, function(k, v) {
+                                                    if (v.Id == itm.Id) {
 
-                                                BuildNew = {};
-                                                BuildNew.Contact = null;
-                                                BuildNew.ContactGroup = v
-                                                BuildNew.ContactTypeId = null;
-                                                BuildNew.Description = groupOwner;
-                                                BuildNew.Recipient = v.Name;
-                                                msgsystem.selectedRecipients.push(BuildNew)
-                                                
-                                                $total = $total - 1;
-                                                if ($total == 0 )
-                                                {
-                                                    cb();
-                                                }
+                                                        BuildNew = {};
+                                                        BuildNew.Contact = null;
+                                                        BuildNew.ContactGroup = v
+                                                        BuildNew.ContactTypeId = null;
+                                                        BuildNew.Description = groupOwner;
+                                                        BuildNew.Recipient = v.Name;
+                                                        msgsystem.selectedRecipients.push(BuildNew)
+
+                                                        $total = $total - 1;
+                                                        if ($total == 0) {
+                                                            cb();
+                                                        }
+                                                    }
+                                                })
                                             }
-                                        })
-}
-}
-}
-})
-break;
-}
-}
-})
-break;
-case "person":
-$.ajax({
-    type: 'GET'
-    , url: '/Api/v1/People/'+itm.OwnerId+'/Contacts'
-    , data: {LighthouseFunction: 'LoadPerson'}
-    , cache: false
-    , dataType: 'json'
-    , complete: function(response, textStatus) {
-        if(textStatus == 'success')
-        {
-            if(response.responseJSON.Results.length) {
-                $.each(response.responseJSON.Results, function(k, v) { 
-                    if (v.Id == itm.Id)
-                    {
-                        BuildNew = {};
-                        BuildNew.Contact = v;
-                        BuildNew.ContactTypeId = v.ContactTypeId;
-                        BuildNew.Description = v.FirstName+" "+v.LastName+ " ("+v.Description+")";
-                        BuildNew.Recipient = v.Detail;
-                        msgsystem.selectedRecipients.push(BuildNew)
-
-
-                        $total = $total - 1;
-                        if ($total == 0 )
-                        {
-                            cb();
+                                        }
+                                    }
+                                })
+                                break;
                         }
-
                     }
                 })
-            }
-        }
-    }
-})
-break;
-case "entity":
-$.ajax({
-    type: 'GET'
-    , url: '/Api/v1/Contacts/Search'
-    , cache: false
-    , dataType: 'json'
-    , data: {
-      'PageIndex':          1
-      ,'PageSize':          1000
-      ,'HeadquarterIds[]':  itm.OwnerId
-      ,'SortField':         "createdon"
-      ,'SortOrder':         "asc"
-      , 'LighthouseFunction': 'CollectionLoadEntity'
-  }
-  , complete: function(response, textStatus) {
-    if(textStatus == 'success'){
-        if(response.responseJSON.Results.length) {
-            $.each(response.responseJSON.Results, function(k, v) { 
-                if (v.Id == itm.Id)
-                {
-                    BuildNew = {};
-                    BuildNew.Contact = v;
-                    BuildNew.ContactTypeId = v.ContactTypeId;
-                    BuildNew.ContactGroup = null;
-                    BuildNew.Description = v.EntityName+ " ("+v.Description+")";
-                    BuildNew.Recipient = v.Detail;
-                    msgsystem.selectedRecipients.push(BuildNew)
+                break;
+            case "person":
+                $.ajax({
+                    type: 'GET',
+                    url: '/Api/v1/People/' + itm.OwnerId + '/Contacts',
+                    data: {
+                        LighthouseFunction: 'LoadPerson'
+                    },
+                    cache: false,
+                    dataType: 'json',
+                    complete: function(response, textStatus) {
+                        if (textStatus == 'success') {
+                            if (response.responseJSON.Results.length) {
+                                $.each(response.responseJSON.Results, function(k, v) {
+                                    if (v.Id == itm.Id) {
+                                        BuildNew = {};
+                                        BuildNew.Contact = v;
+                                        BuildNew.ContactTypeId = v.ContactTypeId;
+                                        BuildNew.Description = v.FirstName + " " + v.LastName + " (" + v.Description + ")";
+                                        BuildNew.Recipient = v.Detail;
+                                        msgsystem.selectedRecipients.push(BuildNew)
 
-                    $total = $total - 1;
-                    if ($total == 0 )
-                    {
-                        cb();
+
+                                        $total = $total - 1;
+                                        if ($total == 0) {
+                                            cb();
+                                        }
+
+                                    }
+                                })
+                            }
+                        }
                     }
+                })
+                break;
+            case "entity":
+                $.ajax({
+                    type: 'GET',
+                    url: '/Api/v1/Contacts/Search',
+                    cache: false,
+                    dataType: 'json',
+                    data: {
+                        'PageIndex': 1,
+                        'PageSize': 1000,
+                        'HeadquarterIds[]': itm.OwnerId,
+                        'SortField': "createdon",
+                        'SortOrder': "asc",
+                        'LighthouseFunction': 'CollectionLoadEntity'
+                    },
+                    complete: function(response, textStatus) {
+                        if (textStatus == 'success') {
+                            if (response.responseJSON.Results.length) {
+                                $.each(response.responseJSON.Results, function(k, v) {
+                                    if (v.Id == itm.Id) {
+                                        BuildNew = {};
+                                        BuildNew.Contact = v;
+                                        BuildNew.ContactTypeId = v.ContactTypeId;
+                                        BuildNew.ContactGroup = null;
+                                        BuildNew.Description = v.EntityName + " (" + v.Description + ")";
+                                        BuildNew.Recipient = v.Detail;
+                                        msgsystem.selectedRecipients.push(BuildNew)
 
-                }
-            })
+                                        $total = $total - 1;
+                                        if ($total == 0) {
+                                            cb();
+                                        }
+
+                                    }
+                                })
+                            }
+                        }
+                    }
+                })
+                break;
         }
-    }
-}
-})
-break;
-}
-})
+    })
 }
 
-function make_collection_button(name, description,count) {
+function make_collection_button(name, description, count) {
     return (
         <span class="label label tag-rebecca">
         <span><p  style="margin-bottom:5px"><i class="fa fa-object-group" aria-hidden="true" style="padding-right: 5px;"></i>{description}<span class="delbutton"><sup style="margin-left: 10px;margin-right: -5px;">X</sup></span></p></span>
         <span>{count} recipients</span>
         </span>
-        )
+    )
 }
 
-function make_team_button(name,TL,counts) {
+function make_team_button(name, TL, counts) {
     return (
         <span class="label label tag-darkgoldenrod">
-        <span><p  style="margin-bottom:5px"><i class="fa fa-users" aria-hidden="true" style="padding-right: 5px;"></i>{name}</p></span>
+        <span><p  style="margin-bottom:5px">{name}</p></span>
         <span><p>{TL}<sup>TL</sup></p>{counts} Members</span>
         </span>
-        )
+    )
 }
 
-function whenWeAreReady(varToCheck,cb) { //when external vars have loaded
-	var waiting = setInterval(function() {
-		if (typeof varToCheck != "undefined") {
-      clearInterval(waiting); //stop timer
-      cb(); //call back
-  }
-}, 200);
+function whenWeAreReady(varToCheck, cb) { //when external vars have loaded
+    var waiting = setInterval(function() {
+        if (typeof varToCheck != "undefined") {
+            clearInterval(waiting); //stop timer
+            cb(); //call back
+        }
+    }, 200);
 }
 
 function DoTour() {
@@ -472,87 +461,85 @@ function DoTour() {
 
     // Instance the tour
     var tour = new Tour({
-      name: "LHTourMessages",
-      smartPlacement: true,
-      placement: "right",
-      debug: true,
-      steps: [
-      {
-        element: "",
-        placement: "top",
-        orphan: true,
-        backdrop: true,
-        title: "Lighthouse Welcome",
-        content: "Lighthouse has made some changes to this page. would you like a tour?"
-    },
-    {
-        element: "#lighthouseEnabled",
-        title: "Lighthouse Load",
-        placement: "bottom",
-        backdrop: false,
-        content: "Lighthouse can prefill the Available Contacts from you unit. Ticking this box enables this behavour. It will also select 'Operational' - 'Yes' by default",
-    },
-    {
-        element: "#lighthouseteams",
-        title: "Active Teams",
-        placement: "auto",
-        backdrop: false,
-        onShown: function (tour) {
-          $('#HQTeamsSet').show();
-      },
-      content: "All active teams at the selected HQ will be shown here. Click the team to SMS the members. Team leader of the clicked team will have (TL) in his name in the Selected Receipients box.",
-  },
-  {
-    element: "#lighthousecollections",
-    title: "Lighthouse Collections",
-    placement: "top",
-    backdrop: false,
-    content: "Lighthouse Collections allow you to save a group of message recipients for quick selection later. Collections can contain any combination of recipients (including groups from different units or regions) and are saved locally on your computer.",
-},
-{
-    element: "#collectionsave",
-    title: "Lighthouse Collections - Save",
-    placement: "top",
-    backdrop: false,
-    onNext: function (tour) {
-        $button = make_collection_button("Tour Example","Tour Example","13")
-        $($button).attr("id","tourbutton")
-        $($button).appendTo('#lighthousecollections');
-    },
-    content: "Once you have selected some message recipients click 'Save As Collection' to save them for later. using a name that already exists will replace the old collection.",
-},
-{
-    element: "#tourbutton",
-    title: "Lighthouse Collections - Load",
-    placement: "top",
-    backdrop: false,
-    onNext: function (tour) {
-        $('#lighthousecollections').empty();
-    },
-    content: "This is a saved collection. Click it to load its contents into 'Selected Recipients'",
-},
-{
-    element: "#recipientsdel",
-    title: "Lighthouse Delete",
-    placement: "auto",
-    backdrop: false,
-    content: "We have added a button to remove all the selected message recipients",
-},
-{
-    element: "",
-    placement: "top",
-    orphan: true,
-    backdrop: true,
-    title: "Questions?",
-    content: "If you have any questions please seek help from the 'About Lighthout' button under the lighthouse menu on the top menu"
-}
-]
-})
+        name: "LHTourMessages",
+        smartPlacement: true,
+        placement: "right",
+        debug: true,
+        steps: [{
+                element: "",
+                placement: "top",
+                orphan: true,
+                backdrop: true,
+                title: "Lighthouse Welcome",
+                content: "Lighthouse has made some changes to this page. would you like a tour?"
+            },
+            {
+                element: "#lighthouseEnabled",
+                title: "Lighthouse Load",
+                placement: "bottom",
+                backdrop: false,
+                content: "Lighthouse can prefill the Available Contacts from you unit. Ticking this box enables this behavour. It will also select 'Operational' - 'Yes' by default",
+            },
+            {
+                element: "#lighthouseteams",
+                title: "Active Teams",
+                placement: "auto",
+                backdrop: false,
+                onShown: function(tour) {
+                    $('#HQTeamsSet').show();
+                },
+                content: "All active teams at the selected HQ will be shown here. Click the team to SMS the members. Team leader of the clicked team will have (TL) in his name in the Selected Receipients box.",
+            },
+            {
+                element: "#lighthousecollections",
+                title: "Lighthouse Collections",
+                placement: "top",
+                backdrop: false,
+                content: "Lighthouse Collections allow you to save a group of message recipients for quick selection later. Collections can contain any combination of recipients (including groups from different units or regions) and are saved locally on your computer.",
+            },
+            {
+                element: "#collectionsave",
+                title: "Lighthouse Collections - Save",
+                placement: "top",
+                backdrop: false,
+                onNext: function(tour) {
+                    $button = make_collection_button("Tour Example", "Tour Example", "13")
+                    $($button).attr("id", "tourbutton")
+                    $($button).appendTo('#lighthousecollections');
+                },
+                content: "Once you have selected some message recipients click 'Save As Collection' to save them for later. using a name that already exists will replace the old collection.",
+            },
+            {
+                element: "#tourbutton",
+                title: "Lighthouse Collections - Load",
+                placement: "top",
+                backdrop: false,
+                onNext: function(tour) {
+                    $('#lighthousecollections').empty();
+                },
+                content: "This is a saved collection. Click it to load its contents into 'Selected Recipients'",
+            },
+            {
+                element: "#recipientsdel",
+                title: "Lighthouse Delete",
+                placement: "auto",
+                backdrop: false,
+                content: "We have added a button to remove all the selected message recipients",
+            },
+            {
+                element: "",
+                placement: "top",
+                orphan: true,
+                backdrop: true,
+                title: "Questions?",
+                content: "If you have any questions please seek help from the 'About Lighthout' button under the lighthouse menu on the top menu"
+            }
+        ]
+    })
 
     /// Initialize the tour
     tour.init();
 
-// Start the tour
-tour.start();
+    // Start the tour
+    tour.start();
 }
-

--- a/src/injectscripts/messages/create.js
+++ b/src/injectscripts/messages/create.js
@@ -173,7 +173,6 @@ function LoadTeams() {
                 {
                     TL = ""
                     $.each(v.Members,function(kk,vv) {
-                        console.log(vv)
                         if (vv.TeamLeader == true)
                         {
                             TL = vv.Person.FirstName+" "+vv.Person.LastName

--- a/src/injectscripts/messages/create.js
+++ b/src/injectscripts/messages/create.js
@@ -155,31 +155,39 @@ DoTour()
 
 
 function LoadTeams() {
+    $('#lighthouseteams').empty() //empty to prevent dupes
+
+    var $spinner = (<i style="width:100%; margin-top:4px; margin-left:auto; margin-right:auto" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
+
+    $($spinner).appendTo($('#lighthouseteams'));
+    $('#teamshq').text("Active Teams (With Members) At "+msgsystem.selectedHeadquarters.peek().Name)
+    $('#HQTeamsSet').show()
     ReturnTeamsActiveAtLHQ(msgsystem.selectedHeadquarters.peek(),null,function(response){
         console.log(response);
         $('#teamscount').text(response.responseJSON.Results.length)
         if(response.responseJSON.Results.length) {
-            $('#lighthouseteams').empty() //empty to prevent dupes
-            $.each(response.responseJSON.Results, function(k, v) {
+                $('#lighthouseteams').empty() //empty to prevent dupes
+
+                $.each(response.responseJSON.Results, function(k, v) {
                 if (v.Members.length > 0) //only show teams with members
-            {
-                TL = ""
-                $.each(v.Members,function(kk,vv) {
-                    console.log(vv)
-                    if (vv.TeamLeader == true)
-                    {
-                        TL = vv.Person.FirstName+" "+vv.Person.LastName
-                    }
-                })
+                {
+                    TL = ""
+                    $.each(v.Members,function(kk,vv) {
+                        console.log(vv)
+                        if (vv.TeamLeader == true)
+                        {
+                            TL = vv.Person.FirstName+" "+vv.Person.LastName
+                        }
+                    })
                 //length + "" to make it a string
-                var $button = make_team_button(v.Callsign,TL,v.Members.length+"")
-                $($button).click(function() { 
-                    var $spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
-                    var nodes = $button.childNodes;
+                var button = make_team_button(v.Callsign,TL,v.Members.length+"")
+                $(button).click(function() { 
+                    var spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
+                    var nodes = button.childNodes;
                     for(i=0; i<nodes.length; i++) {
                         nodes[i].style.display="none";
                     }
-                    $($spinner).appendTo($button);
+                    $(spinner).appendTo(button);
                     console.log("clicked "+v.Callsign)
                     $.each(v.Members, function(kk,vv) {
                         $.ajax({
@@ -211,23 +219,27 @@ function LoadTeams() {
                                         })
 }
 }
-$button.removeChild($spinner);
-                        //cb for when they are loaded
-                        var nodes = $button.childNodes;
-                        for(i=0; i<nodes.length; i++) {
-                            nodes[i].removeAttribute("style");
-                        }
-                    }
-                })
-})
-})
-$($button).appendTo('#lighthouseteams');
+button.removeChild(spinner);
+ //cb for when they are loaded
+ var nodes = button.childNodes;
+ for(i=0; i<nodes.length; i++) {
+   nodes[i].removeAttribute("style");
+}
 }
 })
-$('#teamshq').text("Active Teams (With Members) At "+msgsystem.selectedHeadquarters.peek().Name)
-$('#HQTeamsSet').show()
+})
+})
 
+$(button).appendTo('#lighthouseteams');
+button.style.width = button.offsetWidth+"px";
+button.style.height = button.offsetHeight+"px";
 }
+})
+} else {
+    //nothing found
+     $('#lighthouseteams').empty() //empty to prevent dupes
+
+ }
 });
 }
 

--- a/src/injectscripts/messages/create.js
+++ b/src/injectscripts/messages/create.js
@@ -1,15 +1,27 @@
 var DOM = require('jsx-dom-factory');
+var ReturnTeamsActiveAtLHQ = require('../../../lib/getteams.js');
+
 
 
 console.log("inject running");
 
 $(document).ready(function() {
 
-
-
     if (localStorage.getItem("LighthouseMessagesEnabled") == "true" || localStorage.getItem("LighthouseMessagesEnabled") == null) {
 
         whenWeAreReady(msgsystem, function() {
+
+            msgsystem.selectedHeadquarters.subscribe(function(status){
+                console.log("Picked something")
+                if (status !== null)
+                {
+                    LoadTeams()
+                } else {
+                    console.log("Not a HQ. Cleaning up")
+                    $('#HQTeamsSet').hide()
+
+                }
+            });
 
             //Home HQ - with a wait to catch possible race condition where the page is still loading
             whenWeAreReady(user, function() {
@@ -25,6 +37,7 @@ $(document).ready(function() {
             });
 
         });
+        //auto select ones that have the world default in them
         msgsystem.loadingContacts.subscribe(function(status) {
             if (status == false) {
                 msgsystem.availableContactGroups.peek().forEach(function(item) {
@@ -140,14 +153,71 @@ DoTour()
 
 });
 
-function LoadAllCollections() {
+
+function LoadTeams() {
+    console.log(msgsystem.selectedHeadquarters.peek())
+    ReturnTeamsActiveAtLHQ(msgsystem.selectedHeadquarters.peek(),null,function(response){
+        console.log(response);
+        $('#teamscount').text(response.responseJSON.Results.length)
+        if(response.responseJSON.Results.length) {
+            $('#lighthouseteams').empty()
+            $.each(response.responseJSON.Results, function(k, v) {
+                var $button = make_team_button(v.Callsign,v.Members.length+"")
+                $($button).click(function() { 
+                    console.log("clicked "+v.Callsign)
+                    $.each(v.Members, function(kk,vv) {
+                        $.ajax({
+                            type: 'GET'
+                            , url: '/Api/v1/People/'+vv.Person.Id+'/Contacts'
+                            , data: {LighthouseFunction: 'LoadPerson'}
+                            , cache: false
+                            , dataType: 'json'
+                            , complete: function(response, textStatus) {
+                                if(textStatus == 'success')
+                                {
+                                    if(response.responseJSON.Results.length) {
+                                        $.each(response.responseJSON.Results, function(k, v) { 
+                                            if (v.ContactTypeId == 2)
+                                            {
+                                                BuildNew = {};
+                                                BuildNew.Contact = v;
+                                                BuildNew.ContactTypeId = v.ContactTypeId
+                                                if (vv.TeamLeader) {
+                                                    BuildNew.Description = v.FirstName+" "+v.LastName+" (TL)";
+
+                                                } else {
+                                                    BuildNew.Description = v.FirstName+" "+v.LastName;
+
+                                                }
+                                                BuildNew.Recipient = v.Detail;
+                                                msgsystem.selectedRecipients.push(BuildNew)
+                                            }
+                                        })
+}
+}
+}
+})
+})
+})
+$($button).appendTo('#lighthouseteams');
+
+})
+$('#teamshq').text("Teams Active At "+msgsystem.selectedHeadquarters.peek().Name)
+$('#HQTeamsSet').show()
+
+}
+});
+}
+
+
+function LoadAllCollections() {collectionscount
 
     $("#lighthousecollections").empty();
 
         //Load the saved Collections
         theLoadedCollection = JSON.parse(localStorage.getItem("lighthouseContactCollections"));
         if (theLoadedCollection) {
-            $("#collectionscount").textContent = theLoadedCollection.length;
+            $("#collectionscount").text(theLoadedCollection.length);
             theLoadedCollection.forEach(function(item) {
                 var $button = make_collection_button(item.name,item.description,item.items.length+"")
                 var $spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
@@ -339,7 +409,16 @@ break;
 function make_collection_button(name, description,count) {
     return (
         <span class="label label tag-rebecca">
-        <span><p  style="margin-bottom:5px"><i class="fa fa-users" aria-hidden="true" style="padding-right: 5px;"></i>{description}<span class="delbutton"><sup style="margin-left: 10px;margin-right: -5px;">X</sup></span></p></span>
+        <span><p  style="margin-bottom:5px"><i class="fa fa-object-group" aria-hidden="true" style="padding-right: 5px;"></i>{description}<span class="delbutton"><sup style="margin-left: 10px;margin-right: -5px;">X</sup></span></p></span>
+        <span>{count} recipients</span>
+        </span>
+        )
+}
+
+function make_team_button(name,count) {
+    return (
+        <span class="label label tag-darkgoldenrod">
+        <span><p  style="margin-bottom:5px"><i class="fa fa-users" aria-hidden="true" style="padding-right: 5px;"></i>{name}<span class="delbutton"><sup style="margin-left: 10px;margin-right: -5px;">X</sup></span></p></span>
         <span>{count} recipients</span>
         </span>
         )
@@ -380,12 +459,15 @@ function DoTour() {
         backdrop: false,
         content: "Lighthouse can prefill the Available Contacts from you unit. Ticking this box enables this behavour. It will also select 'Operational' - 'Yes' by default",
     },
-    {
-        element: "#recipientsdel",
-        title: "Lighthouse Delete",
+        {
+        element: "#lighthouseteams",
+        title: "Active Teams",
         placement: "auto",
         backdrop: false,
-        content: "We have added a button to remove all the selected message recipients",
+        onShown: function (tour) {
+          $('#HQTeamsSet').show();
+        },
+        content: "All active teams at the selected HQ will be shown here. Click the team to message the members. Team leader of the clicked team will have (TL) in his name in the Selected Receipients box.",
     },
     {
         element: "#lighthousecollections",
@@ -415,6 +497,13 @@ function DoTour() {
             $('#lighthousecollections').empty();
         },
         content: "This is a saved collection. Click it to load its contents into 'Selected Recipients'",
+    },
+        {
+        element: "#recipientsdel",
+        title: "Lighthouse Delete",
+        placement: "auto",
+        backdrop: false,
+        content: "We have added a button to remove all the selected message recipients",
     },
     {
         element: "",

--- a/src/injectscripts/messages/create.js
+++ b/src/injectscripts/messages/create.js
@@ -164,6 +164,12 @@ function LoadTeams() {
             $.each(response.responseJSON.Results, function(k, v) {
                 var $button = make_team_button(v.Callsign,v.Members.length+"")
                 $($button).click(function() { 
+                    var $spinner = (<i style="margin-top:4px" class="fa fa-refresh fa-spin fa-2x fa-fw"></i>)
+                    var nodes = $button.childNodes;
+                    for(i=0; i<nodes.length; i++) {
+                        nodes[i].style.display="none";
+                    }
+                    $($spinner).appendTo($button);
                     console.log("clicked "+v.Callsign)
                     $.each(v.Members, function(kk,vv) {
                         $.ajax({
@@ -195,8 +201,14 @@ function LoadTeams() {
                                         })
 }
 }
-}
-})
+$button.removeChild($spinner);
+                        //cb for when they are loaded
+                        var nodes = $button.childNodes;
+                        for(i=0; i<nodes.length; i++) {
+                            nodes[i].removeAttribute("style");
+                        }
+                    }
+                })
 })
 })
 $($button).appendTo('#lighthouseteams');
@@ -459,61 +471,61 @@ function DoTour() {
         backdrop: false,
         content: "Lighthouse can prefill the Available Contacts from you unit. Ticking this box enables this behavour. It will also select 'Operational' - 'Yes' by default",
     },
-        {
+    {
         element: "#lighthouseteams",
         title: "Active Teams",
         placement: "auto",
         backdrop: false,
         onShown: function (tour) {
           $('#HQTeamsSet').show();
-        },
-        content: "All active teams at the selected HQ will be shown here. Click the team to SMS the members. Team leader of the clicked team will have (TL) in his name in the Selected Receipients box.",
+      },
+      content: "All active teams at the selected HQ will be shown here. Click the team to SMS the members. Team leader of the clicked team will have (TL) in his name in the Selected Receipients box.",
+  },
+  {
+    element: "#lighthousecollections",
+    title: "Lighthouse Collections",
+    placement: "top",
+    backdrop: false,
+    content: "Lighthouse Collections allow you to save a group of message recipients for quick selection later. Collections can contain any combination of recipients (including groups from different units or regions) and are saved locally on your computer.",
+},
+{
+    element: "#collectionsave",
+    title: "Lighthouse Collections - Save",
+    placement: "top",
+    backdrop: false,
+    onNext: function (tour) {
+        $button = make_collection_button("Tour Example","Tour Example","13")
+        $($button).attr("id","tourbutton")
+        $($button).appendTo('#lighthousecollections');
     },
-    {
-        element: "#lighthousecollections",
-        title: "Lighthouse Collections",
-        placement: "top",
-        backdrop: false,
-        content: "Lighthouse Collections allow you to save a group of message recipients for quick selection later. Collections can contain any combination of recipients (including groups from different units or regions) and are saved locally on your computer.",
+    content: "Once you have selected some message recipients click 'Save As Collection' to save them for later. using a name that already exists will replace the old collection.",
+},
+{
+    element: "#tourbutton",
+    title: "Lighthouse Collections - Load",
+    placement: "top",
+    backdrop: false,
+    onNext: function (tour) {
+        $('#lighthousecollections').empty();
     },
-    {
-        element: "#collectionsave",
-        title: "Lighthouse Collections - Save",
-        placement: "top",
-        backdrop: false,
-        onNext: function (tour) {
-            $button = make_collection_button("Tour Example","Tour Example","13")
-            $($button).attr("id","tourbutton")
-            $($button).appendTo('#lighthousecollections');
-        },
-        content: "Once you have selected some message recipients click 'Save As Collection' to save them for later. using a name that already exists will replace the old collection.",
-    },
-    {
-        element: "#tourbutton",
-        title: "Lighthouse Collections - Load",
-        placement: "top",
-        backdrop: false,
-        onNext: function (tour) {
-            $('#lighthousecollections').empty();
-        },
-        content: "This is a saved collection. Click it to load its contents into 'Selected Recipients'",
-    },
-        {
-        element: "#recipientsdel",
-        title: "Lighthouse Delete",
-        placement: "auto",
-        backdrop: false,
-        content: "We have added a button to remove all the selected message recipients",
-    },
-    {
-        element: "",
-        placement: "top",
-        orphan: true,
-        backdrop: true,
-        title: "Questions?",
-        content: "If you have any questions please seek help from the 'About Lighthout' button under the lighthouse menu on the top menu"
-    }
-    ]
+    content: "This is a saved collection. Click it to load its contents into 'Selected Recipients'",
+},
+{
+    element: "#recipientsdel",
+    title: "Lighthouse Delete",
+    placement: "auto",
+    backdrop: false,
+    content: "We have added a button to remove all the selected message recipients",
+},
+{
+    element: "",
+    placement: "top",
+    orphan: true,
+    backdrop: true,
+    title: "Questions?",
+    content: "If you have any questions please seek help from the 'About Lighthout' button under the lighthouse menu on the top menu"
+}
+]
 })
 
     /// Initialize the tour

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -58,8 +58,7 @@
         "https://*.ses.nsw.gov.au/Messages/Create",
         "https://*.ses.nsw.gov.au/Messages/Create/"
       ],
-      "js": ["contentscripts/messages/create.js"],
-      "run_at" : "document_end"
+      "js": ["contentscripts/messages/create.js"]
     },
     {
       "matches": [

--- a/src/styles/all.css
+++ b/src/styles/all.css
@@ -169,6 +169,17 @@ div[data-bind="text: $data"] {
   background-color: rebeccapurple;
 }
 
+.tag-darkgoldenrod{
+  padding-top:5px;
+  padding-bottom:5px;
+  margin: 5px 5px 0 0;
+  cursor: pointer;
+  float: left;
+  border: 1px solid  #b8860b;
+  color: white;
+  background-color: darkgoldenrod;
+}
+
 
 body.previewbeacon {}
 body.previewbeacon #navbar,


### PR DESCRIPTION
Adds a lighthouse box to the send message screen that shows all active teams at the select HQ. clicking a team loads all the SMS contacts into the selected recipients.

Took the chance to move some of the team selection code used in the quick task into a shared lib so it could be reused.

Fix a quick task bug where only a team with a team leader could be quick tasked.