### PR TITLE
LAD - Add layout presets & minimap basemap sync

### DIFF
--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -309,8 +309,46 @@ map.createPane('pane-tippy-top'); map.getPane('pane-tippy-top').style.zIndex = 7
 map.createPane('pane-tippy-top-plus'); map.getPane('pane-tippy-top-plus').style.zIndex = 701;
 
 
-var osm2 = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { minZoom: 0, maxZoom: 13 });
-new MiniMap(osm2, { toggleDisplay: true }).addTo(map);
+function buildBasemapLayer(key) {
+    // --- NSW VECTOR BASEMAP (Topographic style) ---
+    if (key === "nsw-vector") {
+        return esriVector.vectorTileLayer(
+            "https://portal.spatial.nsw.gov.au/vectortileservices/rest/services/Hosted/NSW_BaseMap_VectorTile/VectorTileServer",
+            {
+                attribution: "© NSW Spatial Services"
+            }
+        );
+    }
+
+    // --- NSW RASTER BASEMAPS (tile MapServer) ---
+    if (key === "nsw-base") {
+        return L.tileLayer(
+            "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Base_Map/MapServer/tile/{z}/{y}/{x}",
+            {
+                maxZoom: 20,
+                attribution: "© NSW Spatial Services"
+            }
+        );
+    }
+
+    if (key === "nsw-imagery") {
+        return L.tileLayer(
+            "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Imagery/MapServer/tile/{z}/{y}/{x}",
+            {
+                maxZoom: 20,
+                attribution: "© NSW Spatial Services"
+            }
+        );
+    }
+
+    // --- EXISTING ESRI BASEMAPS ---
+    return esri.basemapLayer(key, { ignoreDeprecationWarning: true });
+}
+
+
+const minimapInitialKey = localStorage.getItem("map.base") || "Topographic";
+var minimapLayer = buildBasemapLayer(minimapInitialKey) || buildBasemapLayer("Topographic");
+const miniMapControl = new MiniMap(minimapLayer, { toggleDisplay: true }).addTo(map);
 
 const legend = new LegendControl({ collapsed: true, persist: true });
 legend.addTo(map);
@@ -3226,43 +3264,15 @@ function VM() {
                 this._currentBase = null;
             }
 
-            // --- NSW VECTOR BASEMAP (Topographic style) ---
-            if (key === "nsw-vector") {
-                // Uses the NSW_BaseMap_VectorTile VectorTileServer
-                this._currentBase = esriVector.vectorTileLayer(
-                    "https://portal.spatial.nsw.gov.au/vectortileservices/rest/services/Hosted/NSW_BaseMap_VectorTile/VectorTileServer",
-                    {
-                        attribution: "© NSW Spatial Services"
-                    }
-                );
-            }
-
-            // --- NSW RASTER BASEMAPS (tile MapServer) ---
-            else if (key === "nsw-base") {
-                this._currentBase = L.tileLayer(
-                    "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Base_Map/MapServer/tile/{z}/{y}/{x}",
-                    {
-                        maxZoom: 20,
-                        attribution: "© NSW Spatial Services"
-                    }
-                );
-            } else if (key === "nsw-imagery") {
-                this._currentBase = L.tileLayer(
-                    "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Imagery/MapServer/tile/{z}/{y}/{x}",
-                    {
-                        maxZoom: 20,
-                        attribution: "© NSW Spatial Services"
-                    }
-                );
-            }
-
-            // --- EXISTING ESRI BASEMAPS ---
-            else {
-                this._currentBase = esri.basemapLayer(key, { ignoreDeprecationWarning: true });
-            }
+            this._currentBase = buildBasemapLayer(key);
 
             if (this._currentBase) {
                 this._currentBase.addTo(map);
+            }
+
+            const nextMiniMapLayer = buildBasemapLayer(key);
+            if (nextMiniMapLayer) {
+                miniMapControl.changeLayer(nextMiniMapLayer);
             }
         }
 

--- a/src/pages/tasking/resize.js
+++ b/src/pages/tasking/resize.js
@@ -7,31 +7,80 @@ const sidebarEl  = document.querySelector('.sidebar');
 const vsplitEl   = document.getElementById('vsplit');
 
 const paneTopEl  = document.getElementById('paneTop');
+const paneBottomEl = document.getElementById('paneBottom');
 const hsplitEl   = document.getElementById('hsplit');
+
+const LAYOUT_PRESETS = [
+  'map-right-teams-top',
+  'map-right-tasking-top',
+  'map-left-teams-top',
+  'map-left-tasking-top',
+  'map-right-teams-only',
+  'map-right-tasking-only',
+  'map-left-teams-only',
+  'map-left-tasking-only',
+  'map-only'
+];
+const DEFAULT_LAYOUT_PRESET = 'map-right-teams-top';
+const normalizeLayoutPreset = (value) => {
+  const key = String(value || '').trim();
+  return LAYOUT_PRESETS.includes(key) ? key : DEFAULT_LAYOUT_PRESET;
+};
 
 // Leaflet map instance must exist; guard invalidateSize calls
 // eslint-disable-next-line no-empty
 function invalidateMap() { try { map.invalidateSize(); } catch(_) {} }
 
+let currentLayoutPreset = normalizeLayoutPreset(localStorage.getItem('lh.layoutPreset'));
+
+function layoutStorageKey(suffix) {
+  return `lh.layout.${currentLayoutPreset}.${suffix}`;
+}
+
+function applyLayoutPresetClass(preset) {
+  const normalized = normalizeLayoutPreset(preset);
+  currentLayoutPreset = normalized;
+  LAYOUT_PRESETS.forEach(layout => appEl.classList.remove(`layout-${layout}`));
+  appEl.classList.add(`layout-${normalized}`);
+  localStorage.setItem('lh.layoutPreset', normalized);
+}
+
+function topPaneForCurrentLayout() {
+  if (currentLayoutPreset.endsWith('tasking-top') || currentLayoutPreset.endsWith('tasking-only')) {
+    return paneBottomEl;
+  }
+  return paneTopEl;
+}
+
+function resetPaneHeights() {
+  paneTopEl.style.height = '';
+  paneBottomEl.style.height = '';
+}
+
 // ===== Restore persisted sizes on load =====
-(function restoreSizes() {
+function restoreSizes() {
+  resetPaneHeights();
+
   // Left↔Right
-  const savedSidebarPx = Number(localStorage.getItem('lh.sidebarWidthPx'))   || 800;
+  const savedSidebarPx = Number(localStorage.getItem(layoutStorageKey('sidebarWidthPx'))) || 800;
   if (Number.isFinite(savedSidebarPx) && savedSidebarPx > 0) {
     sidebarEl.style.width = savedSidebarPx + 'px';
     appEl.style.setProperty('--sidebar-w', savedSidebarPx + 'px');
   }
 
   // Top↔Bottom
-  const savedTopPx = Number(localStorage.getItem('lh.paneTopHeightPx')   || 500);
+  const savedTopPx = Number(localStorage.getItem(layoutStorageKey('paneTopHeightPx')) || 500);
   if (Number.isFinite(savedTopPx) && savedTopPx > 0) {
-    paneTopEl.style.height = savedTopPx + 'px';
+    topPaneForCurrentLayout().style.height = savedTopPx + 'px';
     appEl.style.setProperty('--pane-top-h', savedTopPx + 'px');
   }
 
   // Let layout settle then fix map size
   setTimeout(invalidateMap, 0);
-})();
+}
+
+applyLayoutPresetClass(currentLayoutPreset);
+restoreSizes();
 
 // ===== Left↔Right (vertical splitter) =====
 let resizingLR = false, rafLR = 0;
@@ -50,8 +99,8 @@ function applyLR(clientX) {
   appEl.style.setProperty('--sidebar-w', w + 'px');
 
   const mapW = appRect.width - w - splitW;
-  localStorage.setItem('lh.sidebarWidthPx', String(w));
-  localStorage.setItem('lh.mapWidthPx', String(Math.max(0, Math.floor(mapW))));
+  localStorage.setItem(layoutStorageKey('sidebarWidthPx'), String(w));
+  localStorage.setItem(layoutStorageKey('mapWidthPx'), String(Math.max(0, Math.floor(mapW))));
 }
 
 function startLR() { resizingLR = true; vsplitEl.classList.add('resizing'); document.body.style.cursor = 'col-resize'; }
@@ -88,8 +137,8 @@ function applyTB(clientY) {
   appEl.style.setProperty('--pane-top-h', topH + 'px');
 
   const botH = Math.max(minBot, total - splitH - topH);
-  localStorage.setItem('lh.paneTopHeightPx', String(Math.floor(topH)));
-  localStorage.setItem('lh.paneBottomHeightPx', String(Math.floor(botH)));
+  localStorage.setItem(layoutStorageKey('paneTopHeightPx'), String(Math.floor(topH)));
+  localStorage.setItem(layoutStorageKey('paneBottomHeightPx'), String(Math.floor(botH)));
 }
 
 function startTB() { resizingTB = true; hsplitEl.classList.add('resizing'); document.body.style.cursor = 'row-resize'; }
@@ -117,7 +166,7 @@ window.addEventListener('resize', () => {
   const splitW  = vsplitEl.getBoundingClientRect().width;
   const minSidebar = 260, minMap = 260;
   const maxSidebar = Math.min(appRect.width - splitW - minMap, appRect.width * 0.7);
-  const savedW = Number(localStorage.getItem('lh.sidebarWidthPx')) || sidebarEl.getBoundingClientRect().width;
+  const savedW = Number(localStorage.getItem(layoutStorageKey('sidebarWidthPx'))) || sidebarEl.getBoundingClientRect().width;
   if (Number.isFinite(savedW) && savedW > 0) {
     const clamped = Math.max(minSidebar, Math.min(savedW, maxSidebar));
     sidebarEl.style.width = clamped + 'px';
@@ -129,14 +178,21 @@ window.addEventListener('resize', () => {
   const splitH = hsplitEl.getBoundingClientRect().height;
   const minTop = 120, minBot = 120;
   const maxTop = Math.max(minTop, sbRect.height - splitH - minBot);
-  const savedTop = Number(localStorage.getItem('lh.paneTopHeightPx')) || paneTopEl.getBoundingClientRect().height;
+  const topPaneEl = topPaneForCurrentLayout();
+  const savedTop = Number(localStorage.getItem(layoutStorageKey('paneTopHeightPx'))) || topPaneEl.getBoundingClientRect().height;
   if (Number.isFinite(savedTop) && savedTop > 0) {
     const clampedTop = Math.max(minTop, Math.min(savedTop, maxTop));
-    paneTopEl.style.height = clampedTop + 'px';
+    topPaneEl.style.height = clampedTop + 'px';
     appEl.style.setProperty('--pane-top-h', clampedTop + 'px');
   }
 
   // Map may need a relayout after width changes
   setTimeout(invalidateMap, 0);
+});
+
+window.addEventListener('lh:layoutPresetChanged', (event) => {
+  const nextPreset = normalizeLayoutPreset(event?.detail?.preset);
+  applyLayoutPresetClass(nextPreset);
+  restoreSizes();
 });
 }

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -13,6 +13,33 @@ const FUNCTION_URL = "https://lambda.lighthouse-extension.com/lad/share";
 export function ConfigVM(root, deps) {
     const self = this;
 
+    const LAYOUT_PRESETS = [
+        'map-right-teams-top',
+        'map-right-tasking-top',
+        'map-left-teams-top',
+        'map-left-tasking-top',
+        'map-right-teams-only',
+        'map-right-tasking-only',
+        'map-left-teams-only',
+        'map-left-tasking-only',
+        'map-only'
+    ];
+    const DEFAULT_LAYOUT_PRESET = 'map-right-teams-top';
+    const normalizeLayoutPreset = (value) => {
+        const key = String(value || '').trim();
+        return LAYOUT_PRESETS.includes(key) ? key : DEFAULT_LAYOUT_PRESET;
+    };
+    const applyLayoutPresetClass = (preset) => {
+        const appEl = document.querySelector('.app');
+        if (!appEl) return;
+
+        LAYOUT_PRESETS.forEach(layout => appEl.classList.remove(`layout-${layout}`));
+        appEl.classList.add(`layout-${preset}`);
+
+        localStorage.setItem('lh.layoutPreset', preset);
+        window.dispatchEvent(new CustomEvent('lh:layoutPresetChanged', { detail: { preset } }));
+    };
+
     // UI state
     self.query = ko.observable('');
     self.results = ko.observableArray([]);
@@ -166,6 +193,64 @@ export function ConfigVM(root, deps) {
     self.showAdvanced = ko.observable(false);
     self.darkMode = ko.observable(false);
 
+    self.layoutPresetDefs = [
+        {
+            id: 'map-right-teams-top',
+            name: 'Map Right · Teams Top',
+            description: 'Teams above tasking in the sidebar, map on the right.',
+            previewClass: 'preset-map-right-teams-top'
+        },
+        {
+            id: 'map-right-tasking-top',
+            name: 'Map Right · Tasking Top',
+            description: 'Tasking above teams in the sidebar, map on the right.',
+            previewClass: 'preset-map-right-tasking-top'
+        },
+        {
+            id: 'map-left-teams-top',
+            name: 'Map Left · Teams Top',
+            description: 'Map on the left with teams above tasking on the right.',
+            previewClass: 'preset-map-left-teams-top'
+        },
+        {
+            id: 'map-left-tasking-top',
+            name: 'Map Left · Tasking Top',
+            description: 'Map on the left with tasking above teams on the right.',
+            previewClass: 'preset-map-left-tasking-top'
+        },
+        {
+            id: 'map-right-teams-only',
+            name: 'Map Right · Teams Only',
+            description: 'Hide tasking pane, keep teams + map.',
+            previewClass: 'preset-map-right-teams-only'
+        },
+        {
+            id: 'map-right-tasking-only',
+            name: 'Map Right · Tasking Only',
+            description: 'Hide teams pane, keep tasking + map.',
+            previewClass: 'preset-map-right-tasking-only'
+        },
+        {
+            id: 'map-left-teams-only',
+            name: 'Map Left · Teams Only',
+            description: 'Map left with teams-only pane on the right.',
+            previewClass: 'preset-map-left-teams-only'
+        },
+        {
+            id: 'map-left-tasking-only',
+            name: 'Map Left · Tasking Only',
+            description: 'Map left with tasking-only pane on the right.',
+            previewClass: 'preset-map-left-tasking-only'
+        },
+        {
+            id: 'map-only',
+            name: 'Map Only',
+            description: 'Hide both sidebar panes and use the full map view.',
+            previewClass: 'preset-map-only'
+        }
+    ];
+    self.layoutPreset = ko.observable(DEFAULT_LAYOUT_PRESET);
+
     //blown away on load
     self.teamStatusFilter = ko.observableArray([]);
 
@@ -293,6 +378,7 @@ export function ConfigVM(root, deps) {
         fetchForward: Number(self.fetchForward()),
         showAdvanced: !!self.showAdvanced(),
         darkMode: !!self.darkMode(),
+        layoutPreset: normalizeLayoutPreset(self.layoutPreset()),
         locationFilters: {
             teams: ko.toJS(self.teamFilters),
             incidents: ko.toJS(self.incidentFilters)
@@ -567,6 +653,7 @@ export function ConfigVM(root, deps) {
         if (typeof cfg.darkMode === 'boolean') {
             self.darkMode(cfg.darkMode);
         }
+        self.layoutPreset(normalizeLayoutPreset(cfg.layoutPreset || localStorage.getItem('lh.layoutPreset')));
         if (typeof cfg.includeIncidentsWithoutSector === 'boolean') {
             self.includeIncidentsWithoutSector(cfg.includeIncidentsWithoutSector);
         }
@@ -763,6 +850,7 @@ export function ConfigVM(root, deps) {
         root.mapVM?.applyPaneOrder?.(self.paneOrder().map(p => p.id));
         root.mapVM?.applyClusterRadius?.(Number(self.clusterRadius()) || 60);
         root.mapVM?.applyClusterEnabled?.(!!self.clusterEnabled());
+        applyLayoutPresetClass(normalizeLayoutPreset(self.layoutPreset()));
         // Apply dark mode
         self._applyDarkMode();
         // Apply dark mode basemap if enabled
@@ -834,6 +922,16 @@ export function ConfigVM(root, deps) {
             root.mapVM.changeBasemap(targetBasemap);
         }
         
+        self.save();
+    });
+
+    self.layoutPreset.subscribe((preset) => {
+        const normalized = normalizeLayoutPreset(preset);
+        if (normalized !== preset) {
+            self.layoutPreset(normalized);
+            return;
+        }
+        applyLayoutPresetClass(normalized);
         self.save();
     });
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2001,9 +2001,7 @@
                     <!-- CONFIG -->
                     <!-- CONFIG -->
                     <div class="card config-card mt-3">
-                        <div class="card-header py-2">
-                            <strong>Other Settings</strong>
-                        </div>
+
                         <div class="card-body">
                             <form id="configForm">
                                 <div class="accordion" id="configOtherSettingsAccordion">
@@ -2091,6 +2089,46 @@
                                                         <div class="form-text">Alerts will start collapsed.</div>
                                                     </div>
                                                 </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Panel Layout -->
+                                    <div class="accordion-item">
+                                        <h2 class="accordion-header" id="headingPanelLayout">
+                                            <button class="accordion-button gap-2 collapsed" type="button"
+                                                data-bs-toggle="collapse" data-bs-target="#collapsePanelLayout"
+                                                aria-expanded="false" aria-controls="collapsePanelLayout">
+                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-columns"></i></span>
+                                                <span>Panel Layout</span>
+                                            </button>
+                                        </h2>
+                                        <div id="collapsePanelLayout" class="accordion-collapse collapse"
+                                            aria-labelledby="headingPanelLayout"
+                                            data-bs-parent="#configOtherSettingsAccordion">
+                                            <div class="accordion-body">
+                                                <label class="form-label">
+                                                    <i class="fa fa-columns me-1"></i>Section Layout Preset
+                                                </label>
+                                                <div class="layout-preset-grid"
+                                                    data-bind="foreach: { data: config.layoutPresetDefs, as: 'preset' }">
+                                                    <label class="layout-preset-card"
+                                                        data-bind="css: { 'is-active': $root.config.layoutPreset() === preset.id }">
+                                                        <input class="form-check-input layout-preset-radio"
+                                                            type="radio" name="layoutPreset"
+                                                            data-bind="checked: $root.config.layoutPreset, checkedValue: preset.id">
+                                                        <div class="layout-preset-preview"
+                                                            data-bind="css: preset.previewClass">
+                                                            <div class="preview-block preview-block--teams">Teams</div>
+                                                            <div class="preview-block preview-block--tasking">Tasking</div>
+                                                            <div class="preview-block preview-block--map">Map</div>
+                                                        </div>
+                                                        <div class="layout-preset-name" data-bind="text: preset.name"></div>
+                                                        <div class="layout-preset-description small text-muted"
+                                                            data-bind="text: preset.description"></div>
+                                                    </label>
+                                                </div>
+                                                <div class="form-text">Pick a layout to instantly preview and apply section placement.</div>
                                             </div>
                                         </div>
                                     </div>

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -260,6 +260,32 @@ td.chev[draggable='true'] * {
   width: 100vw;
 }
 
+.app.layout-map-left-teams-top .sidebar,
+.app.layout-map-left-tasking-top .sidebar,
+.app.layout-map-left-teams-only .sidebar,
+.app.layout-map-left-tasking-only .sidebar {
+  order: 3;
+}
+
+.app.layout-map-left-teams-top .vsplit,
+.app.layout-map-left-tasking-top .vsplit,
+.app.layout-map-left-teams-only .vsplit,
+.app.layout-map-left-tasking-only .vsplit {
+  order: 2;
+}
+
+.app.layout-map-left-teams-top .map-wrap,
+.app.layout-map-left-tasking-top .map-wrap,
+.app.layout-map-left-teams-only .map-wrap,
+.app.layout-map-left-tasking-only .map-wrap {
+  order: 1;
+}
+
+.app.layout-map-only .sidebar,
+.app.layout-map-only .vsplit {
+  display: none !important;
+}
+
 .sidebar {
   width: var(--sidebar-w, 420px);
   display: flex;
@@ -320,6 +346,199 @@ body.sidebar-collapsed .vsplit {
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 60%;
+}
+
+.app.layout-map-right-tasking-top #paneBottom,
+.app.layout-map-left-tasking-top #paneBottom {
+  order: 1;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: auto;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.app.layout-map-right-tasking-top #hsplit,
+.app.layout-map-left-tasking-top #hsplit {
+  order: 2;
+}
+
+.app.layout-map-right-tasking-top #paneTop,
+.app.layout-map-left-tasking-top #paneTop {
+  order: 3;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 60%;
+  border-bottom: 0;
+}
+
+.app.layout-map-right-teams-only #paneBottom,
+.app.layout-map-left-teams-only #paneBottom,
+.app.layout-map-right-teams-only #hsplit,
+.app.layout-map-left-teams-only #hsplit {
+  display: none !important;
+}
+
+.app.layout-map-right-teams-only #paneTop,
+.app.layout-map-left-teams-only #paneTop {
+  order: 1;
+  flex: 1 1 auto;
+  height: auto;
+  border-bottom: 0;
+}
+
+.app.layout-map-right-tasking-only #paneTop,
+.app.layout-map-left-tasking-only #paneTop,
+.app.layout-map-right-tasking-only #hsplit,
+.app.layout-map-left-tasking-only #hsplit {
+  display: none !important;
+}
+
+.app.layout-map-right-tasking-only #paneBottom,
+.app.layout-map-left-tasking-only #paneBottom {
+  order: 1;
+  flex: 1 1 auto;
+  height: auto;
+  border-bottom: 0;
+}
+
+.layout-preset-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  gap: 10px;
+}
+
+.layout-preset-card {
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: var(--bs-body-bg);
+  cursor: pointer;
+}
+
+.layout-preset-card.is-active {
+  border-color: var(--bs-primary);
+  box-shadow: inset 0 0 0 1px var(--bs-primary);
+}
+
+.layout-preset-radio {
+  align-self: flex-start;
+  margin: 0;
+}
+
+.layout-preset-name {
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.layout-preset-description {
+  line-height: 1.25;
+}
+
+.layout-preset-preview {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 3px;
+  height: 62px;
+  border: 1px solid var(--bs-border-color-translucent);
+  border-radius: 0.4rem;
+  padding: 3px;
+  background: var(--bs-secondary-bg);
+}
+
+.layout-preset-preview .preview-block {
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--bs-emphasis-color);
+  background: var(--bs-body-bg);
+}
+
+.layout-preset-preview .preview-block--teams {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.layout-preset-preview .preview-block--tasking {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.layout-preset-preview .preview-block--map {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+}
+
+.layout-preset-preview.preset-map-right-tasking-top .preview-block--teams,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--teams {
+  grid-row: 2;
+}
+
+.layout-preset-preview.preset-map-right-tasking-top .preview-block--tasking,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--tasking {
+  grid-row: 1;
+}
+
+.layout-preset-preview.preset-map-left-teams-top .preview-block--teams,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--teams,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--teams,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--teams,
+.layout-preset-preview.preset-map-left-teams-top .preview-block--tasking,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--tasking,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--tasking,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--tasking {
+  grid-column: 2;
+}
+
+.layout-preset-preview.preset-map-left-teams-top .preview-block--map,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--map,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--map,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--map {
+  grid-column: 1;
+}
+
+.layout-preset-preview.preset-map-right-teams-only .preview-block--tasking,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--tasking {
+  display: none;
+}
+
+.layout-preset-preview.preset-map-right-teams-only .preview-block--teams,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--teams {
+  grid-row: 1 / span 2;
+}
+
+.layout-preset-preview.preset-map-right-tasking-only .preview-block--teams,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--teams {
+  display: none;
+}
+
+.layout-preset-preview.preset-map-right-tasking-only .preview-block--tasking,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--tasking {
+  grid-row: 1 / span 2;
+}
+
+.layout-preset-preview.preset-map-only {
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+}
+
+.layout-preset-preview.preset-map-only .preview-block--teams,
+.layout-preset-preview.preset-map-only .preview-block--tasking {
+  display: none;
+}
+
+.layout-preset-preview.preset-map-only .preview-block--map {
+  grid-column: 1;
+  grid-row: 1;
 }
 
 .team-table-container,


### PR DESCRIPTION
Introduce reusable basemap builder and hook the MiniMap to the selected basemap (persisted via localStorage 'map.base'), ensuring the minimap updates when the base changes. Add layout presets for sidebar/pane arrangements with CSS, a UI in the config panel to preview/select presets, and per-preset persistence for split sizes (localStorage keys scoped as 'lh.layout.<preset>.<suffix>'). Update resize logic to apply preset classes, read/write layout-scoped sizes, restore sizes on load, and emit/listen to an 'lh:layoutPresetChanged' event so the UI and layout stay in sync.