### PR TITLE
Batch job tasking fetch and debounce

### DIFF
--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -2005,6 +2005,39 @@ function VM() {
     }, null, "arrayChange");
 
 
+    // --- Debounced initial-load batch for newly filtered-in jobs ---
+    let _pendingInitialTaskingJobs = [];
+    let _pendingInitialTaskingTimer = null;
+
+    function scheduleInitialTaskingFetch(job) {
+        _pendingInitialTaskingJobs.push(job);
+        if (_pendingInitialTaskingTimer) clearTimeout(_pendingInitialTaskingTimer);
+        _pendingInitialTaskingTimer = setTimeout(async () => {
+            const jobs = _pendingInitialTaskingJobs.splice(0);
+            _pendingInitialTaskingTimer = null;
+            if (jobs.length === 0) return;
+
+            const jobIds = jobs.map(j => j.id());
+            console.log(`[batch-tasking] Initial fetch for ${jobIds.length} newly filtered-in jobs`);
+            jobs.forEach(j => j.taskingLoading(true));
+
+            try {
+                const t = await getToken();
+                BeaconClient.job.getTasking(jobIds, apiHost, params.userId, t, (res) => {
+                    (res?.Results || []).forEach(t => myViewModel.upsertTaskingFromPayload(t));
+                    const touchedTime = new Date();
+                    jobs.forEach(j => {
+                        j.lastTaskingDataUpdate = touchedTime;
+                        j.taskingLoading(false);
+                    });
+                });
+            } catch (err) {
+                console.error('[batch-tasking] Initial fetch failed:', err);
+                jobs.forEach(j => j.taskingLoading(false));
+            }
+        }, 250); // 250ms debounce to collect burst of additions
+    }
+
     // automatically refresh markers when jobs change
     self.filteredJobs.subscribe((changes) => {
         // Bail early if incidents are not visible – no need to attach markers
@@ -2015,7 +2048,7 @@ function VM() {
             if (ch.status === 'added') {
                 jobMarkerBatcher.scheduleAdd(ch.value);
                 ch.value.isFilteredIn(true);
-                ch.value.fetchTasking();
+                scheduleInitialTaskingFetch(ch.value);
             } else if (ch.status === 'deleted') {
                 if (ch.value.expanded() || ch.value.popUpIsOpen()) {
                     showAlert("The job you were viewing has been refreshed and filtered out based on the current filters. It has probably been closed or completed.", "warning", 4000);
@@ -2259,6 +2292,55 @@ function VM() {
         });
     }
 
+    // ---- BATCH TASKING REFRESH ----
+    // Collects all filtered-in jobs whose tasking data is stale
+    // (older than the configured refresh interval) and fetches
+    // them in a single API call.
+
+    self.fetchBatchJobTasking = async function () {
+        const staleMs = Number(self.config.refreshInterval() || 60) * 1000;
+        const now = Date.now();
+        const staleJobs = self.filteredJobs().filter(job => {
+            const last = job.lastTaskingDataUpdate?.getTime?.() ?? 0;
+            return (now - last) > staleMs;
+        });
+
+        if (staleJobs.length === 0) return;
+
+        const jobIds = staleJobs.map(j => j.id());
+        console.log(`[batch-tasking] Refreshing tasking for ${jobIds.length} stale jobs`);
+
+        staleJobs.forEach(j => j.taskingLoading(true));
+
+        try {
+            const t = await getToken();
+            BeaconClient.job.getTasking(jobIds, apiHost, params.userId, t, (res) => {
+                (res?.Results || []).forEach(t => myViewModel.upsertTaskingFromPayload(t));
+
+                // Mark all requested jobs as refreshed (even if they had no taskings)
+                const touchedTime = new Date();
+                staleJobs.forEach(j => {
+                    j.lastTaskingDataUpdate = touchedTime;
+                    j.taskingLoading(false);
+                });
+            });
+        } catch (err) {
+            console.error('[batch-tasking] Failed:', err);
+            staleJobs.forEach(j => j.taskingLoading(false));
+        }
+    };
+
+    let batchTaskingTimer = null;
+
+    function startBatchTaskingTimer() {
+        if (batchTaskingTimer) clearInterval(batchTaskingTimer);
+        const interval = Number(self.config.refreshInterval() || 60) * 1000;
+        batchTaskingTimer = setInterval(() => {
+            self.fetchBatchJobTasking();
+        }, interval);
+        console.log('[batch-tasking] Timer started:', interval, 'ms');
+    }
+
     self.setJobStatus = async function (jobId, statusName, text, cb) {
         console.log("Setting job status:", jobId, " to ", statusName, " with text:", text);
         const t = await getToken();
@@ -2479,10 +2561,11 @@ function VM() {
 
 
 
-    // re-arm timer when refreshInterval changes
+    // re-arm timers when refreshInterval changes
     self.config.refreshInterval.subscribe(() => {
-        console.log("refreshInterval changed → restarting timer");
+        console.log("refreshInterval changed → restarting timers");
         startJobsTeamsTimer();
+        startBatchTaskingTimer();
     });
 
 
@@ -2525,7 +2608,8 @@ function VM() {
         self.fetchAllTrackableAssets();
 
         startJobsTeamsTimer();
-        startAssetDataRefreshTimer()
+        startAssetDataRefreshTimer();
+        startBatchTaskingTimer();
     }
 
     // --- Polling layers ---

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -1879,8 +1879,10 @@ function VM() {
             } else {
                 showAlert(`Failed to assign incident ${jobVm.identifier()} to team ${teamVm.callsign()}.`, 'danger', 5000);
             }
-            jobVm.fetchTasking();
-            teamVm.fetchTasking();
+            console.log(teamVm, jobVm);
+            jobVm.fetchTasking({ force: true });
+            teamVm.fetchTasking({ force: true });
+            teamVm.refreshData(); // ensure team data is fresh 
             if (cb) cb(r);
         })
     }
@@ -2214,7 +2216,11 @@ function VM() {
 
     self.updateTeamStatus = function (tasking, status, payload, cb) {
         BeaconClient.tasking.updateTeamStatus(apiHost, tasking.id(), status, payload, token, function (data) {
-            tasking.job.fetchTasking();
+            tasking.job.fetchTasking({ force: true });
+            if (tasking.team?.isFilteredIn?.()) {
+                tasking.team.fetchTasking({ force: true });
+                tasking.team.refreshData();
+            }
             cb(data || []);
         }, function (err) {
             console.error("Failed to update team status:", err);
@@ -2225,7 +2231,11 @@ function VM() {
 
     self.callOffTeam = function (tasking, payload, cb) {
         BeaconClient.tasking.callOffTeam(apiHost, tasking.id(), payload, token, function (data) {
-            tasking.job.fetchTasking();
+            tasking.job.fetchTasking({ force: true });
+            if (tasking.team?.isFilteredIn?.()) {
+                tasking.team.fetchTasking({ force: true });
+                tasking.team.refreshData();
+            }
             cb(data || []);
         }, function (err) {
             console.error("Failed to call off team:", err);
@@ -2237,7 +2247,11 @@ function VM() {
     self.untaskTeam = function (tasking, payload, cb) {
         const form = BeaconClient.toFormUrlEncoded(payload);
         BeaconClient.tasking.untaskTeam(apiHost, tasking.id(), form, token, function (data) {
-            tasking.job.fetchTasking();
+            tasking.job.fetchTasking({ force: true });
+            if (tasking.team?.isFilteredIn?.()) {
+                tasking.team.fetchTasking({ force: true });
+                tasking.team.refreshData();
+            }
             cb(data);
         }, function (err) {
             console.error("Failed to Untask Team:", err);

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -2453,7 +2453,7 @@ function VM() {
             statusFilterToView,
             incidentTypeFilterToView,
             sectorToView,
-            `Unsectorised=${self.config.includeIncidentsWithoutSector()}`,
+            self.config.applySectorsToIncidents() ? `Unsectorised=${self.config.includeIncidentsWithoutSector()}` : '',
             `ViewModelType=6`,
         ].filter(param => param && param.trim() !== '');
 

--- a/src/pages/tasking/models/Job.js
+++ b/src/pages/tasking/models/Job.js
@@ -387,7 +387,7 @@ export function Job(data = {}, deps = {}) {
     self.incompleteTaskingsOnly = ko.pureComputed(() =>
         self.taskings().filter(t => {
             const status = t.currentStatus();
-            return status !== "Complete" && status !== "CalledOff";
+            return status !== "Complete" && status !== "CalledOff" && status !== "Untasked";
         })
     );
 

--- a/src/pages/tasking/models/Job.js
+++ b/src/pages/tasking/models/Job.js
@@ -258,38 +258,16 @@ export function Job(data = {}, deps = {}) {
 
     self.lastTaskingDataUpdate = new Date();
 
-
-    // ---- Tasking REFRESH CHECK ----
-    // ---- Because the tasking doesnt come down in the job search ----
-    const dataRefreshInterval = makeFilteredInterval(async () => {
-        const now = Date.now();
-        const last = self.lastTaskingDataUpdate?.getTime?.() ?? 0;
-        // only refresh if we haven't had an update in > 2 minutes
-        if (now - last > 120000) {
-            self.fetchTasking();
-        }
-    }, 30000, { runImmediately: false });
-
-    self.startDataRefreshCheck = function () {
-        dataRefreshInterval.start();
-    };
-
-    self.stopDataRefreshCheck = function () {
-        dataRefreshInterval.stop();
-    };
+    // Minimum cooldown (ms) between single-job tasking fetches.
+    // Bulk/batch refreshes update lastTaskingDataUpdate directly,
+    // so this gate also prevents a single fetch right after a batch.
+    const SINGLE_FETCH_COOLDOWN_MS = 10_000;
 
     self.drawJobTargetRing = function () {
         drawJobTargetRing(self);
     };
 
-    // Start/stop with filter state
-    self.isFilteredIn.subscribe((flag) => {
-        if (flag) {
-            self.startDataRefreshCheck();
-        } else {
-            self.stopDataRefreshCheck();
-        }
-    });
+    // (Periodic tasking refresh is now handled in bulk by main.js)
 
     self.expanded.subscribe((isExpanded) => {
         self.instantTask.popupActive(isExpanded || self.popUpIsOpen());
@@ -526,8 +504,6 @@ export function Job(data = {}, deps = {}) {
 
     Job.prototype.updateFromJson = function (d = {}) {
 
-        this.startDataRefreshCheck(); // restart timer
-
         // sector might be undefined or null. they mean different things
         if (d.Sector !== undefined) { //sector present in payload
             if (d.Sector === null) { //theres no sector assigned
@@ -655,7 +631,7 @@ export function Job(data = {}, deps = {}) {
     };
 
     self.toggleAndExpand = function () {
-        console.log("Toggling and expanding job", self.id());
+        console.log("Toggling job", self.id());
         self.toggleAndLoad();
         scrollToThisInTable();
     }
@@ -737,12 +713,20 @@ export function Job(data = {}, deps = {}) {
         self.refreshData();
     }
 
-    self.fetchTasking = function () {
+    self.fetchTasking = function (opts = {}) {
+        const force = opts.force === true;
+        if (!force) {
+            const now = Date.now();
+            const last = self.lastTaskingDataUpdate?.getTime?.() ?? 0;
+            if (now - last < SINGLE_FETCH_COOLDOWN_MS) {
+                console.log("Skipping tasking fetch for job", self.id(), "due to cooldown");
+                return; // recently refreshed (single or batch), skip
+            }
+        }
         self.taskingLoading(true);
         fetchJobTasking(self.id(), () => {
             self.taskingLoading(false);
         });
-
     };
 
     self.refreshData = async function () {

--- a/src/pages/tasking/models/Team.js
+++ b/src/pages/tasking/models/Team.js
@@ -534,8 +534,13 @@ export function Team(data = {}, deps = {}) {
     self.fetchTasking = function () {
         if (!getTeamTasking || !upsertTasking) return;
         const now = Date.now();
-        if (now - self._lastFetchTaskingTime < 10000) {
-            console.log(`[Team ${self.id.peek()}] fetchTasking throttled — last called ${now - self._lastFetchTaskingTime}ms ago`);
+        // Gate against both direct fetches AND bulk/batch updates
+        const lastFetch = self._lastFetchTaskingTime || 0;
+        const lastData = self.lastTaskingDataUpdate?.getTime?.() ?? 0;
+        const lastRefresh = Math.max(lastFetch, lastData);
+        if (now - lastRefresh < 10000) {
+            console.log(`[Team ${self.id.peek()}] fetchTasking throttled — last refreshed ${now - lastRefresh}ms ago`);
+            self.taskingLoading(false); // clear loading state since data is already fresh
             return;
         }
         self._lastFetchTaskingTime = now;
@@ -611,20 +616,38 @@ export function Team(data = {}, deps = {}) {
     }
 
     Team.prototype.updateFromJson = function (d = {}) {
-        if (d.Id !== undefined) this.id(d.Id);
-        if (d.TaskedJobCount !== undefined) this.taskedJobCount(d.TaskedJobCount);
-        if (d.Callsign !== undefined) this.callsign(d.Callsign);
-        if (d.TeamStatusType !== undefined) this.teamStatusType(d.TeamStatusType);
-        if (d.Members !== undefined) this.members(d.Members);
-        if (d.AssignedTo !== undefined && d.CreatedAt !== undefined) this.assignedTo(new Entity(d.AssignedTo || d.CreatedAt)); //safety for beacon bug
+        if (d.Id !== undefined && d.Id !== this.id()) this.id(d.Id);
+        if (d.TaskedJobCount !== undefined && d.TaskedJobCount !== this.taskedJobCount()) this.taskedJobCount(d.TaskedJobCount);
+        if (d.Callsign !== undefined && d.Callsign !== this.callsign()) this.callsign(d.Callsign);
+        if (d.TeamStatusType !== undefined) {
+            const cur = this.teamStatusType();
+            if (!cur || cur.Id !== d.TeamStatusType?.Id) this.teamStatusType(d.TeamStatusType);
+        }
+        if (d.Members !== undefined) {
+            // Members is an array of objects — compare by length + leader/person ids
+            const prev = this.members() || [];
+            const next = d.Members || [];
+            const changed = prev.length !== next.length ||
+                next.some((m, i) => m.Person?.Id !== prev[i]?.Person?.Id || m.TeamLeader !== prev[i]?.TeamLeader);
+            if (changed) this.members(next);
+        }
+        if (d.AssignedTo !== undefined && d.CreatedAt !== undefined) {
+            const cur = this.assignedTo();
+            const src = d.AssignedTo || d.CreatedAt;
+            if (!cur || cur.id?.() !== src?.Id) this.assignedTo(new Entity(src));
+        }
         if (d.Sector !== undefined) {
             if (d.Sector === null) {
-                this.sector(new Sector({}));
+                if (this.sector().id?.()) this.sector(new Sector({}));
             } else {
                 this.sector().updateFromJson(d.Sector);
             }
         }
         if (d.statusId !== undefined) this.updateStatusById(d.statusId);
-        if (d.TeamStatusStartDate !== undefined) this.statusDate(new Date(d.TeamStatusStartDate));
+        if (d.TeamStatusStartDate !== undefined) {
+            const newDate = new Date(d.TeamStatusStartDate);
+            const cur = this.statusDate();
+            if (!cur || cur.getTime() !== newDate.getTime()) this.statusDate(newDate);
+        }
     }
 }

--- a/src/pages/tasking/models/Team.js
+++ b/src/pages/tasking/models/Team.js
@@ -531,14 +531,15 @@ export function Team(data = {}, deps = {}) {
 
     self._lastFetchTaskingTime = 0;
 
-    self.fetchTasking = function () {
+    self.fetchTasking = function (opts = {}) {
         if (!getTeamTasking || !upsertTasking) return;
+        const force = opts.force === true;
         const now = Date.now();
         // Gate against both direct fetches AND bulk/batch updates
         const lastFetch = self._lastFetchTaskingTime || 0;
         const lastData = self.lastTaskingDataUpdate?.getTime?.() ?? 0;
         const lastRefresh = Math.max(lastFetch, lastData);
-        if (now - lastRefresh < 10000) {
+        if (!force && now - lastRefresh < 10000) {
             console.log(`[Team ${self.id.peek()}] fetchTasking throttled — last refreshed ${now - lastRefresh}ms ago`);
             self.taskingLoading(false); // clear loading state since data is already fresh
             return;

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -40,7 +40,7 @@ export function ConfigVM(root, deps) {
     //Sectors
     self.sectorFilters = ko.observableArray([]);   // [{id, name}]
     self.includeIncidentsWithoutSector = ko.observable(true);
-    self.applySectorsToIncidents = ko.observable(true);
+    self.applySectorsToIncidents = ko.observable(false);
     self.applySectorsToTeams = ko.observable(false);
 
     //Map layer order
@@ -441,7 +441,7 @@ export function ConfigVM(root, deps) {
             cfg.teamTaskStatusFilter = self.teamTaskStatusFilterDefaults;
             cfg.sectorFilters = [];
             cfg.includeIncidentsWithoutSector = true;
-            cfg.applySectorsToIncidents = true;
+            cfg.applySectorsToIncidents = false;
             cfg.applySectorsToTeams = false;
             cfg.pinnedTeamIds = [];
             cfg.pinnedIncidentIds = [];
@@ -654,19 +654,14 @@ export function ConfigVM(root, deps) {
      */
     self._sectorHqIds = () => {
         const ids = new Set();
-        if (self.applySectorsToIncidents()) {
-            (self.incidentFilters() || []).forEach(f => ids.add(f.id));
-        }
-        if (self.applySectorsToTeams()) {
-            (self.teamFilters() || []).forEach(f => ids.add(f.id));
-        }
+        (self.incidentFilters() || []).forEach(f => ids.add(f.id));
+        (self.teamFilters() || []).forEach(f => ids.add(f.id));
         return [...ids];
     };
 
     /** Trigger a sector refresh using the current scope-aware HQ list. */
     self._refreshSectors = () => {
         if (self._suppressSectorRefresh) return;
-        if (!self.applySectorsToIncidents() && !self.applySectorsToTeams()) return;
         const ids = self._sectorHqIds();
         if (ids.length === 0) return;          // no HQs selected — nothing to search
         deps.fetchAllSectors(ids);
@@ -690,6 +685,7 @@ export function ConfigVM(root, deps) {
     self._suppressSectorRefresh = true;
     self.loadFromStorage()
     self._suppressSectorRefresh = false;
+    self._refreshSectors();
 
     self.incidentFilters.subscribe(() => {
         self._refreshSectors();

--- a/src/shared/BeaconClient/job.js
+++ b/src/shared/BeaconClient/job.js
@@ -143,21 +143,19 @@ export function get(id, viewModelType = 1, host, userId = 'notPassed', token, ca
 }
 
 
-export function getTasking(id, host, userId = 'notPassed', token, callback) {
-  $.ajax({
-    type: 'GET',
-    url: host + "/Api/v1/Tasking/Search?LighthouseFunction=GetJobTaskingFromBeacon&userId=" + userId + "&JobIds%5B%5D=" + id,
-    beforeSend: function (n) {
-      n.setRequestHeader("Authorization", "Bearer " + token)
-    },
-    cache: false,
-    dataType: 'json',
-    complete: function (response, textStatus) {
-      if (textStatus == 'success') {
-        callback(response.responseJSON);
-      }
+export function getTasking(ids, host, userId = 'notPassed', token, callback) {
+  // Support single id or array of ids
+  const idArr = Array.isArray(ids) ? ids : [ids];
+  const fnName = Array.isArray(ids) ? 'GetBulkJobTaskingFromBeacon' : 'GetJobTaskingFromBeacon';
+  const jobIdsParam = idArr.map(jid => "JobIds%5B%5D=" + encodeURIComponent(jid)).join("&");
+  const url = host + "/Api/v1/Tasking/Search?LighthouseFunction=" + fnName + "&userId=" + userId + "&" + jobIdsParam;
+  getJsonPaginated(
+    url, token, 0, 100,
+    function () { /* progress – not needed */ },
+    function (results) {
+      callback({ Results: results });
     }
-  });
+  );
 }
 
 export function searchwithFilter(unit, host, StartDate, EndDate, userId = 'notPassed', token, callback, progressCallBack, viewmodel, statusTypes = [], jobType = [], onPage) {

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -1177,8 +1177,7 @@
                                                                                     data-bind="text: j.sectorName()"></span>
                                                                                 <span class="caret"></span>
                                                                             </button>
-                                                                            <ul class="dropdown-menu sectorDropdown"
-                                                                                data-bs-popper="static">
+                                                                            <ul class="dropdown-menu sectorDropdown">
                                                                                 <!-- ko foreach: $root.sectors -->
                                                                                 <li>
                                                                                     <button type="button"

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2003,11 +2003,13 @@ overflow: hidden;
   z-index: 3000 !important;
 }
 
-#sectorDropdown {
+.sectorDropdown {
   z-index: 3000 !important;
+  max-height: calc(10 * 2em + 1rem);
+  overflow-y: auto;
 }
 
-#sectorDropdown.show {
+.sectorDropdown.show {
   position: fixed !important;
 }
 


### PR DESCRIPTION
Add batched and debounced tasking fetches to reduce per-job API calls and bursts. main.js: introduce a 250ms debounced initial-load batch for newly filtered-in jobs, a periodic batch refresh (driven by config.refreshInterval) and timer management (start/restart). Job.js: remove per-job periodic refresh checks, add a SINGLE_FETCH_COOLDOWN_MS (10s) and make fetchTasking honor a force option to avoid redundant single-job requests right after batch updates. Team.js: gate fetchTasking against both last fetch time and last bulk refresh time, clear loading state when throttled, and make updateFromJson do defensive/no-op updates to avoid unnecessary observable writes. shared/BeaconClient/job.js: extend getTasking to accept single id or array of ids, build multi-JobIds parameters, and use paginated JSON fetch to return a unified Results array. Overall this reduces API traffic, prevents duplicate refreshes, and avoids unnecessary UI churn.