### PR TITLE
Adding Required Module (crossfilter2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "brfs": "^1.4.3",
     "browserify": "^12.0.2",
     "browserify-css": "git+https://github.com/sdunster/browserify-css.git",
+    "crossfilter2": "^1.5.4",
     "fs-extra": "^0.26.7",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",


### PR DESCRIPTION
Was getting an error "_Browserify bundle error { Error: Cannot find module 'crossfilter2' from 'E:\_Common\_Projects\NSWSES - Lighthouse\_GitHub\node_modules\dc'_" when running `gulp`.

After adding this module, `gulp` works OK.