### PR TITLE
Adjust job-details column width to col-md-7

### DIFF
--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -1128,7 +1128,7 @@
 
                                                 <div class="card-body job-details-form">
                                                     <div class="row g-3">
-                                                        <div class="col-md-8">
+                                                        <div class="col-md-7">
                                                             <!-- Unacknowledged Notifications Warning -->
                                                             <!-- ko if: j.hasUnacceptedNotifications() -->
                                                             <div class="alert alert-danger d-flex align-items-center justify-content-center text-center py-2 mb-2"


### PR DESCRIPTION
This pull request makes a small adjustment to the layout of the job details form on the `tasking.html` page by changing the column width for one of the form sections.

* Reduced the column width from 8 to 7 (`col-md-8` to `col-md-7`) in the job details form to improve layout and spacing.Update static/pages/tasking.html: change the Bootstrap column class in the job-details-form from col-md-8 to col-md-7 to adjust the layout/spacing of the form.