### PR TITLE
Add layout presets, minimap sync, and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6831,9 +6831,10 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6302,9 +6302,9 @@
       "peer": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -6312,6 +6312,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6688,9 +6689,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -6706,10 +6707,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -7450,10 +7452,11 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -309,8 +309,46 @@ map.createPane('pane-tippy-top'); map.getPane('pane-tippy-top').style.zIndex = 7
 map.createPane('pane-tippy-top-plus'); map.getPane('pane-tippy-top-plus').style.zIndex = 701;
 
 
-var osm2 = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { minZoom: 0, maxZoom: 13 });
-new MiniMap(osm2, { toggleDisplay: true }).addTo(map);
+function buildBasemapLayer(key) {
+    // --- NSW VECTOR BASEMAP (Topographic style) ---
+    if (key === "nsw-vector") {
+        return esriVector.vectorTileLayer(
+            "https://portal.spatial.nsw.gov.au/vectortileservices/rest/services/Hosted/NSW_BaseMap_VectorTile/VectorTileServer",
+            {
+                attribution: "© NSW Spatial Services"
+            }
+        );
+    }
+
+    // --- NSW RASTER BASEMAPS (tile MapServer) ---
+    if (key === "nsw-base") {
+        return L.tileLayer(
+            "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Base_Map/MapServer/tile/{z}/{y}/{x}",
+            {
+                maxZoom: 20,
+                attribution: "© NSW Spatial Services"
+            }
+        );
+    }
+
+    if (key === "nsw-imagery") {
+        return L.tileLayer(
+            "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Imagery/MapServer/tile/{z}/{y}/{x}",
+            {
+                maxZoom: 20,
+                attribution: "© NSW Spatial Services"
+            }
+        );
+    }
+
+    // --- EXISTING ESRI BASEMAPS ---
+    return esri.basemapLayer(key, { ignoreDeprecationWarning: true });
+}
+
+
+const minimapInitialKey = localStorage.getItem("map.base") || "Topographic";
+var minimapLayer = buildBasemapLayer(minimapInitialKey) || buildBasemapLayer("Topographic");
+const miniMapControl = new MiniMap(minimapLayer, { toggleDisplay: true }).addTo(map);
 
 const legend = new LegendControl({ collapsed: true, persist: true });
 legend.addTo(map);
@@ -3226,43 +3264,15 @@ function VM() {
                 this._currentBase = null;
             }
 
-            // --- NSW VECTOR BASEMAP (Topographic style) ---
-            if (key === "nsw-vector") {
-                // Uses the NSW_BaseMap_VectorTile VectorTileServer
-                this._currentBase = esriVector.vectorTileLayer(
-                    "https://portal.spatial.nsw.gov.au/vectortileservices/rest/services/Hosted/NSW_BaseMap_VectorTile/VectorTileServer",
-                    {
-                        attribution: "© NSW Spatial Services"
-                    }
-                );
-            }
-
-            // --- NSW RASTER BASEMAPS (tile MapServer) ---
-            else if (key === "nsw-base") {
-                this._currentBase = L.tileLayer(
-                    "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Base_Map/MapServer/tile/{z}/{y}/{x}",
-                    {
-                        maxZoom: 20,
-                        attribution: "© NSW Spatial Services"
-                    }
-                );
-            } else if (key === "nsw-imagery") {
-                this._currentBase = L.tileLayer(
-                    "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Imagery/MapServer/tile/{z}/{y}/{x}",
-                    {
-                        maxZoom: 20,
-                        attribution: "© NSW Spatial Services"
-                    }
-                );
-            }
-
-            // --- EXISTING ESRI BASEMAPS ---
-            else {
-                this._currentBase = esri.basemapLayer(key, { ignoreDeprecationWarning: true });
-            }
+            this._currentBase = buildBasemapLayer(key);
 
             if (this._currentBase) {
                 this._currentBase.addTo(map);
+            }
+
+            const nextMiniMapLayer = buildBasemapLayer(key);
+            if (nextMiniMapLayer) {
+                miniMapControl.changeLayer(nextMiniMapLayer);
             }
         }
 

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -3324,6 +3324,34 @@ function VM() {
         }
     });
 
+    // --- Settings button (visible in map-only mode to open config modal)
+    const MapSettingsControl = L.Control.extend({
+        options: { position: "topleft" },
+
+        onAdd(_map) {
+            const container = L.DomUtil.create("div", "leaflet-control map-settings-control leaflet-bar");
+            container.innerHTML = `
+                <button type="button" class="btn btn-light btn-sm shadow-sm" title="Open page config"
+                    style="width:30px;height:30px;padding:0;display:flex;align-items:center;justify-content:center;">
+                    <i class="fas fa-cog"></i>
+                </button>
+            `;
+
+            const btn = container.querySelector(".btn");
+            L.DomEvent.on(btn, "click", (ev) => {
+                L.DomEvent.stop(ev);
+                const modalEl = document.getElementById('configModal');
+                if (modalEl) {
+                    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+                    modal.show();
+                }
+            });
+
+            L.DomEvent.disableClickPropagation(container);
+            return container;
+        }
+    });
+
     // --- Zoom-to-fit button (sits directly below the zoom control)
     const ZoomToFit = L.Control.extend({
         options: { position: "topleft" },
@@ -3372,6 +3400,9 @@ function VM() {
 
     const sidebarToggle = new SidebarToggle();
     sidebarToggle.addTo(map);
+
+    const mapSettingsControl = new MapSettingsControl();
+    mapSettingsControl.addTo(map);
 
     const layersDrawer = new LayersDrawer();
     layersDrawer.addTo(map);

--- a/src/pages/tasking/resize.js
+++ b/src/pages/tasking/resize.js
@@ -103,13 +103,13 @@ function applyLR(clientX) {
   localStorage.setItem(layoutStorageKey('mapWidthPx'), String(Math.max(0, Math.floor(mapW))));
 }
 
-function startLR() { resizingLR = true; vsplitEl.classList.add('resizing'); document.body.style.cursor = 'col-resize'; }
+function startLR() { resizingLR = true; vsplitEl.classList.add('resizing'); document.body.classList.add('sidebar-resizing'); document.body.style.cursor = 'col-resize'; }
 function moveLR(x) {
   if (!resizingLR) return;
   if (rafLR) return;
   rafLR = requestAnimationFrame(() => { rafLR = 0; applyLR(x); invalidateMap(); });
 }
-function endLR() { if (!resizingLR) return; resizingLR = false; vsplitEl.classList.remove('resizing'); document.body.style.cursor=''; invalidateMap(); }
+function endLR() { if (!resizingLR) return; resizingLR = false; vsplitEl.classList.remove('resizing'); document.body.classList.remove('sidebar-resizing'); document.body.style.cursor=''; invalidateMap(); }
 
 if (vsplitEl) {
   vsplitEl.addEventListener('mousedown', e => { e.preventDefault(); startLR(); });

--- a/src/pages/tasking/resize.js
+++ b/src/pages/tasking/resize.js
@@ -7,31 +7,80 @@ const sidebarEl  = document.querySelector('.sidebar');
 const vsplitEl   = document.getElementById('vsplit');
 
 const paneTopEl  = document.getElementById('paneTop');
+const paneBottomEl = document.getElementById('paneBottom');
 const hsplitEl   = document.getElementById('hsplit');
+
+const LAYOUT_PRESETS = [
+  'map-right-teams-top',
+  'map-right-tasking-top',
+  'map-left-teams-top',
+  'map-left-tasking-top',
+  'map-right-teams-only',
+  'map-right-tasking-only',
+  'map-left-teams-only',
+  'map-left-tasking-only',
+  'map-only'
+];
+const DEFAULT_LAYOUT_PRESET = 'map-right-teams-top';
+const normalizeLayoutPreset = (value) => {
+  const key = String(value || '').trim();
+  return LAYOUT_PRESETS.includes(key) ? key : DEFAULT_LAYOUT_PRESET;
+};
 
 // Leaflet map instance must exist; guard invalidateSize calls
 // eslint-disable-next-line no-empty
 function invalidateMap() { try { map.invalidateSize(); } catch(_) {} }
 
+let currentLayoutPreset = normalizeLayoutPreset(localStorage.getItem('lh.layoutPreset'));
+
+function layoutStorageKey(suffix) {
+  return `lh.layout.${currentLayoutPreset}.${suffix}`;
+}
+
+function applyLayoutPresetClass(preset) {
+  const normalized = normalizeLayoutPreset(preset);
+  currentLayoutPreset = normalized;
+  LAYOUT_PRESETS.forEach(layout => appEl.classList.remove(`layout-${layout}`));
+  appEl.classList.add(`layout-${normalized}`);
+  localStorage.setItem('lh.layoutPreset', normalized);
+}
+
+function topPaneForCurrentLayout() {
+  if (currentLayoutPreset.endsWith('tasking-top') || currentLayoutPreset.endsWith('tasking-only')) {
+    return paneBottomEl;
+  }
+  return paneTopEl;
+}
+
+function resetPaneHeights() {
+  paneTopEl.style.height = '';
+  paneBottomEl.style.height = '';
+}
+
 // ===== Restore persisted sizes on load =====
-(function restoreSizes() {
+function restoreSizes() {
+  resetPaneHeights();
+
   // Left↔Right
-  const savedSidebarPx = Number(localStorage.getItem('lh.sidebarWidthPx'))   || 800;
+  const savedSidebarPx = Number(localStorage.getItem(layoutStorageKey('sidebarWidthPx'))) || 800;
   if (Number.isFinite(savedSidebarPx) && savedSidebarPx > 0) {
     sidebarEl.style.width = savedSidebarPx + 'px';
     appEl.style.setProperty('--sidebar-w', savedSidebarPx + 'px');
   }
 
   // Top↔Bottom
-  const savedTopPx = Number(localStorage.getItem('lh.paneTopHeightPx')   || 500);
+  const savedTopPx = Number(localStorage.getItem(layoutStorageKey('paneTopHeightPx')) || 500);
   if (Number.isFinite(savedTopPx) && savedTopPx > 0) {
-    paneTopEl.style.height = savedTopPx + 'px';
+    topPaneForCurrentLayout().style.height = savedTopPx + 'px';
     appEl.style.setProperty('--pane-top-h', savedTopPx + 'px');
   }
 
   // Let layout settle then fix map size
   setTimeout(invalidateMap, 0);
-})();
+}
+
+applyLayoutPresetClass(currentLayoutPreset);
+restoreSizes();
 
 // ===== Left↔Right (vertical splitter) =====
 let resizingLR = false, rafLR = 0;
@@ -50,8 +99,8 @@ function applyLR(clientX) {
   appEl.style.setProperty('--sidebar-w', w + 'px');
 
   const mapW = appRect.width - w - splitW;
-  localStorage.setItem('lh.sidebarWidthPx', String(w));
-  localStorage.setItem('lh.mapWidthPx', String(Math.max(0, Math.floor(mapW))));
+  localStorage.setItem(layoutStorageKey('sidebarWidthPx'), String(w));
+  localStorage.setItem(layoutStorageKey('mapWidthPx'), String(Math.max(0, Math.floor(mapW))));
 }
 
 function startLR() { resizingLR = true; vsplitEl.classList.add('resizing'); document.body.style.cursor = 'col-resize'; }
@@ -88,8 +137,8 @@ function applyTB(clientY) {
   appEl.style.setProperty('--pane-top-h', topH + 'px');
 
   const botH = Math.max(minBot, total - splitH - topH);
-  localStorage.setItem('lh.paneTopHeightPx', String(Math.floor(topH)));
-  localStorage.setItem('lh.paneBottomHeightPx', String(Math.floor(botH)));
+  localStorage.setItem(layoutStorageKey('paneTopHeightPx'), String(Math.floor(topH)));
+  localStorage.setItem(layoutStorageKey('paneBottomHeightPx'), String(Math.floor(botH)));
 }
 
 function startTB() { resizingTB = true; hsplitEl.classList.add('resizing'); document.body.style.cursor = 'row-resize'; }
@@ -117,7 +166,7 @@ window.addEventListener('resize', () => {
   const splitW  = vsplitEl.getBoundingClientRect().width;
   const minSidebar = 260, minMap = 260;
   const maxSidebar = Math.min(appRect.width - splitW - minMap, appRect.width * 0.7);
-  const savedW = Number(localStorage.getItem('lh.sidebarWidthPx')) || sidebarEl.getBoundingClientRect().width;
+  const savedW = Number(localStorage.getItem(layoutStorageKey('sidebarWidthPx'))) || sidebarEl.getBoundingClientRect().width;
   if (Number.isFinite(savedW) && savedW > 0) {
     const clamped = Math.max(minSidebar, Math.min(savedW, maxSidebar));
     sidebarEl.style.width = clamped + 'px';
@@ -129,14 +178,21 @@ window.addEventListener('resize', () => {
   const splitH = hsplitEl.getBoundingClientRect().height;
   const minTop = 120, minBot = 120;
   const maxTop = Math.max(minTop, sbRect.height - splitH - minBot);
-  const savedTop = Number(localStorage.getItem('lh.paneTopHeightPx')) || paneTopEl.getBoundingClientRect().height;
+  const topPaneEl = topPaneForCurrentLayout();
+  const savedTop = Number(localStorage.getItem(layoutStorageKey('paneTopHeightPx'))) || topPaneEl.getBoundingClientRect().height;
   if (Number.isFinite(savedTop) && savedTop > 0) {
     const clampedTop = Math.max(minTop, Math.min(savedTop, maxTop));
-    paneTopEl.style.height = clampedTop + 'px';
+    topPaneEl.style.height = clampedTop + 'px';
     appEl.style.setProperty('--pane-top-h', clampedTop + 'px');
   }
 
   // Map may need a relayout after width changes
   setTimeout(invalidateMap, 0);
+});
+
+window.addEventListener('lh:layoutPresetChanged', (event) => {
+  const nextPreset = normalizeLayoutPreset(event?.detail?.preset);
+  applyLayoutPresetClass(nextPreset);
+  restoreSizes();
 });
 }

--- a/src/pages/tasking/utils/jobTypesToUI.js
+++ b/src/pages/tasking/utils/jobTypesToUI.js
@@ -11,7 +11,9 @@ export function jobsToUI(job) {
         result.fillcolor = priorityStroke[p?.Name] || "#6b7280ff"; // default gray
     }
 
-    result.shape = jobTypeParentCategoryShape[jobTypeParentCategoryKey(job)] || jobTypeParentCategoryShape.default; //shape is from the parent
+    result.shape = jobTypeShape[type]
+        || jobTypeParentCategoryShape[jobTypeParentCategoryKey(job)]
+        || jobTypeParentCategoryShape.default;
 
     result.strokecolor = "#000000"; // default stroke color
 
@@ -33,6 +35,11 @@ const floodCatStroke = {
     "Category3": "#EA580C", // Trapped - rising
     "Category4": "#EAB308", // Trapped - stable
     "Category5": "#16A34A", // Animal rescue
+};
+
+// Concrete job type overrides take precedence over parent-category shapes.
+const jobTypeShape = {
+    "FR": "pentagon",
 };
 
 const jobTypeParentCategoryShape = {

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -13,6 +13,33 @@ const FUNCTION_URL = "https://lambda.lighthouse-extension.com/lad/share";
 export function ConfigVM(root, deps) {
     const self = this;
 
+    const LAYOUT_PRESETS = [
+        'map-right-teams-top',
+        'map-right-tasking-top',
+        'map-left-teams-top',
+        'map-left-tasking-top',
+        'map-right-teams-only',
+        'map-right-tasking-only',
+        'map-left-teams-only',
+        'map-left-tasking-only',
+        'map-only'
+    ];
+    const DEFAULT_LAYOUT_PRESET = 'map-right-teams-top';
+    const normalizeLayoutPreset = (value) => {
+        const key = String(value || '').trim();
+        return LAYOUT_PRESETS.includes(key) ? key : DEFAULT_LAYOUT_PRESET;
+    };
+    const applyLayoutPresetClass = (preset) => {
+        const appEl = document.querySelector('.app');
+        if (!appEl) return;
+
+        LAYOUT_PRESETS.forEach(layout => appEl.classList.remove(`layout-${layout}`));
+        appEl.classList.add(`layout-${preset}`);
+
+        localStorage.setItem('lh.layoutPreset', preset);
+        window.dispatchEvent(new CustomEvent('lh:layoutPresetChanged', { detail: { preset } }));
+    };
+
     // UI state
     self.query = ko.observable('');
     self.results = ko.observableArray([]);
@@ -166,6 +193,64 @@ export function ConfigVM(root, deps) {
     self.showAdvanced = ko.observable(false);
     self.darkMode = ko.observable(false);
 
+    self.layoutPresetDefs = [
+        {
+            id: 'map-right-teams-top',
+            name: 'Map Right · Teams Top',
+            description: 'Teams above tasking in the sidebar, map on the right.',
+            previewClass: 'preset-map-right-teams-top'
+        },
+        {
+            id: 'map-right-tasking-top',
+            name: 'Map Right · Tasking Top',
+            description: 'Tasking above teams in the sidebar, map on the right.',
+            previewClass: 'preset-map-right-tasking-top'
+        },
+        {
+            id: 'map-left-teams-top',
+            name: 'Map Left · Teams Top',
+            description: 'Map on the left with teams above tasking on the right.',
+            previewClass: 'preset-map-left-teams-top'
+        },
+        {
+            id: 'map-left-tasking-top',
+            name: 'Map Left · Tasking Top',
+            description: 'Map on the left with tasking above teams on the right.',
+            previewClass: 'preset-map-left-tasking-top'
+        },
+        {
+            id: 'map-right-teams-only',
+            name: 'Map Right · Teams Only',
+            description: 'Hide tasking pane, keep teams + map.',
+            previewClass: 'preset-map-right-teams-only'
+        },
+        {
+            id: 'map-right-tasking-only',
+            name: 'Map Right · Tasking Only',
+            description: 'Hide teams pane, keep tasking + map.',
+            previewClass: 'preset-map-right-tasking-only'
+        },
+        {
+            id: 'map-left-teams-only',
+            name: 'Map Left · Teams Only',
+            description: 'Map left with teams-only pane on the right.',
+            previewClass: 'preset-map-left-teams-only'
+        },
+        {
+            id: 'map-left-tasking-only',
+            name: 'Map Left · Tasking Only',
+            description: 'Map left with tasking-only pane on the right.',
+            previewClass: 'preset-map-left-tasking-only'
+        },
+        {
+            id: 'map-only',
+            name: 'Map Only',
+            description: 'Hide both sidebar panes and use the full map view.',
+            previewClass: 'preset-map-only'
+        }
+    ];
+    self.layoutPreset = ko.observable(DEFAULT_LAYOUT_PRESET);
+
     //blown away on load
     self.teamStatusFilter = ko.observableArray([]);
 
@@ -293,6 +378,7 @@ export function ConfigVM(root, deps) {
         fetchForward: Number(self.fetchForward()),
         showAdvanced: !!self.showAdvanced(),
         darkMode: !!self.darkMode(),
+        layoutPreset: normalizeLayoutPreset(self.layoutPreset()),
         locationFilters: {
             teams: ko.toJS(self.teamFilters),
             incidents: ko.toJS(self.incidentFilters)
@@ -567,6 +653,7 @@ export function ConfigVM(root, deps) {
         if (typeof cfg.darkMode === 'boolean') {
             self.darkMode(cfg.darkMode);
         }
+        self.layoutPreset(normalizeLayoutPreset(cfg.layoutPreset || localStorage.getItem('lh.layoutPreset')));
         if (typeof cfg.includeIncidentsWithoutSector === 'boolean') {
             self.includeIncidentsWithoutSector(cfg.includeIncidentsWithoutSector);
         }
@@ -763,6 +850,7 @@ export function ConfigVM(root, deps) {
         root.mapVM?.applyPaneOrder?.(self.paneOrder().map(p => p.id));
         root.mapVM?.applyClusterRadius?.(Number(self.clusterRadius()) || 60);
         root.mapVM?.applyClusterEnabled?.(!!self.clusterEnabled());
+        applyLayoutPresetClass(normalizeLayoutPreset(self.layoutPreset()));
         // Apply dark mode
         self._applyDarkMode();
         // Apply dark mode basemap if enabled
@@ -834,6 +922,16 @@ export function ConfigVM(root, deps) {
             root.mapVM.changeBasemap(targetBasemap);
         }
         
+        self.save();
+    });
+
+    self.layoutPreset.subscribe((preset) => {
+        const normalized = normalizeLayoutPreset(preset);
+        if (normalized !== preset) {
+            self.layoutPreset(normalized);
+            return;
+        }
+        applyLayoutPresetClass(normalized);
         self.save();
     });
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2001,9 +2001,7 @@
                     <!-- CONFIG -->
                     <!-- CONFIG -->
                     <div class="card config-card mt-3">
-                        <div class="card-header py-2">
-                            <strong>Other Settings</strong>
-                        </div>
+
                         <div class="card-body">
                             <form id="configForm">
                                 <div class="accordion" id="configOtherSettingsAccordion">
@@ -2091,6 +2089,46 @@
                                                         <div class="form-text">Alerts will start collapsed.</div>
                                                     </div>
                                                 </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Panel Layout -->
+                                    <div class="accordion-item">
+                                        <h2 class="accordion-header" id="headingPanelLayout">
+                                            <button class="accordion-button gap-2 collapsed" type="button"
+                                                data-bs-toggle="collapse" data-bs-target="#collapsePanelLayout"
+                                                aria-expanded="false" aria-controls="collapsePanelLayout">
+                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-columns"></i></span>
+                                                <span>Panel Layout</span>
+                                            </button>
+                                        </h2>
+                                        <div id="collapsePanelLayout" class="accordion-collapse collapse"
+                                            aria-labelledby="headingPanelLayout"
+                                            data-bs-parent="#configOtherSettingsAccordion">
+                                            <div class="accordion-body">
+                                                <label class="form-label">
+                                                    <i class="fa fa-columns me-1"></i>Section Layout Preset
+                                                </label>
+                                                <div class="layout-preset-grid"
+                                                    data-bind="foreach: { data: config.layoutPresetDefs, as: 'preset' }">
+                                                    <label class="layout-preset-card"
+                                                        data-bind="css: { 'is-active': $root.config.layoutPreset() === preset.id }">
+                                                        <input class="form-check-input layout-preset-radio"
+                                                            type="radio" name="layoutPreset"
+                                                            data-bind="checked: $root.config.layoutPreset, checkedValue: preset.id">
+                                                        <div class="layout-preset-preview"
+                                                            data-bind="css: preset.previewClass">
+                                                            <div class="preview-block preview-block--teams">Teams</div>
+                                                            <div class="preview-block preview-block--tasking">Tasking</div>
+                                                            <div class="preview-block preview-block--map">Map</div>
+                                                        </div>
+                                                        <div class="layout-preset-name" data-bind="text: preset.name"></div>
+                                                        <div class="layout-preset-description small text-muted"
+                                                            data-bind="text: preset.description"></div>
+                                                    </label>
+                                                </div>
+                                                <div class="form-text">Pick a layout to instantly preview and apply section placement.</div>
                                             </div>
                                         </div>
                                     </div>

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -260,6 +260,32 @@ td.chev[draggable='true'] * {
   width: 100vw;
 }
 
+.app.layout-map-left-teams-top .sidebar,
+.app.layout-map-left-tasking-top .sidebar,
+.app.layout-map-left-teams-only .sidebar,
+.app.layout-map-left-tasking-only .sidebar {
+  order: 3;
+}
+
+.app.layout-map-left-teams-top .vsplit,
+.app.layout-map-left-tasking-top .vsplit,
+.app.layout-map-left-teams-only .vsplit,
+.app.layout-map-left-tasking-only .vsplit {
+  order: 2;
+}
+
+.app.layout-map-left-teams-top .map-wrap,
+.app.layout-map-left-tasking-top .map-wrap,
+.app.layout-map-left-teams-only .map-wrap,
+.app.layout-map-left-tasking-only .map-wrap {
+  order: 1;
+}
+
+.app.layout-map-only .sidebar,
+.app.layout-map-only .vsplit {
+  display: none !important;
+}
+
 .sidebar {
   width: var(--sidebar-w, 420px);
   display: flex;
@@ -320,6 +346,199 @@ body.sidebar-collapsed .vsplit {
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 60%;
+}
+
+.app.layout-map-right-tasking-top #paneBottom,
+.app.layout-map-left-tasking-top #paneBottom {
+  order: 1;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: auto;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.app.layout-map-right-tasking-top #hsplit,
+.app.layout-map-left-tasking-top #hsplit {
+  order: 2;
+}
+
+.app.layout-map-right-tasking-top #paneTop,
+.app.layout-map-left-tasking-top #paneTop {
+  order: 3;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 60%;
+  border-bottom: 0;
+}
+
+.app.layout-map-right-teams-only #paneBottom,
+.app.layout-map-left-teams-only #paneBottom,
+.app.layout-map-right-teams-only #hsplit,
+.app.layout-map-left-teams-only #hsplit {
+  display: none !important;
+}
+
+.app.layout-map-right-teams-only #paneTop,
+.app.layout-map-left-teams-only #paneTop {
+  order: 1;
+  flex: 1 1 auto;
+  height: auto;
+  border-bottom: 0;
+}
+
+.app.layout-map-right-tasking-only #paneTop,
+.app.layout-map-left-tasking-only #paneTop,
+.app.layout-map-right-tasking-only #hsplit,
+.app.layout-map-left-tasking-only #hsplit {
+  display: none !important;
+}
+
+.app.layout-map-right-tasking-only #paneBottom,
+.app.layout-map-left-tasking-only #paneBottom {
+  order: 1;
+  flex: 1 1 auto;
+  height: auto;
+  border-bottom: 0;
+}
+
+.layout-preset-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  gap: 10px;
+}
+
+.layout-preset-card {
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: var(--bs-body-bg);
+  cursor: pointer;
+}
+
+.layout-preset-card.is-active {
+  border-color: var(--bs-primary);
+  box-shadow: inset 0 0 0 1px var(--bs-primary);
+}
+
+.layout-preset-radio {
+  align-self: flex-start;
+  margin: 0;
+}
+
+.layout-preset-name {
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.layout-preset-description {
+  line-height: 1.25;
+}
+
+.layout-preset-preview {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 3px;
+  height: 62px;
+  border: 1px solid var(--bs-border-color-translucent);
+  border-radius: 0.4rem;
+  padding: 3px;
+  background: var(--bs-secondary-bg);
+}
+
+.layout-preset-preview .preview-block {
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--bs-emphasis-color);
+  background: var(--bs-body-bg);
+}
+
+.layout-preset-preview .preview-block--teams {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.layout-preset-preview .preview-block--tasking {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.layout-preset-preview .preview-block--map {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+}
+
+.layout-preset-preview.preset-map-right-tasking-top .preview-block--teams,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--teams {
+  grid-row: 2;
+}
+
+.layout-preset-preview.preset-map-right-tasking-top .preview-block--tasking,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--tasking {
+  grid-row: 1;
+}
+
+.layout-preset-preview.preset-map-left-teams-top .preview-block--teams,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--teams,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--teams,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--teams,
+.layout-preset-preview.preset-map-left-teams-top .preview-block--tasking,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--tasking,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--tasking,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--tasking {
+  grid-column: 2;
+}
+
+.layout-preset-preview.preset-map-left-teams-top .preview-block--map,
+.layout-preset-preview.preset-map-left-tasking-top .preview-block--map,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--map,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--map {
+  grid-column: 1;
+}
+
+.layout-preset-preview.preset-map-right-teams-only .preview-block--tasking,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--tasking {
+  display: none;
+}
+
+.layout-preset-preview.preset-map-right-teams-only .preview-block--teams,
+.layout-preset-preview.preset-map-left-teams-only .preview-block--teams {
+  grid-row: 1 / span 2;
+}
+
+.layout-preset-preview.preset-map-right-tasking-only .preview-block--teams,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--teams {
+  display: none;
+}
+
+.layout-preset-preview.preset-map-right-tasking-only .preview-block--tasking,
+.layout-preset-preview.preset-map-left-tasking-only .preview-block--tasking {
+  grid-row: 1 / span 2;
+}
+
+.layout-preset-preview.preset-map-only {
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+}
+
+.layout-preset-preview.preset-map-only .preview-block--teams,
+.layout-preset-preview.preset-map-only .preview-block--tasking {
+  display: none;
+}
+
+.layout-preset-preview.preset-map-only .preview-block--map {
+  grid-column: 1;
+  grid-row: 1;
 }
 
 .team-table-container,

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -242,6 +242,8 @@ td.chev[draggable='true'] * {
   position: relative;
   user-select: none;
   touch-action: none;
+  overflow: hidden;
+  transition: width 0.3s ease;
 }
 .vsplit::after {
   content: '';
@@ -286,10 +288,32 @@ td.chev[draggable='true'] * {
   display: none !important;
 }
 
+/* Hide sidebar toggle button in map-only layout */
+.app.layout-map-only .leaflet-control.sidebar-toggle {
+  display: none !important;
+}
+
+/* Show settings control only in map-only layout */
+.app.layout-map-only .leaflet-control.map-settings-control {
+  display: block !important;
+}
+
+/* Hide settings control in non-map-only layouts by default */
+.leaflet-control.map-settings-control {
+  display: none !important;
+}
+
 .sidebar {
   width: var(--sidebar-w, 420px);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+  transition: width 0.3s ease, min-width 0.3s ease;
+}
+
+body.sidebar-resizing .sidebar,
+body.sidebar-resizing .vsplit {
+  transition: none !important;
 }
 
 /* Full sidebar collapse driven by a body class */
@@ -300,7 +324,8 @@ body.sidebar-collapsed .sidebar {
 }
 
 body.sidebar-collapsed .vsplit {
-  display: none !important;
+  width: 0 !important;
+  pointer-events: none;
 }
 
 .hsplit {


### PR DESCRIPTION
This pull request introduces a major update to the map/tasking UI, focusing on improved layout flexibility, persistent user preferences, and enhanced map controls. The most notable changes are the addition of customizable layout presets (with full persistence and dynamic switching), improvements to the minimap and basemap handling, and the introduction of a map settings control for easier configuration access.

**Layout Preset System and Persistence:**

* Added a comprehensive layout preset system, allowing users to choose from multiple sidebar/map arrangements (e.g., map-only, map-right, map-left, teams-only, tasking-only). The selected preset is persisted in `localStorage` and applied dynamically, including during configuration changes. (`src/pages/tasking/resize.js`, `src/pages/tasking/viewmodels/Config.js`) [[1]](diffhunk://#diff-6a909b44d1c8fbe8960412b1ae8f8f73bf46dc0642b7ac156782c4bbb3ea6ed1R10-R83) [[2]](diffhunk://#diff-31aaf1e44d77b302d4e4629b2b3d30243e8280efbbf6a705052da1eae97f81e2R16-R42) [[3]](diffhunk://#diff-31aaf1e44d77b302d4e4629b2b3d30243e8280efbbf6a705052da1eae97f81e2R196-R253) [[4]](diffhunk://#diff-31aaf1e44d77b302d4e4629b2b3d30243e8280efbbf6a705052da1eae97f81e2R381) [[5]](diffhunk://#diff-31aaf1e44d77b302d4e4629b2b3d30243e8280efbbf6a705052da1eae97f81e2R656) [[6]](diffhunk://#diff-31aaf1e44d77b302d4e4629b2b3d30243e8280efbbf6a705052da1eae97f81e2R853) [[7]](diffhunk://#diff-31aaf1e44d77b302d4e4629b2b3d30243e8280efbbf6a705052da1eae97f81e2R928-R937)

* Pane and sidebar sizes are now stored and restored per layout preset, ensuring that each layout remembers its own dimensions. This includes logic for handling top/bottom pane assignment based on the current preset. (`src/pages/tasking/resize.js`) [[1]](diffhunk://#diff-6a909b44d1c8fbe8960412b1ae8f8f73bf46dc0642b7ac156782c4bbb3ea6ed1R10-R83) [[2]](diffhunk://#diff-6a909b44d1c8fbe8960412b1ae8f8f73bf46dc0642b7ac156782c4bbb3ea6ed1L53-R112) [[3]](diffhunk://#diff-6a909b44d1c8fbe8960412b1ae8f8f73bf46dc0642b7ac156782c4bbb3ea6ed1L91-R141) [[4]](diffhunk://#diff-6a909b44d1c8fbe8960412b1ae8f8f73bf46dc0642b7ac156782c4bbb3ea6ed1L120-R169) [[5]](diffhunk://#diff-6a909b44d1c8fbe8960412b1ae8f8f73bf46dc0642b7ac156782c4bbb3ea6ed1L132-R197)

**Map Controls and Basemap Handling:**

* Refactored basemap layer creation into a reusable `buildBasemapLayer` function, supporting NSW vector/raster basemaps as well as existing ESRI basemaps. The minimap now uses the same logic and updates dynamically with the main map's basemap selection. (`src/pages/tasking/main.js`) [[1]](diffhunk://#diff-e26998de000c026c298af7c589db86546dfb254e3168a3c68e8f53a39e8c5122L312-R351) [[2]](diffhunk://#diff-e26998de000c026c298af7c589db86546dfb254e3168a3c68e8f53a39e8c5122L3229-R3276)

* Introduced a map settings control button, visible in map-only mode, to provide quick access to the configuration modal directly from the map interface. (`src/pages/tasking/main.js`) [[1]](diffhunk://#diff-e26998de000c026c298af7c589db86546dfb254e3168a3c68e8f53a39e8c5122R3327-R3354) [[2]](diffhunk://#diff-e26998de000c026c298af7c589db86546dfb254e3168a3c68e8f53a39e8c5122R3404-R3406)

**Job Type UI Improvements:**

* Added the ability to override job shapes based on specific job types, not just parent categories, allowing for finer-grained UI representation (e.g., "FR" jobs now use a pentagon shape). (`src/pages/tasking/utils/jobTypesToUI.js`) [[1]](diffhunk://#diff-86452147cf0cea1ae5f5b59622c7bb3fc21072c5e0b9848f1bd86100276445a4L14-R16) [[2]](diffhunk://#diff-86452147cf0cea1ae5f5b59622c7bb3fc21072c5e0b9848f1bd86100276445a4R40-R44)

**Configuration UI:**

* Expanded the configuration modal with a detailed list of layout presets, including names, descriptions, and preview classes for each option. (`src/pages/tasking/viewmodels/Config.js`)

These changes collectively provide a more flexible, user-friendly, and maintainable map/tasking interface.