### PR TITLE
Add collaborative tasking layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Lighthouse.zip
 .DS_Store
 *.DS_Store
 package-lock.json
+lambda

--- a/src/injectscripts/all.js
+++ b/src/injectscripts/all.js
@@ -51,6 +51,8 @@ whenWeAreReady(function () {
   var vars =
     '?userId=' +
     user.Id +
+    '&personId=' +
+    user.personId +
     '&host=' +
     urls.Base +
     '&source=' +

--- a/src/pages/tasking/components/collab_marker_icons.js
+++ b/src/pages/tasking/components/collab_marker_icons.js
@@ -1,0 +1,142 @@
+import L from 'leaflet';
+
+/**
+ * Curated set of Font Awesome 5 Free icons relevant to emergency-service
+ * field marking (hazards, medical, welfare, shelter, infrastructure,
+ * vehicles/rescue, status). Grouped for a scannable picker UI.
+ *
+ * Every `fa` class here is confirmed present in the bundled
+ * @fortawesome/fontawesome-free 5.15.4 solid set -- don't add an icon
+ * without checking node_modules/@fortawesome/fontawesome-free/svgs/solid/.
+ */
+export const MARKER_ICON_GROUPS = [
+    {
+        group: 'Hazards',
+        icons: [
+            { key: 'fire', label: 'Fire', fa: 'fa-fire' },
+            { key: 'fire-extinguisher', label: 'Fire (controlled)', fa: 'fa-fire-extinguisher' },
+            { key: 'water', label: 'Flooding', fa: 'fa-water' },
+            { key: 'house-damage', label: 'Structural damage', fa: 'fa-house-damage' },
+            { key: 'exclamation-triangle', label: 'Hazard', fa: 'fa-exclamation-triangle' },
+            { key: 'skull-crossbones', label: 'Danger / poison', fa: 'fa-skull-crossbones' },
+            { key: 'biohazard', label: 'Biohazard', fa: 'fa-biohazard' },
+            { key: 'radiation', label: 'Radiation', fa: 'fa-radiation' },
+            { key: 'bolt', label: 'Downed power line', fa: 'fa-bolt' },
+            { key: 'wind', label: 'Storm / wind damage', fa: 'fa-wind' },
+            { key: 'smog', label: 'Smoke / air hazard', fa: 'fa-smog' },
+            { key: 'car-crash', label: 'Vehicle accident', fa: 'fa-car-crash' },
+            { key: 'tree', label: 'Fallen tree', fa: 'fa-tree' },
+            { key: 'gas-pump', label: 'Fuel / gas hazard', fa: 'fa-gas-pump' },
+            { key: 'ban', label: 'Road closed', fa: 'fa-ban' },
+        ],
+    },
+    {
+        group: 'Medical',
+        icons: [
+            { key: 'ambulance', label: 'Ambulance', fa: 'fa-ambulance' },
+            { key: 'first-aid', label: 'First aid', fa: 'fa-first-aid' },
+            { key: 'hospital', label: 'Hospital', fa: 'fa-hospital' },
+            { key: 'user-md', label: 'Medical personnel', fa: 'fa-user-md' },
+            { key: 'user-injured', label: 'Injured person', fa: 'fa-user-injured' },
+            { key: 'syringe', label: 'Medical supplies', fa: 'fa-syringe' },
+        ],
+    },
+    {
+        group: 'People',
+        icons: [
+            { key: 'user', label: 'Person', fa: 'fa-user' },
+            { key: 'users', label: 'Group of people', fa: 'fa-users' },
+            { key: 'wheelchair', label: 'Accessibility needs', fa: 'fa-wheelchair' },
+            { key: 'baby-carriage', label: 'Infant / child', fa: 'fa-baby-carriage' },
+            { key: 'paw', label: 'Animal / livestock', fa: 'fa-paw' },
+        ],
+    },
+    {
+        group: 'Shelter & Resources',
+        icons: [
+            { key: 'campground', label: 'Evacuation centre', fa: 'fa-campground' },
+            { key: 'home', label: 'Shelter / house', fa: 'fa-home' },
+            { key: 'warehouse', label: 'Supply depot', fa: 'fa-warehouse' },
+            { key: 'tint', label: 'Water supply', fa: 'fa-tint' },
+            { key: 'shower', label: 'Sanitation', fa: 'fa-shower' },
+        ],
+    },
+    {
+        group: 'Infrastructure',
+        icons: [
+            { key: 'road', label: 'Road / route', fa: 'fa-road' },
+            { key: 'route', label: 'Evacuation route', fa: 'fa-route' },
+            { key: 'broadcast-tower', label: 'Communications', fa: 'fa-broadcast-tower' },
+            { key: 'plug', label: 'Power / utility', fa: 'fa-plug' },
+        ],
+    },
+    {
+        group: 'Vehicles & Rescue',
+        icons: [
+            { key: 'truck', label: 'Truck', fa: 'fa-truck' },
+            { key: 'helicopter', label: 'Helicopter', fa: 'fa-helicopter' },
+            { key: 'ship', label: 'Boat', fa: 'fa-ship' },
+            { key: 'life-ring', label: 'Rescue', fa: 'fa-life-ring' },
+        ],
+    },
+    {
+        group: 'Status',
+        icons: [
+            { key: 'map-marker-alt', label: 'General marker', fa: 'fa-map-marker-alt' },
+            { key: 'flag', label: 'Checkpoint', fa: 'fa-flag' },
+            { key: 'check-circle', label: 'Cleared / complete', fa: 'fa-check-circle' },
+            { key: 'question-circle', label: 'Unknown / needs check', fa: 'fa-question-circle' },
+        ],
+    },
+];
+
+/** Flat key -> { fa, label } lookup, built once. */
+export const MARKER_ICONS_BY_KEY = MARKER_ICON_GROUPS.reduce((acc, g) => {
+    g.icons.forEach((i) => { acc[i.key] = i; });
+    return acc;
+}, {});
+
+export const DEFAULT_MARKER_ICON_KEY = 'map-marker-alt';
+
+/**
+ * Preset badge-color swatches for the marker form -- chosen to stay
+ * readable with a white icon glyph on top (no light/pastel tones) and to
+ * span enough distinct hues for status/severity coding at a glance.
+ */
+export const MARKER_COLOR_SWATCHES = [
+    '#d32f2f', // red
+    '#f57c00', // orange
+    '#fbc02d', // amber
+    '#388e3c', // green
+    '#00897b', // teal
+    '#1976d2', // blue
+    '#3949ab', // indigo
+    '#8e24aa', // purple
+    '#6d4c41', // brown
+    '#455a64', // slate
+];
+
+/** Look up the FA class for an icon key, falling back to the default marker glyph. */
+export function faClassForIconKey(iconKey) {
+    return (MARKER_ICONS_BY_KEY[iconKey] || MARKER_ICONS_BY_KEY[DEFAULT_MARKER_ICON_KEY]).fa;
+}
+
+/**
+ * Build a circular colored badge with a white Font Awesome glyph -- the
+ * marker style used for collaborative-layer markers (deliberately distinct
+ * from the teardrop asset/job markers so responders can tell "someone
+ * dropped this" apart from tracked assets at a glance).
+ */
+export function buildMarkerBadgeIcon({ icon, fill }, { size = 28 } = {}) {
+    const faClass = faClassForIconKey(icon);
+    const bg = fill || '#2b7bbb';
+    const html = `<div class="collab-marker-badge" style="background:${bg}"><i class="fas ${faClass}"></i></div>`;
+
+    return L.divIcon({
+        className: 'collab-marker-icon',
+        html,
+        iconSize: [size, size],
+        iconAnchor: [size / 2, size / 2],
+        popupAnchor: [0, -size / 2],
+    });
+}

--- a/src/pages/tasking/components/job_icon.js
+++ b/src/pages/tasking/components/job_icon.js
@@ -2,7 +2,7 @@ import {jobsToUI} from "../utils/jobTypesToUI.js";
 
 // --- SVG factory (shape+style → L.divIcon) ---
 import L from "leaflet";
-export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2 }) {
+function shapeInnerSvg({ shape, fill, stroke, radius = 7, strokeWidth = 2 }) {
     const d = radius * 2;
     const cx = radius, cy = radius;
 
@@ -118,6 +118,12 @@ export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2
                           fill="${fill}" stroke="${stroke}" stroke-width="${strokeWidth}" />`;
     }
 
+    return inner;
+}
+
+export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2 }) {
+    const d = radius * 2;
+    const inner = shapeInnerSvg({ shape, fill, stroke, radius, strokeWidth });
     const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${d}" height="${d}" viewBox="0 0 ${d} ${d}">
               ${inner}
             </svg>`;

--- a/src/pages/tasking/components/mapContextMenu.js
+++ b/src/pages/tasking/components/mapContextMenu.js
@@ -40,10 +40,13 @@ export function installMapContextMenu({
     geocodeMarkerIcon = null,            // pass your defaultSvgIcon if you want
     geocodeRedMarkerIcon = null,         // pass your defaultRedSvgIcon if you want
     geocodeMaxResults = 10,
+    canAddMarker = null,                 // () => boolean -- show/hide the "Add marker" item
+    onAddMarker = null,                  // (latlng) => void -- invoked when it's clicked
 }) {
     const ctxMenu = document.getElementById("mapContextMenu");
     const btnSearch = document.getElementById("ctxSearchHere");
     const btnGeocode = document.getElementById("ctxGeocodeHere");
+    const btnAddMarker = document.getElementById("ctxAddCollabMarker");
 
     if (!map || !ctxMenu || !btnSearch || !btnGeocode) {
         console.warn("MapContextMenu: missing dependencies or DOM");
@@ -78,9 +81,19 @@ export function installMapContextMenu({
     map.on("contextmenu", (e) => {
         lastLatLng = e.latlng;
 
+        if (btnAddMarker) {
+            btnAddMarker.classList.toggle("d-none", !canAddMarker?.());
+        }
+
         const p = map.latLngToContainerPoint(e.latlng);
         const rect = map.getContainer().getBoundingClientRect();
         showMenuAt(rect.left + p.x, rect.top + p.y);
+    });
+
+    // ---- ADD MARKER (collaborative layers) ----
+    btnAddMarker?.addEventListener("click", () => {
+        hideMenu();
+        if (lastLatLng) onAddMarker?.(lastLatLng);
     });
 
 

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -66,6 +66,7 @@ import { registerWaterNSWBoundariesLayer, registerEPAContaminationSitesLayer } f
 import { registerNSWDeclaredDamsLayer } from "./mapLayers/dams.js";
 import { registerBOMLandWarningsLayer } from "./mapLayers/bom.js";
 import { registerRainRadarLayer } from "./mapLayers/rainviewer.js";
+import { registerCollabLayers, getVisibleCollabLayers, startAddMarkerFlow } from "./mapLayers/collabLayer.js";
 import {
     registerBOMRainfallLayer,
     registerBOMRadarLayer,
@@ -196,6 +197,13 @@ const params = getSearchParameters();
 const apiHost = params.host
 const sourceUrl = params.source
 
+// Collaborative map layer markers are attributed to the Beacon Person
+// record (params.personId), not the login/account id (params.userId) --
+// these are separate id systems in Beacon's data model (see
+// BeaconClient/people.js), so userId must never be used as a stand-in
+// here even if personId happens to be missing.
+const markerActorId = params.personId;
+
 // Tell Team model which API URL to use for shared default-asset pushes
 setDefaultAssetApiUrl(sourceUrl);
 
@@ -231,6 +239,12 @@ installMapContextMenu({
     onGeocodeResultClicked: (_r) => {
         // TODO: replace with real action
     },
+    // myViewModel isn't constructed yet at this point in the file (see the
+    // existing `var myViewModel;` module-level pattern below) -- these
+    // callbacks only run later, on an actual right-click, by which point
+    // it's fully populated.
+    canAddMarker: () => getVisibleCollabLayers(myViewModel).length > 0,
+    onAddMarker: (latlng) => startAddMarkerFlow(myViewModel, sourceUrl, markerActorId, latlng),
 });
 
 
@@ -399,6 +413,34 @@ function VM() {
     self.taskingsById = new Map();
     self.assetsById = new Map();
     self.sectorsById = new Map();
+    self.personNamesById = new Map(); // personId -> Promise<string>, caches + dedupes concurrent lookups
+
+    /**
+     * Resolve a Beacon person ID to their display name, caching the result
+     * (and de-duping concurrent lookups for the same id, since the cache
+     * stores the in-flight Promise itself). Falls back to the raw id string
+     * if the lookup fails.
+     */
+    self.resolvePersonName = function (personId) {
+        const idStr = String(personId);
+        if (self.personNamesById.has(idStr)) return self.personNamesById.get(idStr);
+
+        const pending = (async () => {
+            try {
+                const tk = await getToken();
+                const person = await new Promise((resolve, reject) => {
+                    BeaconClient.people.getSimplePerson(idStr, apiHost, params.userId, tk, resolve, reject);
+                });
+                return person?.FullName || idStr;
+            } catch (err) {
+                console.warn('Failed to resolve person name for', idStr, err);
+                return idStr;
+            }
+        })();
+
+        self.personNamesById.set(idStr, pending);
+        return pending;
+    };
 
     // Global collections
     self.teams = ko.observableArray();
@@ -1341,6 +1383,8 @@ function VM() {
             });
         },
         fetchAllSectors: (hqs) => self.fetchAllSectors(hqs),
+        apiUrl: sourceUrl,
+        userId: params.userId,
     };
 
     self.config = new ConfigVM(self, configDeps);
@@ -2978,6 +3022,7 @@ function VM() {
     registerBOMFloodWarningBoundariesLayer(self, sourceUrl);
     registerBOMFireWeatherDistrictsLayer(self, sourceUrl);
     registerRainRadarLayer(self, map);
+    registerCollabLayers(self, sourceUrl, markerActorId);
 
     // --- Layers Drawer (under zoom)
     const LayersDrawer = L.Control.extend({
@@ -2992,6 +3037,8 @@ function VM() {
 
         onAdd(map) {
             const c = L.DomUtil.create("div", "layers-drawer");
+            this._container = c;
+            this._map = map;
 
             // stop wheel -> no map zoom when scrolling the panel
             c.addEventListener("wheel", (e) => { e.stopPropagation(); }, { passive: false });
@@ -3075,6 +3122,103 @@ function VM() {
 
             this._setBasemap(this._baseKey, map);
 
+            this._renderOverlays();
+
+            // --- Search filter ---
+            const searchInput = c.querySelector(".ld-search-input");
+            this._searchFilter = (query) => {
+                const q = query.toLowerCase().trim();
+                const grid = c.querySelector(".ld-grid");
+                const cells = grid.querySelectorAll(".ld-grid-cell");
+
+                cells.forEach(cell => {
+                    const buttons = cell.querySelectorAll(".ld-overlay-btn");
+                    let anyVisible = false;
+
+                    buttons.forEach(btn => {
+                        let shouldShow = !q; // Show all if no query
+
+                        if (q) {
+                            // Extract label from the span.me-2 text content
+                            const labelSpan = btn.querySelector("span.me-2");
+                            const label = labelSpan ? labelSpan.textContent.trim().toLowerCase() : "";
+                            shouldShow = label.includes(q);
+                        }
+
+                        btn.style.setProperty("display", shouldShow ? "" : "none", "important");
+                        if (shouldShow) anyVisible = true;
+                    });
+
+                    // Show cell only if at least one button is visible
+                    cell.style.setProperty("display", anyVisible ? "" : "none", "important");
+                });
+            };
+
+            searchInput.addEventListener("input", (e) => {
+                this._searchFilter(e.target.value);
+            });
+
+            // --- Toggle button ---
+            const toggleBtn = c.querySelector(".ld-toggle-btn");
+            const panel = c.querySelector(".ld-panel");
+
+            const fitPanel = () => {
+                requestAnimationFrame(() => {
+                    const rect = panel.getBoundingClientRect();
+                    const avail = window.innerHeight - rect.top - 20; // 20px bottom margin
+                    panel.style.maxHeight = Math.max(avail, 160) + "px";
+                });
+            };
+            this._fitPanel = fitPanel;
+
+            L.DomEvent.on(toggleBtn, "click", (ev) => {
+                L.DomEvent.stop(ev);
+                const hidden = panel.classList.toggle("d-none");
+                toggleBtn.setAttribute("aria-expanded", (!hidden).toString());
+                toggleBtn.parentElement.classList.toggle("no-border", !hidden);
+                localStorage.setItem("layers.open", hidden ? "0" : "1");
+                if (!hidden) {
+                    // Clear search when opening
+                    searchInput.value = "";
+                    this._searchFilter("");
+                    fitPanel();
+                }
+            });
+
+            // Re-fit when window resizes
+            window.addEventListener("resize", () => {
+                if (!panel.classList.contains("d-none")) fitPanel();
+            });
+
+            // Initial fit if panel starts open
+            if (this._open) setTimeout(fitPanel, 50);
+
+            // Close panel when map is clicked
+            map.on("click", () => {
+                if (!panel.classList.contains("d-none")) {
+                    panel.classList.add("d-none");
+                    toggleBtn.setAttribute("aria-expanded", "false");
+                    toggleBtn.parentElement.classList.remove("no-border");
+                    localStorage.setItem("layers.open", "0");
+                }
+            });
+
+            L.DomEvent.disableClickPropagation(c);
+
+            return c;
+        },
+
+        /** Rebuild the overlay grid (e.g. after a new collaborative layer is created). */
+        refresh() {
+            if (!this._container) return;
+            this._renderOverlays();
+            this._searchFilter?.("");
+        },
+
+        _renderOverlays() {
+            const map = this._map;
+            const c = this._container;
+
             // --- Overlays: group by def.group ---
             const overlayDefs = self.mapVM.getOverlayDefsForControl() || [];
             const groups = new Map();
@@ -3088,6 +3232,7 @@ function VM() {
 
             // --- Build two-column grid of always-visible groups ---
             const grid = c.querySelector(".ld-grid");
+            grid.innerHTML = "";
 
             groups.forEach((defs, groupKey) => {
                 const cell = document.createElement("div");
@@ -3179,88 +3324,6 @@ function VM() {
                 cell.appendChild(body);
                 grid.appendChild(cell);
             });
-
-            // --- Search filter ---
-            const searchInput = c.querySelector(".ld-search-input");
-            const searchFilter = (query) => {
-                const q = query.toLowerCase().trim();
-                const cells = grid.querySelectorAll(".ld-grid-cell");
-
-                cells.forEach(cell => {
-                    const buttons = cell.querySelectorAll(".ld-overlay-btn");
-                    let anyVisible = false;
-
-                    buttons.forEach(btn => {
-                        let shouldShow = !q; // Show all if no query
-
-                        if (q) {
-                            // Extract label from the span.me-2 text content
-                            const labelSpan = btn.querySelector("span.me-2");
-                            const label = labelSpan ? labelSpan.textContent.trim().toLowerCase() : "";
-                            shouldShow = label.includes(q);
-                        }
-
-                        btn.style.setProperty("display", shouldShow ? "" : "none", "important");
-                        if (shouldShow) anyVisible = true;
-                    });
-
-                    // Show cell only if at least one button is visible
-                    cell.style.setProperty("display", anyVisible ? "" : "none", "important");
-                });
-            };
-
-            searchInput.addEventListener("input", (e) => {
-                searchFilter(e.target.value);
-            });
-
-            // --- Toggle button ---
-            const toggleBtn = c.querySelector(".ld-toggle-btn");
-            const panel = c.querySelector(".ld-panel");
-
-            const fitPanel = () => {
-                requestAnimationFrame(() => {
-                    const rect = panel.getBoundingClientRect();
-                    const avail = window.innerHeight - rect.top - 20; // 20px bottom margin
-                    panel.style.maxHeight = Math.max(avail, 160) + "px";
-                });
-            };
-
-            L.DomEvent.on(toggleBtn, "click", (ev) => {
-                L.DomEvent.stop(ev);
-                const hidden = panel.classList.toggle("d-none");
-                toggleBtn.setAttribute("aria-expanded", (!hidden).toString());
-                toggleBtn.parentElement.classList.toggle("no-border", !hidden);
-                localStorage.setItem("layers.open", hidden ? "0" : "1");
-                if (!hidden) {
-                    // Clear search when opening
-                    searchInput.value = "";
-                    searchFilter("");
-                    fitPanel();
-                }
-            });
-
-            // Re-fit when window resizes
-            window.addEventListener("resize", () => {
-                if (!panel.classList.contains("d-none")) fitPanel();
-            });
-
-            // Initial fit if panel starts open
-            if (this._open) setTimeout(fitPanel, 50);
-
-            // Close panel when map is clicked
-            map.on("click", () => {
-                if (!panel.classList.contains("d-none")) {
-                    panel.classList.add("d-none");
-                    toggleBtn.setAttribute("aria-expanded", "false");
-                    toggleBtn.parentElement.classList.remove("no-border");
-                    localStorage.setItem("layers.open", "0");
-                }
-            });
-
-            L.DomEvent.disableClickPropagation(c);
-
-            this._container = c;
-            return c;
         },
 
 

--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -1,0 +1,451 @@
+import L from "leaflet";
+import { MARKER_ICON_GROUPS, DEFAULT_MARKER_ICON_KEY, MARKER_COLOR_SWATCHES, buildMarkerBadgeIcon, faClassForIconKey } from "../components/collab_marker_icons.js";
+import {
+    listLayers,
+    createLayer,
+    fetchLayerMarkers,
+    upsertMarker,
+    deleteMarker,
+} from "../utils/collabLayerSync.js";
+
+const REFRESH_MS = 10000; // polling only fires while the layer is visible (registerPollingLayer's hasLayer gate)
+const DEFAULT_FILL = MARKER_COLOR_SWATCHES[5]; // blue -- also the first swatch highlighted as "active" for a new marker
+
+const layerKeyFor = (layerId) => `collab-${layerId}`;
+
+function timeAgo(iso) {
+    if (!iso) return "";
+    const ms = Date.now() - new Date(iso).getTime();
+    if (!Number.isFinite(ms) || ms < 0) return "";
+    const mins = Math.round(ms / 60000);
+    if (mins < 1) return "just now";
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.round(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    return `${Math.round(hrs / 24)}d ago`;
+}
+
+/** Collaborative layers currently toggled visible on the map. */
+function visibleCollabLayers(vm) {
+    return (vm.mapVM.collabLayers() || []).filter((layer) => {
+        const entry = vm.mapVM.onlineLayers.get(layerKeyFor(layer.id));
+        return entry && vm.mapVM.map.hasLayer(entry.layerGroup);
+    });
+}
+
+/**
+ * Register the polling Leaflet layer for a single collaborative layer.
+ * Visibility is controlled entirely by the existing layers drawer /
+ * `ov.<key>` mechanism already built into registerPollingLayer +
+ * getOverlayDefsForControl — no separate "enabled set" is needed since
+ * polling is a no-op while the layer isn't visible.
+ */
+function registerLayerPolling(vm, apiUrl, layer, actorId) {
+    const key = layerKeyFor(layer.id);
+    vm.mapVM.registerPollingLayer(key, {
+        label: layer.name,
+        menuGroup: "Collaborative Layers",
+        refreshMs: REFRESH_MS,
+        visibleByDefault: false,
+        fetchFn: () => fetchLayerMarkers(apiUrl, layer.id),
+        drawFn: (layerGroup, data) => drawCollabMarkers(vm, layerGroup, data, apiUrl, layer.id, key, actorId),
+    });
+}
+
+/**
+ * Fetch the list of collaborative layers for the org, store it on the
+ * MapVM for the config modal to bind to, and register/refresh polling
+ * layers for any layer not already registered.
+ */
+export async function refreshCollabLayerList(vm, apiUrl, actorId) {
+    const layers = await listLayers(apiUrl);
+    vm.mapVM.collabLayers(layers);
+    layers.forEach((layer) => registerLayerPolling(vm, apiUrl, layer, actorId));
+    vm.mapVM.layersDrawer?.refresh?.();
+    return layers;
+}
+
+/**
+ * Called once at startup (main.js), alongside the other register*Layer
+ * calls. The right-click "Add marker" trigger itself is wired up
+ * separately, into the app's existing map context menu (see
+ * components/mapContextMenu.js + startAddMarkerFlow/getVisibleCollabLayers
+ * above) rather than a second contextmenu listener here.
+ */
+export async function registerCollabLayers(vm, apiUrl, actorId) {
+    await refreshCollabLayerList(vm, apiUrl, actorId);
+}
+
+/** Create a new named layer, register its polling layer immediately, and refresh the drawer. */
+export async function createCollabLayer(vm, apiUrl, name, actorId) {
+    const layer = await createLayer(apiUrl, name, actorId);
+    if (!layer) return null;
+    const list = vm.mapVM.collabLayers();
+    vm.mapVM.collabLayers([...list, layer]);
+    registerLayerPolling(vm, apiUrl, layer, actorId);
+    vm.mapVM.layersDrawer?.refresh?.();
+    return layer;
+}
+
+// ── Drawing ──────────────────────────────────────────────────────────
+
+function drawCollabMarkers(vm, layerGroup, data, apiUrl, layerId, key, actorId) {
+    const markers = (data?.markers || []).filter((m) => !m.deleted);
+    markers.forEach((marker) => {
+        const icon = buildMarkerBadgeIcon({ icon: marker.icon, fill: marker.fill || DEFAULT_FILL });
+
+        const leafletMarker = L.marker([marker.lat, marker.lng], { icon });
+        leafletMarker.bindPopup(() => buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId), {
+            minWidth: 240,
+            maxWidth: 280,
+        });
+        layerGroup.addLayer(leafletMarker);
+    });
+}
+
+// Any marker on a visible layer can be edited/deleted -- protection against
+// accidental changes comes from requiring an explicit Edit/Delete button
+// click (and a confirm step for delete), not from a separate "edit mode".
+function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId) {
+    const el = document.createElement("div");
+    el.className = "collab-marker-popup";
+
+    const escHtml = (s) => String(s || "").replace(/[&<>"']/g, (c) => ({
+        "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    }[c]));
+
+    el.innerHTML = `
+        <div class="collab-marker-desc">${escHtml(marker.description) || "<em>No description</em>"}</div>
+        <div class="collab-marker-meta">Added by <span class="collab-marker-author">user ${escHtml(marker.createdBy)}</span>${marker.updatedAt ? ` · updated ${timeAgo(marker.updatedAt)}` : ""}</div>
+        <div class="collab-marker-actions">
+            <button type="button" class="btn btn-sm btn-outline-secondary collab-edit-marker-btn">Edit</button>
+            <button type="button" class="btn btn-sm btn-outline-danger collab-delete-marker-btn">Delete</button>
+        </div>
+        <div class="collab-marker-confirm d-none">
+            <span>Delete this marker?</span>
+            <button type="button" class="btn btn-sm btn-danger collab-confirm-delete-btn">Confirm Delete</button>
+            <button type="button" class="btn btn-sm btn-secondary collab-cancel-delete-btn">Cancel</button>
+        </div>
+    `;
+
+    const editBtn = el.querySelector(".collab-edit-marker-btn");
+    const deleteBtn = el.querySelector(".collab-delete-marker-btn");
+    const confirmBox = el.querySelector(".collab-marker-confirm");
+    const actionsBox = el.querySelector(".collab-marker-actions");
+    const confirmDeleteBtn = el.querySelector(".collab-confirm-delete-btn");
+    const cancelDeleteBtn = el.querySelector(".collab-cancel-delete-btn");
+
+    editBtn.addEventListener("click", () => {
+        vm.mapVM.map.closePopup();
+        openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, L.latLng(marker.lat, marker.lng));
+    });
+
+    deleteBtn.addEventListener("click", () => {
+        actionsBox.classList.add("d-none");
+        confirmBox.classList.remove("d-none");
+    });
+    cancelDeleteBtn.addEventListener("click", () => {
+        confirmBox.classList.add("d-none");
+        actionsBox.classList.remove("d-none");
+    });
+    confirmDeleteBtn.addEventListener("click", async () => {
+        await deleteMarker(apiUrl, layerId, marker.id, actorId);
+        vm.mapVM.refreshPollingLayer(key);
+    });
+
+    // Resolve the raw user id shown above into a display name once it's
+    // available (cached/deduped by vm.resolvePersonName). The placeholder
+    // stays if the marker's own popup gets closed/rebuilt before this
+    // resolves -- updating a detached node is a harmless no-op.
+    if (marker.createdBy && vm.resolvePersonName) {
+        const authorEl = el.querySelector(".collab-marker-author");
+        vm.resolvePersonName(marker.createdBy).then((name) => {
+            if (authorEl && name) authorEl.textContent = name;
+        });
+    }
+
+    return el;
+}
+
+// ── Marker create/edit form (inline popup) ──────────────────────────
+
+function buildIconPickerHtml(selectedIcon) {
+    return MARKER_ICON_GROUPS.map((group) => `
+        <div class="collab-icon-group-label">${group.group}</div>
+        <div class="collab-icon-grid">
+            ${group.icons.map((i) => `
+                <button type="button" class="collab-icon-btn ${i.key === selectedIcon ? "active" : ""}"
+                    data-icon="${i.key}" title="${i.label}">
+                    <i class="fas ${i.fa}"></i>
+                </button>
+            `).join("")}
+        </div>
+    `).join("");
+}
+
+function buildColorSwatchesHtml(selectedFill) {
+    return MARKER_COLOR_SWATCHES.map((color) => `
+        <button type="button" class="collab-color-swatch ${color === selectedFill ? "active" : ""}"
+            data-color="${color}" style="background:${color}" title="${color}"></button>
+    `).join("");
+}
+
+/**
+ * Open an inline popup form (create if `marker` is null, edit otherwise)
+ * at the given latlng. Only an explicit Save click writes data.
+ *
+ * Icon and color are each picked from a small dropdown toggle button, with
+ * a live preview badge showing the combined result. Both dropdowns render
+ * as floating panels appended to the map container -- outside the Leaflet
+ * popup's own content -- so opening/closing either one never changes the
+ * popup's size or makes it reposition itself.
+ */
+function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng) {
+    let icon = marker?.icon || DEFAULT_MARKER_ICON_KEY;
+    let fill = marker?.fill || DEFAULT_FILL;
+
+    const el = document.createElement("div");
+    el.className = "collab-marker-form";
+    el.innerHTML = `
+        <div class="collab-style-preview-row">
+            <span class="collab-style-preview"></span>
+            <span class="collab-style-preview-label">Preview</span>
+        </div>
+        <div class="collab-picker-row">
+            <button type="button" class="collab-picker-toggle collab-icon-toggle" title="Choose icon">
+                <i class="fas collab-toggle-icon"></i>
+                <span>Icon</span>
+                <i class="fas fa-caret-down ms-auto"></i>
+            </button>
+            <button type="button" class="collab-picker-toggle collab-color-toggle" title="Choose color">
+                <span class="collab-toggle-swatch"></span>
+                <span>Color</span>
+                <i class="fas fa-caret-down ms-auto"></i>
+            </button>
+        </div>
+        <textarea class="collab-desc-input" placeholder="Description" rows="2">${marker?.description || ""}</textarea>
+        <div class="collab-form-actions">
+            <button type="button" class="btn btn-sm btn-secondary collab-cancel-btn">Cancel</button>
+            <button type="button" class="btn btn-sm btn-primary collab-save-btn">Save</button>
+        </div>
+    `;
+
+    const previewEl = el.querySelector(".collab-style-preview");
+    const iconToggle = el.querySelector(".collab-icon-toggle");
+    const colorToggle = el.querySelector(".collab-color-toggle");
+
+    const renderPreview = () => {
+        previewEl.innerHTML = `<span class="collab-marker-badge"><i class="fas ${faClassForIconKey(icon)}"></i></span>`;
+        previewEl.querySelector(".collab-marker-badge").style.background = fill;
+        iconToggle.querySelector(".collab-toggle-icon").className = `fas ${faClassForIconKey(icon)} collab-toggle-icon`;
+        colorToggle.querySelector(".collab-toggle-swatch").style.background = fill;
+    };
+    renderPreview();
+
+    iconToggle.addEventListener("click", () => {
+        if (iconToggle.classList.contains("open")) { closeFloatingDropdown(); return; }
+        openFloatingDropdown(vm, iconToggle, "collab-icon-dropdown", (panel) => {
+            const render = () => { panel.innerHTML = buildIconPickerHtml(icon); };
+            render();
+            panel.addEventListener("click", (e) => {
+                const btn = e.target.closest(".collab-icon-btn");
+                if (!btn) return;
+                icon = btn.dataset.icon;
+                renderPreview();
+                render(); // keep the dropdown open so multiple icons can be browsed
+            });
+        });
+    });
+
+    colorToggle.addEventListener("click", () => {
+        if (colorToggle.classList.contains("open")) { closeFloatingDropdown(); return; }
+        openFloatingDropdown(vm, colorToggle, "collab-color-dropdown", (panel) => {
+            panel.innerHTML = `<div class="collab-color-swatches"></div>`;
+            const swatches = panel.querySelector(".collab-color-swatches");
+            swatches.innerHTML = buildColorSwatchesHtml(fill);
+            swatches.addEventListener("click", (e) => {
+                const btn = e.target.closest(".collab-color-swatch");
+                if (!btn) return;
+                fill = btn.dataset.color;
+                renderPreview();
+                closeFloatingDropdown(); // color is a single quick pick, close straight away
+            });
+        });
+    });
+
+    const popup = L.popup({ minWidth: 220, maxWidth: 260, closeOnClick: false, autoPanPadding: [16, 16] })
+        .setLatLng(latlng)
+        .setContent(el)
+        .openOn(vm.mapVM.map);
+
+    popup.on("remove", closeFloatingDropdown);
+
+    el.querySelector(".collab-cancel-btn").addEventListener("click", () => {
+        vm.mapVM.map.closePopup(popup);
+    });
+
+    el.querySelector(".collab-save-btn").addEventListener("click", async () => {
+        const description = el.querySelector(".collab-desc-input").value.trim();
+        const payload = {
+            id: marker?.id,
+            lat: latlng.lat,
+            lng: latlng.lng,
+            icon,
+            fill,
+            description,
+        };
+        vm.mapVM.map.closePopup(popup);
+        await upsertMarker(apiUrl, layerId, payload, actorId);
+        vm.mapVM.refreshPollingLayer(key);
+    });
+}
+
+// Singleton so only one dropdown (icon or color, across any open marker
+// form) is ever on screen at once.
+let dropdownCloser = null;
+
+function closeFloatingDropdown() {
+    if (dropdownCloser) {
+        dropdownCloser();
+        dropdownCloser = null;
+    }
+}
+
+/**
+ * Shared plumbing for a floating panel anchored below `anchorEl`, appended
+ * to the map container rather than any Leaflet popup's content. `populate`
+ * is called once with the empty panel element to fill it in and wire its
+ * own interactions.
+ */
+function openFloatingDropdown(vm, anchorEl, className, populate) {
+    closeFloatingDropdown();
+
+    const map = vm.mapVM.map;
+    const mapContainer = map.getContainer();
+    const anchorRect = anchorEl.getBoundingClientRect();
+    const containerRect = mapContainer.getBoundingClientRect();
+
+    const panel = document.createElement("div");
+    panel.className = className;
+    panel.style.left = `${anchorRect.left - containerRect.left}px`;
+    panel.style.top = `${anchorRect.bottom - containerRect.top + 4}px`;
+
+    populate(panel);
+
+    mapContainer.appendChild(panel);
+    anchorEl.classList.add("open");
+    L.DomEvent.disableClickPropagation(panel);
+    L.DomEvent.disableScrollPropagation(panel);
+
+    const onMapInteract = () => closeFloatingDropdown();
+    const onDocClick = (e) => {
+        if (!panel.contains(e.target) && !anchorEl.contains(e.target)) closeFloatingDropdown();
+    };
+    const onKeyDown = (e) => { if (e.key === "Escape") closeFloatingDropdown(); };
+
+    map.on("zoomstart dragstart", onMapInteract);
+    document.addEventListener("click", onDocClick, true);
+    document.addEventListener("keydown", onKeyDown);
+
+    dropdownCloser = () => {
+        panel.remove();
+        anchorEl.classList.remove("open");
+        map.off("zoomstart dragstart", onMapInteract);
+        document.removeEventListener("click", onDocClick, true);
+        document.removeEventListener("keydown", onKeyDown);
+    };
+}
+
+// ── Right-click "add marker" ─────────────────────────────────────────
+//
+// Only available when at least one collaborative layer is currently
+// visible. With exactly one visible layer, right-click opens the marker
+// form immediately. With more than one visible, right-click shows a small
+// picker so the user chooses which layer receives the new marker.
+
+let openContextMenu = null; // cleanup for a currently-open picker menu, if any
+
+function closeContextMenu() {
+    if (openContextMenu) {
+        openContextMenu();
+        openContextMenu = null;
+    }
+}
+
+function showLayerPickerMenu(vm, apiUrl, actorId, layers, containerPoint, latlng) {
+    closeContextMenu();
+
+    const map = vm.mapVM.map;
+    const mapContainer = map.getContainer();
+
+    const menu = document.createElement("div");
+    menu.className = "collab-context-menu";
+    menu.style.left = `${containerPoint.x}px`;
+    menu.style.top = `${containerPoint.y}px`;
+
+    const header = document.createElement("div");
+    header.className = "collab-context-menu-header";
+    header.textContent = "Add marker to…";
+    menu.appendChild(header);
+
+    // Items scroll independently so the header stays put and the menu
+    // never runs off-screen when many layers are visible at once.
+    const itemsBox = document.createElement("div");
+    itemsBox.className = "collab-context-menu-items";
+    menu.appendChild(itemsBox);
+
+    const sortedLayers = layers.slice().sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+    sortedLayers.forEach((layer) => {
+        const item = document.createElement("button");
+        item.type = "button";
+        item.className = "collab-context-menu-item";
+        item.textContent = layer.name;
+        item.title = layer.name;
+        item.addEventListener("click", () => {
+            closeContextMenu();
+            openMarkerForm(vm, apiUrl, layer.id, layerKeyFor(layer.id), actorId, null, latlng);
+        });
+        itemsBox.appendChild(item);
+    });
+
+    mapContainer.appendChild(menu);
+    L.DomEvent.disableClickPropagation(menu);
+
+    const onMapInteract = () => closeContextMenu();
+    const onKeyDown = (e) => { if (e.key === "Escape") closeContextMenu(); };
+    map.on("click zoomstart dragstart", onMapInteract);
+    document.addEventListener("keydown", onKeyDown);
+
+    openContextMenu = () => {
+        menu.remove();
+        map.off("click zoomstart dragstart", onMapInteract);
+        document.removeEventListener("keydown", onKeyDown);
+    };
+}
+
+/** Whether the "Add marker" item in the map's right-click context menu should be shown. */
+export function getVisibleCollabLayers(vm) {
+    return visibleCollabLayers(vm);
+}
+
+/**
+ * Entry point for the "Add marker to shared layer" item in the app's
+ * existing right-click context menu (components/mapContextMenu.js). With
+ * exactly one visible layer, opens the marker form immediately; with more
+ * than one, shows a small picker so the user chooses which layer receives
+ * the new marker.
+ */
+export function startAddMarkerFlow(vm, apiUrl, actorId, latlng) {
+    closeContextMenu();
+
+    const visible = visibleCollabLayers(vm);
+    if (visible.length === 0) return;
+
+    if (visible.length === 1) {
+        openMarkerForm(vm, apiUrl, visible[0].id, layerKeyFor(visible[0].id), actorId, null, latlng);
+        return;
+    }
+
+    const containerPoint = vm.mapVM.map.latLngToContainerPoint(latlng);
+    showLayerPickerMenu(vm, apiUrl, actorId, visible, containerPoint, latlng);
+}

--- a/src/pages/tasking/utils/collabLayerSync.js
+++ b/src/pages/tasking/utils/collabLayerSync.js
@@ -1,0 +1,227 @@
+/**
+ * collabLayerSync.js
+ *
+ * Client-side helper for the collaborative map-layers feature: listing
+ * layers for an org, creating layers, and reading/writing markers via
+ * the Lambda / S3 backend.
+ *
+ * Mirrors the fetch/cache conventions of defaultAssetSync.js: GETs are
+ * cached to localStorage so data survives reloads and is available
+ * immediately on next open; mutations apply an optimistic local update
+ * before firing the remote write.
+ */
+
+const LAMBDA_BASE = 'https://lambda.lighthouse-extension.com/lad/map-layers';
+
+const LS_INDEX_KEY = 'lh_collabLayers_index'; // cached layer list for the current org
+const layerCacheKey = (layerId) => `lh_collabLayer_${layerId}`;
+
+// ── Local cache helpers ─────────────────────────────────────────────
+
+/**
+ * Read the cached layer index (list of layers for the current org).
+ * @returns {Array<Object>}
+ */
+export function loadCachedLayerIndex() {
+    try {
+        return JSON.parse(localStorage.getItem(LS_INDEX_KEY)) || [];
+    } catch {
+        return [];
+    }
+}
+
+function saveCachedLayerIndex(layers) {
+    localStorage.setItem(LS_INDEX_KEY, JSON.stringify(layers || []));
+}
+
+/**
+ * Read a cached layer (including its markers).
+ * @param {string} layerId
+ * @returns {Object|null}
+ */
+export function loadCachedLayer(layerId) {
+    try {
+        return JSON.parse(localStorage.getItem(layerCacheKey(layerId))) || null;
+    } catch {
+        return null;
+    }
+}
+
+function saveCachedLayer(layerId, layer) {
+    localStorage.setItem(layerCacheKey(layerId), JSON.stringify(layer));
+}
+
+// ── List / create layers ────────────────────────────────────────────
+
+/**
+ * List collaborative layers for an org (layers unused for 120+ days are
+ * excluded server-side, not deleted).
+ * @param {string} apiUrl
+ * @returns {Promise<Array<Object>>}
+ */
+export async function listLayers(apiUrl) {
+    if (!apiUrl) return loadCachedLayerIndex();
+
+    try {
+        const url = `${LAMBDA_BASE}?apiUrl=${encodeURIComponent(apiUrl)}`;
+        const res = await fetch(url, { method: 'GET', headers: { Accept: 'application/json' } });
+        if (!res.ok) {
+            console.warn('[collabLayerSync] list failed:', res.status);
+            return loadCachedLayerIndex();
+        }
+        const { layers } = await res.json();
+        saveCachedLayerIndex(layers || []);
+        return layers || [];
+    } catch (err) {
+        console.warn('[collabLayerSync] list error:', err);
+        return loadCachedLayerIndex();
+    }
+}
+
+/**
+ * Create a new named collaborative layer.
+ * @param {string} apiUrl
+ * @param {string} name
+ * @param {string} actorId
+ * @returns {Promise<Object|null>} the created layer summary, or null on failure
+ */
+export async function createLayer(apiUrl, name, actorId) {
+    const trimmed = (name || '').trim();
+    if (!apiUrl || !trimmed) return null;
+
+    try {
+        const res = await fetch(LAMBDA_BASE, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ apiUrl, name: trimmed, createdBy: String(actorId) }),
+        });
+        if (!res.ok) {
+            throw new Error(`Create layer failed with status ${res.status}`);
+        }
+        const layer = await res.json();
+
+        // Optimistically add to the cached index
+        const index = loadCachedLayerIndex();
+        index.push(layer);
+        saveCachedLayerIndex(index);
+
+        return layer;
+    } catch (err) {
+        console.warn('[collabLayerSync] createLayer error:', err);
+        return null;
+    }
+}
+
+// ── Layer markers ────────────────────────────────────────────────────
+
+/**
+ * Fetch a layer's markers (also counts as "use" server-side, so this
+ * layer won't age out of listLayers()).
+ * @param {string} apiUrl
+ * @param {string} layerId
+ * @returns {Promise<Object|null>} the layer, including its markers array
+ */
+export async function fetchLayerMarkers(apiUrl, layerId) {
+    if (!apiUrl || !layerId) return loadCachedLayer(layerId);
+
+    try {
+        const url = `${LAMBDA_BASE}/${encodeURIComponent(layerId)}?apiUrl=${encodeURIComponent(apiUrl)}`;
+        const res = await fetch(url, { method: 'GET', headers: { Accept: 'application/json' } });
+        if (!res.ok) {
+            console.warn('[collabLayerSync] fetchLayerMarkers failed:', res.status);
+            return loadCachedLayer(layerId);
+        }
+        const layer = await res.json();
+        saveCachedLayer(layerId, layer);
+        return layer;
+    } catch (err) {
+        console.warn('[collabLayerSync] fetchLayerMarkers error:', err);
+        return loadCachedLayer(layerId);
+    }
+}
+
+/**
+ * Create or update a marker on a layer. Applies an optimistic local
+ * update to the cached layer before firing the remote write.
+ * @param {string} apiUrl
+ * @param {string} layerId
+ * @param {{id?: string, lat: number, lng: number, shape: string, fill: string, stroke: string, description: string}} marker
+ * @param {string} actorId
+ * @returns {Promise<Object|null>} the saved marker (with server-assigned id/timestamps), or null on failure
+ */
+export async function upsertMarker(apiUrl, layerId, marker, actorId) {
+    if (!apiUrl || !layerId || !marker) return null;
+
+    // Optimistic local update
+    const cached = loadCachedLayer(layerId) || { id: layerId, markers: [] };
+    cached.markers = Array.isArray(cached.markers) ? cached.markers : [];
+    const now = new Date().toISOString();
+    const optimistic = {
+        ...marker,
+        id: marker.id || `local-${Date.now()}`,
+        updatedBy: String(actorId),
+        updatedAt: now,
+        createdBy: marker.createdBy || String(actorId),
+        createdAt: marker.createdAt || now,
+        deleted: false,
+    };
+    const idx = cached.markers.findIndex((m) => m.id === optimistic.id);
+    if (idx >= 0) {
+        cached.markers[idx] = optimistic;
+    } else {
+        cached.markers.push(optimistic);
+    }
+    saveCachedLayer(layerId, cached);
+
+    try {
+        const res = await fetch(`${LAMBDA_BASE}/${encodeURIComponent(layerId)}/features`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ apiUrl, marker, actorId: String(actorId) }),
+        });
+        if (!res.ok) {
+            throw new Error(`upsertMarker failed with status ${res.status}`);
+        }
+        const saved = await res.json();
+
+        // Reconcile optimistic entry with server-assigned id/timestamps
+        const latest = loadCachedLayer(layerId) || cached;
+        const i = latest.markers.findIndex((m) => m.id === optimistic.id);
+        if (i >= 0) latest.markers[i] = saved;
+        else latest.markers.push(saved);
+        saveCachedLayer(layerId, latest);
+
+        return saved;
+    } catch (err) {
+        console.warn('[collabLayerSync] upsertMarker error:', err);
+        return optimistic;
+    }
+}
+
+/**
+ * Delete (soft-delete) a marker from a layer. Optimistically removes it
+ * from the local cache, then fires the remote write.
+ * @param {string} apiUrl
+ * @param {string} layerId
+ * @param {string} markerId
+ * @param {string} actorId
+ * @returns {Promise<void>}
+ */
+export async function deleteMarker(apiUrl, layerId, markerId, actorId) {
+    if (!apiUrl || !layerId || !markerId) return;
+
+    // Optimistic local update
+    const cached = loadCachedLayer(layerId);
+    if (cached && Array.isArray(cached.markers)) {
+        cached.markers = cached.markers.filter((m) => m.id !== markerId);
+        saveCachedLayer(layerId, cached);
+    }
+
+    try {
+        const url = `${LAMBDA_BASE}/${encodeURIComponent(layerId)}/features/${encodeURIComponent(markerId)}` +
+            `?apiUrl=${encodeURIComponent(apiUrl)}&actorId=${encodeURIComponent(actorId)}`;
+        await fetch(url, { method: 'DELETE' });
+    } catch (err) {
+        console.warn('[collabLayerSync] deleteMarker error:', err);
+    }
+}

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -3,6 +3,7 @@ import ko from 'knockout';
 
 import * as bootstrap from 'bootstrap5'; // Modal, Tooltip, etc.
 import { Enum } from '../utils/enum.js';
+import { createCollabLayer } from '../mapLayers/collabLayer.js';
 
 
 
@@ -188,6 +189,100 @@ export function ConfigVM(root, deps) {
             onCancel && onCancel();
         };
     }
+    // ── Collaborative map layers ──
+    self.collabLayers = root.mapVM?.collabLayers || ko.observableArray([]);
+    self.newLayerName = ko.observable('');
+    self.creatingCollabLayer = ko.observable(false);
+    self.collabLayerError = ko.observable('');
+    self.collabLayerSearch = ko.observable(''); // filters the (possibly long) layer list below
+
+    function relativeTime(iso) {
+        if (!iso) return 'never';
+        const ms = Date.now() - new Date(iso).getTime();
+        if (!Number.isFinite(ms) || ms < 0) return 'just now';
+        const mins = Math.round(ms / 60000);
+        if (mins < 1) return 'just now';
+        if (mins < 60) return `${mins}m ago`;
+        const hrs = Math.round(mins / 60);
+        if (hrs < 24) return `${hrs}h ago`;
+        return `${Math.round(hrs / 24)}d ago`;
+    }
+
+    // Applies the actual show/hide side-effect when a row's View switch
+    // changes. `row.key` is the unprefixed registry key used by
+    // mapVM.onlineLayers; `row.drawerKey` is the 'online-'-prefixed key the
+    // layers drawer uses for its `ov.<key>` localStorage visibility flag
+    // (see getOverlayDefsForControl in Map.js) — both must be kept in sync.
+    // Any user can add/edit/delete markers on a visible layer directly on
+    // the map (right-click to add, popup buttons to edit/delete) — there's
+    // no separate "edit mode" toggle here, just View.
+    self._applyCollabLayerView = (row, enabled) => {
+        const layerObj = root.mapVM.onlineLayers.get(row.key)?.layerGroup;
+        if (!layerObj) return;
+        if (enabled) {
+            root.mapVM.map.addLayer(layerObj);
+            localStorage.setItem(`ov.${row.drawerKey}`, '1');
+        } else {
+            root.mapVM.map.removeLayer(layerObj);
+            localStorage.setItem(`ov.${row.drawerKey}`, '0');
+        }
+        root.mapVM.layersDrawer?.refresh?.();
+    };
+
+    // Sorted alphabetically so a long list stays scannable; filtered by
+    // collabLayerSearch below for the same reason.
+    self.collabLayerRows = ko.pureComputed(() => self.collabLayers()
+        .slice()
+        .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+        .map(layer => {
+            const key = `collab-${layer.id}`;
+            const drawerKey = `online-${key}`;
+            const row = {
+                layer,
+                key,
+                drawerKey,
+                name: layer.name,
+                markerCount: layer.markerCount || 0,
+                lastUsedLabel: relativeTime(layer.lastUsedAt),
+                viewEnabled: ko.observable(localStorage.getItem(`ov.${drawerKey}`) === '1'),
+            };
+            row.viewEnabled.subscribe((v) => self._applyCollabLayerView(row, v));
+            return row;
+        }));
+
+    self.filteredCollabLayerRows = ko.pureComputed(() => {
+        const q = self.collabLayerSearch().trim().toLowerCase();
+        const rows = self.collabLayerRows();
+        if (!q) return rows;
+        return rows.filter(row => row.name.toLowerCase().includes(q));
+    });
+
+    self.createCollabLayer = async () => {
+        const name = self.newLayerName().trim();
+        if (!name || !deps.apiUrl) return;
+
+        self.collabLayerError('');
+        self.creatingCollabLayer(true);
+        try {
+            const layer = await createCollabLayer(root, deps.apiUrl, name, deps.userId);
+            if (!layer) throw new Error('Create failed');
+            self.newLayerName('');
+        } catch (err) {
+            console.error('Error creating collaborative layer:', err);
+            self.collabLayerError('Failed to create layer. Try again later.');
+        } finally {
+            self.creatingCollabLayer(false);
+        }
+    };
+
+    // Named method (rather than an inline function in the data-bind attribute)
+    // because knockout-secure-binding's restricted grammar doesn't support
+    // control-flow statements like `if` inside inline function literals.
+    self.handleNewLayerNameKeydown = (data, event) => {
+        if (event.key === 'Enter') self.createCollabLayer();
+        return true;
+    };
+
     self.fetchPeriod = ko.observable(7).extend({ min: 0, max: 31, digit: true });
     self.fetchForward = ko.observable(0).extend({ min: 0, max: 31, digit: true });
     self.showAdvanced = ko.observable(false);

--- a/src/pages/tasking/viewmodels/Map.js
+++ b/src/pages/tasking/viewmodels/Map.js
@@ -618,6 +618,9 @@ export function MapVM(Lmap, root) {
     return defs;
   };
 
+  // --- Collaborative map layers ---
+  self.collabLayers = ko.observableArray([]); // layer summaries for the current org, from listLayers()
+
   // helpers
   self.setOpen = (kind, ref) => self.openPopup({ kind, id: ref.id?.(), ref });
   self.clearOpen = () => self.openPopup(null);

--- a/src/shared/BeaconClient.js
+++ b/src/shared/BeaconClient.js
@@ -21,11 +21,12 @@ import * as messages from './BeaconClient/messages.js';
 import * as suppliers from './BeaconClient/suppliers.js';
 import * as images from './BeaconClient/images.js';
 import * as icems from './BeaconClient/icems.js';
+import * as people from './BeaconClient/people.js';
 
-export { job, asset, nitc, operationslog, resources, team, unit, entities, tasking, notifications, geoservices, tags, sectors, frao, contacts, messages, suppliers, images, icems };
+export { job, asset, nitc, operationslog, resources, team, unit, entities, tasking, notifications, geoservices, tags, sectors, frao, contacts, messages, suppliers, images, icems, people };
 
 // re-export functions
-export default { job, asset, nitc, operationslog, resources, team, unit, entities, tasking, notifications, geoservices, tags, sectors, frao, contacts, messages, suppliers, images, icems, toFormUrlEncoded };
+export default { job, asset, nitc, operationslog, resources, team, unit, entities, tasking, notifications, geoservices, tags, sectors, frao, contacts, messages, suppliers, images, icems, people, toFormUrlEncoded };
 export function toFormUrlEncoded(obj) {
     const params = [];
     for (const key in obj) {

--- a/src/shared/BeaconClient/people.js
+++ b/src/shared/BeaconClient/people.js
@@ -1,0 +1,24 @@
+import $ from 'jquery';
+
+export function getSimplePerson(personId, host, userId = 'notPassed', token, callback, errorCallback) {
+  $.ajax({
+    type: 'GET',
+    url: host + '/Api/v1/People/GetSimplePerson/' + encodeURIComponent(personId) + '?LighthouseFunction=GetSimplePerson&userId=' + userId,
+    beforeSend: function (n) {
+      n.setRequestHeader('Authorization', 'Bearer ' + token);
+    },
+    cache: false,
+    dataType: 'json',
+    complete: function (response, textStatus) {
+      if (textStatus == 'success') {
+        if (typeof callback === 'function') {
+          callback(response.responseJSON);
+        }
+      } else {
+        if (typeof errorCallback === 'function') {
+          errorCallback(response);
+        }
+      }
+    }
+  });
+}

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2701,6 +2701,10 @@
                                             aria-labelledby="headingMapLayers"
                                             data-bs-parent="#configOtherSettingsAccordion">
                                             <div class="accordion-body">
+
+                                                <h6 class="fw-semibold mb-2">
+                                                    <i class="fa fa-sliders me-1"></i>Display Settings
+                                                </h6>
                                                 <div class="row g-3">
 
                                                     <!-- Clustering options -->
@@ -2784,6 +2788,66 @@
                                                     </div>
 
                                                 </div>
+
+                                                <hr class="my-4">
+
+                                                <h6 class="fw-semibold mb-2">
+                                                    <i class="fa fa-users me-1"></i>Collaborative Layers
+                                                </h6>
+                                                <p class="small text-muted mb-3">
+                                                    Shared marker layers that everyone in your organisation can see and
+                                                    edit together. Enable View to show a layer on the map — once
+                                                    visible, right-click anywhere on the map to drop a marker on it.
+                                                    Layers unused for 120 days stop appearing here, but their data
+                                                    isn't deleted.
+                                                </p>
+
+                                                <div class="input-group input-group-sm mb-3">
+                                                    <input type="text" class="form-control" placeholder="New layer name"
+                                                        data-bind="value: config.newLayerName, valueUpdate: 'input',
+                                                            event: { keydown: config.handleNewLayerNameKeydown }">
+                                                    <button class="btn btn-outline-primary" type="button"
+                                                        data-bind="click: config.createCollabLayer,
+                                                            enable: config.newLayerName().trim().length > 0 && !config.creatingCollabLayer()">
+                                                        <i class="fa fa-plus me-1"></i>New layer
+                                                    </button>
+                                                </div>
+                                                <div class="text-danger small mb-2"
+                                                    data-bind="visible: config.collabLayerError, text: config.collabLayerError"></div>
+
+                                                <div class="input-group input-group-sm mb-2"
+                                                    data-bind="visible: config.collabLayerRows().length > 5">
+                                                    <span class="input-group-text"><i class="fa fa-search"></i></span>
+                                                    <input type="text" class="form-control" placeholder="Filter layers by name"
+                                                        data-bind="value: config.collabLayerSearch, valueUpdate: 'input'">
+                                                </div>
+
+                                                <div class="collab-layer-list-scroll">
+                                                    <ul class="list-group" data-bind="foreach: { data: config.filteredCollabLayerRows, as: 'row' }">
+                                                        <li class="list-group-item d-flex align-items-center gap-2 py-2">
+                                                            <div class="flex-grow-1 collab-layer-row-info">
+                                                                <div class="collab-layer-row-name" data-bind="text: row.name, attr: { title: row.name }"></div>
+                                                                <div class="form-text">
+                                                                    <span data-bind="text: row.markerCount"></span> markers ·
+                                                                    used <span data-bind="text: row.lastUsedLabel"></span>
+                                                                </div>
+                                                            </div>
+                                                            <div class="form-check form-switch mb-0" title="View">
+                                                                <input class="form-check-input" type="checkbox" role="switch"
+                                                                    data-bind="checked: row.viewEnabled">
+                                                                <label class="form-check-label small">View</label>
+                                                            </div>
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                                <div class="form-text mt-2" data-bind="visible: config.collabLayerRows().length === 0">
+                                                    No collaborative layers yet — create one above.
+                                                </div>
+                                                <div class="form-text mt-2"
+                                                    data-bind="visible: config.collabLayerRows().length > 0 && config.filteredCollabLayerRows().length === 0">
+                                                    No layers match "<span data-bind="text: config.collabLayerSearch"></span>".
+                                                </div>
+
                                             </div>
                                         </div>
                                     </div>
@@ -3861,6 +3925,9 @@
     <!-- MAP CONTEXT MENU (floating) -->
     <div id="mapContextMenu" class="dropdown-menu shadow"
         style="position:fixed; display:none; z-index:5000; min-width: 220px;">
+        <button type="button" class="dropdown-item d-none" id="ctxAddCollabMarker">
+            <i class="fa fa-map-marker-alt me-2"></i>Add marker to shared layer
+        </button>
         <button type="button" class="dropdown-item" id="ctxSearchHere">
             <i class="fa fa-search me-2"></i>Address Search
         </button>

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2589,6 +2589,283 @@ overflow: hidden;
   padding: 3px 6px;
 }
 
+/* ── Collaborative layer list (config modal) — scrolls instead of growing the modal indefinitely ── */
+.collab-layer-list-scroll {
+  max-height: 280px;
+  overflow-y: auto;
+}
+.collab-layer-row-info {
+  min-width: 0; /* allow text-overflow to work inside a flex row */
+}
+.collab-layer-row-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Collaborative marker popup (view/edit) ── */
+.collab-marker-popup {
+  font-size: 12px;
+  min-width: 200px;
+}
+.collab-marker-desc {
+  margin-bottom: 4px;
+}
+.collab-marker-meta {
+  color: #888;
+  font-size: 11px;
+  margin-bottom: 6px;
+}
+.collab-marker-actions,
+.collab-marker-confirm {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.collab-marker-actions .btn,
+.collab-marker-confirm .btn {
+  font-size: 10px;
+  padding: 1px 6px;
+  line-height: 1.4;
+}
+
+/* ── Collaborative marker icon badge (the actual map marker) ── */
+.leaflet-marker-icon.collab-marker-icon {
+  display: block;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-sizing: content-box;
+  pointer-events: auto;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+.collab-marker-badge {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  border: 2px solid #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, .45);
+}
+.collab-marker-badge i {
+  font-size: 13px;
+}
+
+/* ── Collaborative marker create/edit inline form ── */
+.collab-marker-form {
+  font-size: 12px;
+  min-width: 220px;
+  max-width: 260px;
+}
+
+/* Live preview badge -- reflects the currently chosen icon + color before
+   Save, updated as either dropdown selection changes. */
+.collab-style-preview-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.collab-style-preview {
+  display: inline-block;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+}
+.collab-style-preview-label {
+  color: #666;
+}
+
+/* Icon + color toggle buttons sit side by side on the popup; each opens
+   its own floating dropdown (see .collab-icon-dropdown / .collab-color-
+   dropdown below) rather than expanding inline, so neither ever resizes
+   or repositions the Leaflet popup they belong to. */
+.collab-picker-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+.collab-picker-toggle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid #ddd;
+  background: #f9f9f9;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: #333;
+  cursor: pointer;
+  min-width: 0;
+}
+.collab-picker-toggle:hover {
+  background: #f0f0f0;
+}
+.collab-picker-toggle.open {
+  border-color: #4a90e2;
+}
+.collab-picker-toggle .fa-caret-down {
+  font-size: 10px;
+  transition: transform .15s ease;
+}
+.collab-picker-toggle.open .fa-caret-down {
+  transform: rotate(180deg);
+}
+.collab-toggle-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .15);
+}
+.collab-picker-toggle .collab-toggle-icon {
+  width: 14px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+/* Floating dropdowns -- appended to the map container, not the Leaflet
+   popup's own content, so opening/closing either one never resizes or
+   repositions the popup it belongs to. */
+.collab-icon-dropdown,
+.collab-color-dropdown {
+  position: absolute;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .3);
+  padding: 8px;
+  z-index: 1000;
+  font-size: 12px;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.collab-icon-dropdown {
+  width: 210px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.collab-color-dropdown {
+  width: 168px;
+}
+.collab-color-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.collab-color-swatch {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 2px solid transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .15);
+}
+.collab-color-swatch:hover {
+  transform: scale(1.1);
+}
+.collab-color-swatch.active {
+  border-color: #333;
+}
+.collab-icon-group-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .03em;
+  color: #999;
+  margin: 6px 0 3px;
+}
+.collab-icon-group-label:first-child {
+  margin-top: 0;
+}
+.collab-icon-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 3px;
+}
+.collab-icon-btn {
+  border: 1px solid #ddd;
+  background: #f9f9f9;
+  border-radius: 4px;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #444;
+}
+.collab-icon-btn:hover {
+  background: #eee;
+}
+.collab-icon-btn.active {
+  border-color: #4a90e2;
+  background: #eaf2fc;
+  color: #2b6cb0;
+}
+.collab-desc-input {
+  width: 100%;
+  margin-bottom: 6px;
+  font-size: 12px;
+}
+.collab-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+/* ── Right-click "add marker to…" layer picker (multiple visible layers) ── */
+.collab-context-menu {
+  position: absolute;
+  transform: translate(-4px, -4px);
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .3);
+  padding: 4px;
+  min-width: 180px;
+  max-width: 260px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12px;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.collab-context-menu-header {
+  color: #888;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .03em;
+  padding: 4px 8px 2px;
+}
+.collab-context-menu-items {
+  max-height: 240px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.collab-context-menu-item {
+  border: none;
+  background: none;
+  text-align: left;
+  padding: 6px 8px;
+  border-radius: 3px;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.collab-context-menu-item:hover {
+  background: #f0f4f9;
+}
+
 /* ── Radar playback bar (bottom-center) ── */
 .rv-wrapper {
   position: absolute;


### PR DESCRIPTION
Adds shared tasking layers with marker sync, right-click marker creation, and popup editing/deletion. Also adds the collaborative layer list and visibility controls in the config modal, plus Beacon person-name lookup for marker attribution.


<img width="1131" height="645" alt="Screenshot 2026-08-03 at 9 48 56 am" src="https://github.com/user-attachments/assets/9c5817f7-d5c8-4f7b-83c8-3b612fab5134" />
<img width="601" height="359" alt="Screenshot 2026-08-03 at 9 48 47 am" src="https://github.com/user-attachments/assets/512023e7-3780-480b-ae85-23575873fa71" />
