### PR TITLE
Lad fixes

### DIFF
--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -3324,6 +3324,34 @@ function VM() {
         }
     });
 
+    // --- Settings button (visible in map-only mode to open config modal)
+    const MapSettingsControl = L.Control.extend({
+        options: { position: "topleft" },
+
+        onAdd(_map) {
+            const container = L.DomUtil.create("div", "leaflet-control map-settings-control leaflet-bar");
+            container.innerHTML = `
+                <button type="button" class="btn btn-light btn-sm shadow-sm" title="Open page config"
+                    style="width:30px;height:30px;padding:0;display:flex;align-items:center;justify-content:center;">
+                    <i class="fas fa-cog"></i>
+                </button>
+            `;
+
+            const btn = container.querySelector(".btn");
+            L.DomEvent.on(btn, "click", (ev) => {
+                L.DomEvent.stop(ev);
+                const modalEl = document.getElementById('configModal');
+                if (modalEl) {
+                    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+                    modal.show();
+                }
+            });
+
+            L.DomEvent.disableClickPropagation(container);
+            return container;
+        }
+    });
+
     // --- Zoom-to-fit button (sits directly below the zoom control)
     const ZoomToFit = L.Control.extend({
         options: { position: "topleft" },
@@ -3372,6 +3400,9 @@ function VM() {
 
     const sidebarToggle = new SidebarToggle();
     sidebarToggle.addTo(map);
+
+    const mapSettingsControl = new MapSettingsControl();
+    mapSettingsControl.addTo(map);
 
     const layersDrawer = new LayersDrawer();
     layersDrawer.addTo(map);

--- a/src/pages/tasking/resize.js
+++ b/src/pages/tasking/resize.js
@@ -103,13 +103,13 @@ function applyLR(clientX) {
   localStorage.setItem(layoutStorageKey('mapWidthPx'), String(Math.max(0, Math.floor(mapW))));
 }
 
-function startLR() { resizingLR = true; vsplitEl.classList.add('resizing'); document.body.style.cursor = 'col-resize'; }
+function startLR() { resizingLR = true; vsplitEl.classList.add('resizing'); document.body.classList.add('sidebar-resizing'); document.body.style.cursor = 'col-resize'; }
 function moveLR(x) {
   if (!resizingLR) return;
   if (rafLR) return;
   rafLR = requestAnimationFrame(() => { rafLR = 0; applyLR(x); invalidateMap(); });
 }
-function endLR() { if (!resizingLR) return; resizingLR = false; vsplitEl.classList.remove('resizing'); document.body.style.cursor=''; invalidateMap(); }
+function endLR() { if (!resizingLR) return; resizingLR = false; vsplitEl.classList.remove('resizing'); document.body.classList.remove('sidebar-resizing'); document.body.style.cursor=''; invalidateMap(); }
 
 if (vsplitEl) {
   vsplitEl.addEventListener('mousedown', e => { e.preventDefault(); startLR(); });

--- a/src/pages/tasking/utils/jobTypesToUI.js
+++ b/src/pages/tasking/utils/jobTypesToUI.js
@@ -11,7 +11,9 @@ export function jobsToUI(job) {
         result.fillcolor = priorityStroke[p?.Name] || "#6b7280ff"; // default gray
     }
 
-    result.shape = jobTypeParentCategoryShape[jobTypeParentCategoryKey(job)] || jobTypeParentCategoryShape.default; //shape is from the parent
+    result.shape = jobTypeShape[type]
+        || jobTypeParentCategoryShape[jobTypeParentCategoryKey(job)]
+        || jobTypeParentCategoryShape.default;
 
     result.strokecolor = "#000000"; // default stroke color
 
@@ -33,6 +35,11 @@ const floodCatStroke = {
     "Category3": "#EA580C", // Trapped - rising
     "Category4": "#EAB308", // Trapped - stable
     "Category5": "#16A34A", // Animal rescue
+};
+
+// Concrete job type overrides take precedence over parent-category shapes.
+const jobTypeShape = {
+    "FR": "pentagon",
 };
 
 const jobTypeParentCategoryShape = {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -242,6 +242,8 @@ td.chev[draggable='true'] * {
   position: relative;
   user-select: none;
   touch-action: none;
+  overflow: hidden;
+  transition: width 0.3s ease;
 }
 .vsplit::after {
   content: '';
@@ -286,10 +288,27 @@ td.chev[draggable='true'] * {
   display: none !important;
 }
 
+/* Hide sidebar toggle button in map-only layout */
+.app.layout-map-only .leaflet-control.sidebar-toggle {
+  display: none !important;
+}
+
+/* Show settings control only in map-only layout */
+.app.layout-map-only .leaflet-control.map-settings-control {
+  display: block !important;
+}
+
+/* Hide settings control in non-map-only layouts by default */
+.leaflet-control.map-settings-control {
+  display: none !important;
+}
+
 .sidebar {
   width: var(--sidebar-w, 420px);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+  transition: width 0.3s ease, min-width 0.3s ease;
 }
 
 /* Full sidebar collapse driven by a body class */
@@ -300,7 +319,8 @@ body.sidebar-collapsed .sidebar {
 }
 
 body.sidebar-collapsed .vsplit {
-  display: none !important;
+  width: 0 !important;
+  pointer-events: none;
 }
 
 .hsplit {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -311,6 +311,11 @@ td.chev[draggable='true'] * {
   transition: width 0.3s ease, min-width 0.3s ease;
 }
 
+body.sidebar-resizing .sidebar,
+body.sidebar-resizing .vsplit {
+  transition: none !important;
+}
+
 /* Full sidebar collapse driven by a body class */
 body.sidebar-collapsed .sidebar {
   width: 0 !important;


### PR DESCRIPTION
This pull request introduces several UI improvements to the tasking page, focusing on enhancing the map-only layout and refining the sidebar resizing experience. The most notable changes are the addition of a dedicated settings button for map-only mode, improved sidebar resizing feedback, and more flexible job shape assignment in the UI.

**Map-only layout enhancements:**

* Added a new `MapSettingsControl` Leaflet control, which displays a settings (cog) button in map-only mode. Clicking it opens the configuration modal. This control is only visible in map-only layout, and the sidebar toggle button is hidden in this mode. (`src/pages/tasking/main.js` [[1]](diffhunk://#diff-e26998de000c026c298af7c589db86546dfb254e3168a3c68e8f53a39e8c5122R3327-R3354) [[2]](diffhunk://#diff-e26998de000c026c298af7c589db86546dfb254e3168a3c68e8f53a39e8c5122R3404-R3406); `styles/pages/tasking.css` [[3]](diffhunk://#diff-6831c50604ca03ff9f7f363ca9020081018d156e544efb4064de22c4f69da772R291-R316)

**Sidebar resizing improvements:**

* When resizing the sidebar, a `sidebar-resizing` class is applied to the body to disable CSS transitions on the sidebar and vertical splitter, making the resizing feel smoother and more responsive. (`src/pages/tasking/resize.js` [[1]](diffhunk://#diff-6a909b44d1c8fbe8960412b1ae8f8f73bf46dc0642b7ac156782c4bbb3ea6ed1L106-R112); `styles/pages/tasking.css` [[2]](diffhunk://#diff-6831c50604ca03ff9f7f363ca9020081018d156e544efb4064de22c4f69da772R245-R246) [[3]](diffhunk://#diff-6831c50604ca03ff9f7f363ca9020081018d156e544efb4064de22c4f69da772R291-R316)
* The `.vsplit` element now uses a smooth width transition, and when the sidebar is collapsed, its width is set to zero and pointer events are disabled for better UX. (`styles/pages/tasking.css` [[1]](diffhunk://#diff-6831c50604ca03ff9f7f363ca9020081018d156e544efb4064de22c4f69da772R245-R246) [[2]](diffhunk://#diff-6831c50604ca03ff9f7f363ca9020081018d156e544efb4064de22c4f69da772L303-R328)

**Job shape assignment logic:**

* Updated the job shape assignment so that concrete job type overrides (e.g., `"FR": "pentagon"`) take precedence over parent category shapes, allowing for more granular UI customization of job markers. (`src/pages/tasking/utils/jobTypesToUI.js` [[1]](diffhunk://#diff-86452147cf0cea1ae5f5b59622c7bb3fc21072c5e0b9848f1bd86100276445a4R40-R44) [[2]](diffhunk://#diff-86452147cf0cea1ae5f5b59622c7bb3fc21072c5e0b9848f1bd86100276445a4L14-R16)