### PR TITLE
Resolving NITC Export Error

### DIFF
--- a/src/pages/nitcexport.js
+++ b/src/pages/nitcexport.js
@@ -99,7 +99,7 @@ function HackTheMatrix(progressBar) {
   var start = new Date(decodeURIComponent(params.start));
   var end = new Date(decodeURIComponent(params.end));
 
-  BeaconClient.nitc.get(params, params.userId, token, start, end, function(nitcs) {
+  BeaconClient.nitc.search(params, params.userId, token, start, end, function(nitcs) {
     let exports;
 
     if (document.getElementById("Activity").checked) {  // Activity list export


### PR DESCRIPTION
Updated nitcexport.js to use correct BeaconClient.nitc function to correct issue where NITC Export page does not work.

Tested Unpacked Extension on:
Chrome Version 112.0.5615.138 (Official Build) (64-bit)
Edge Version 112.0.1722.48 (Official build) (64-bit)

Both Browsers able to successfully export NITC Data.

