### PR TITLE
Require Beacon auth on all lambda.lighthouse-extension.com Lambdas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,7 @@ dist
 package
 *.swp
 .env
-
 Lighthouse.zip
 .DS_Store
 *.DS_Store
 package-lock.json
-lambda

--- a/lambda/default-assets-v2/index.mjs
+++ b/lambda/default-assets-v2/index.mjs
@@ -1,0 +1,175 @@
+/**
+ * AWS Lambda — Default-Asset Mapping Store (v2, auth-gated)
+ *
+ * Stores each team's chosen default-asset as a small JSON file in S3,
+ * namespaced by the Beacon API URL so different environments
+ * (train / dev / prod) never collide.
+ *
+ * S3 structure:
+ *   s3://{BUCKET}/{CONFIG_PREFIX}/{urlHash}/{teamId}.json
+ *
+ * Old objects are automatically expired by S3 Lifecycle policy.
+ *
+ * ── Routes ──
+ *
+ *   GET  /default-assets?apiUrl=…&teamIds=1,2,3
+ *        → { "mapping": { "1": "assetA", "3": "assetC" } }
+ *        Teams with no stored default are simply omitted from mapping.
+ *
+ *   PUT  /default-assets
+ *        body: { "apiUrl": "…", "teamId": "…", "assetId": "…" }
+ *        → { "saved": true, "teamId": "…", "assetId": "…" }
+ *
+ * Both routes require `Authorization: Bearer <Beacon access token>`.
+ */
+
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import crypto from 'crypto';
+import { verifyBeaconToken } from './verifyBeaconToken.mjs';
+
+// ── Config ──────────────────────────────────────────────────────────
+const BUCKET        = process.env.BUCKET_NAME   || 'lighthouse-default-assets';
+const CONFIG_PREFIX = process.env.CONFIG_PREFIX  || '';
+
+const s3 = new S3Client({});
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** Deterministic short hash of the API URL (namespace key). */
+function hashApiUrl(apiUrl) {
+    return crypto.createHash('sha256').update(apiUrl.trim().toLowerCase()).digest('hex').slice(0, 16);
+}
+
+/** Build the S3 object key for one team. */
+function s3Key(urlHash, teamId) {
+    const base = CONFIG_PREFIX ? `${CONFIG_PREFIX}/${urlHash}` : urlHash;
+    return `${base}/${teamId}.json`;
+}
+
+/** Read a single object; returns parsed JSON or null if missing. */
+async function getObject(key) {
+    try {
+        const res = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: key }));
+        const body = await streamToString(res.Body);
+        return JSON.parse(body);
+    } catch (err) {
+        const code = err.name || err.Code || '';
+        const status = err.$metadata?.httpStatusCode;
+        if (code === 'NoSuchKey' || code === 'NotFound' || status === 404 || status === 403) {
+            return null;
+        }
+        // Unexpected error — log but don't throw; treat as missing
+        console.warn('getObject unexpected error for key:', key, err);
+        return null;
+    }
+}
+
+/** Convert a readable stream to a string. */
+function streamToString(stream) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        stream.on('data', (c) => chunks.push(c));
+        stream.on('error', reject);
+        stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    });
+}
+
+/** Standard JSON response helper. */
+function respond(statusCode, body) {
+    return {
+        statusCode,
+        headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, PUT, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        },
+        body: JSON.stringify(body),
+    };
+}
+
+// ── Handler ─────────────────────────────────────────────────────────
+
+export const handler = async (event) => {
+    const method = event.httpMethod || event.requestContext?.http?.method || 'GET';
+
+    // CORS preflight
+    if (method === "OPTIONS") {
+        return respond(204, '');
+    }
+
+    try {
+        await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+    } catch (err) {
+        return respond(401, { error: 'Unauthorized', message: err?.message || String(err) });
+    }
+
+    try {
+        // ---------- GET: Bulk fetch for a list of team IDs ----------
+        if (method === 'GET') {
+            const qs = event.queryStringParameters || {};
+            const apiUrl  = qs.apiUrl;
+            const teamIds = qs.teamIds;
+
+            if (!apiUrl || !teamIds) {
+                return respond(400, { error: 'Missing required query params: apiUrl, teamIds' });
+            }
+
+            const urlHash = hashApiUrl(apiUrl);
+            const ids = teamIds.split(',').map(s => s.trim()).filter(Boolean);
+
+            if (ids.length === 0) {
+                return respond(200, { mapping: {} });
+            }
+
+            // Fan-out reads (S3 handles concurrency well at this scale)
+            const entries = await Promise.all(
+                ids.map(async (id) => {
+                    const data = await getObject(s3Key(urlHash, id));
+                    return data ? [id, data.assetId] : null;
+                })
+            );
+
+            const mapping = {};
+            for (const entry of entries) {
+                if (entry) mapping[entry[0]] = entry[1];
+            }
+
+            return respond(200, { mapping });
+        }
+
+        // ---------- PUT: Save a single mapping ----------
+        if (method === 'PUT') {
+            const body = typeof event.body === 'string' ? JSON.parse(event.body) : event.body;
+            const { apiUrl, teamId, assetId } = body || {};
+
+            if (!apiUrl || !teamId || !assetId) {
+                return respond(400, { error: 'Missing required fields: apiUrl, teamId, assetId' });
+            }
+
+            const urlHash = hashApiUrl(apiUrl);
+            const key = s3Key(urlHash, teamId);
+
+            const payload = {
+                teamId: String(teamId),
+                assetId: String(assetId),
+                updatedAt: new Date().toISOString(),
+            };
+
+            await s3.send(new PutObjectCommand({
+                Bucket: BUCKET,
+                Key: key,
+                Body: JSON.stringify(payload),
+                ContentType: 'application/json',
+            }));
+
+            return respond(200, { saved: true, teamId, assetId });
+        }
+
+        return respond(405, { error: `Method ${method} not allowed` });
+
+    } catch (err) {
+        console.error('Lambda error:', err);
+        return respond(500, { error: 'Internal server error' });
+    }
+};

--- a/lambda/geocode-v2/index.mjs
+++ b/lambda/geocode-v2/index.mjs
@@ -1,0 +1,101 @@
+import pkg from "@aws-sdk/client-geo-places";
+import { verifyBeaconToken } from "./verifyBeaconToken.mjs";
+
+const { GeoPlacesClient, GeocodeCommand, ReverseGeocodeCommand } = pkg;
+
+const client = new GeoPlacesClient({
+  region: process.env.AWS_REGION, // required for SigV4 endpoints; Lambda sets AWS_REGION
+});
+
+const corsHeaders = {
+  "content-type": "application/json; charset=utf-8",
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET,OPTIONS",
+  "access-control-allow-headers": "content-type,authorization",
+};
+
+const json = (statusCode, obj) => ({
+  statusCode,
+  headers: corsHeaders,
+  body: JSON.stringify(obj),
+});
+
+export const handler = async (event) => {
+  // CORS preflight
+  if (event?.httpMethod === "OPTIONS" || event.requestContext?.http?.method === "OPTIONS") {
+    return { statusCode: 204, headers: corsHeaders, body: "" };
+  }
+
+  try {
+    await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+  } catch (err) {
+    return json(401, { error: "Unauthorized", message: err?.message || String(err) });
+  }
+
+  const qsp = event?.queryStringParameters || {};
+
+  // Forward geocode: ?q=...
+  const q = typeof qsp.q === "string" ? qsp.q.trim() : "";
+
+  // Reverse geocode: ?lat=&lon=
+  const lat = Number(qsp.lat);
+  const lon = Number(qsp.lon);
+
+  const maxResults = (() => {
+    const mr = Number(qsp.maxResults);
+    return Number.isFinite(mr) && mr > 0 ? Math.min(mr, 100) : 10;
+  })();
+
+  try {
+    if (q) {
+      // Places v2 Geocode request fields: QueryText, BiasPosition, Filter.IncludeCountries, MaxResults, etc. :contentReference[oaicite:1]{index=1}
+      const cmd = new GeocodeCommand({
+        QueryText: q,
+        MaxResults: maxResults,
+        BiasPosition: [151.2093, -33.8688], // [lng, lat]
+        Filter: {
+          IncludeCountries: ["AUS"],
+        },
+        IntendedUse: "SingleUse",
+      });
+
+      const resp = await client.send(cmd);
+
+      return json(200, {
+        input: { q },
+        results: resp.ResultItems ?? [],
+      });
+    }
+
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+      return json(400, { error: "Provide either q=... or lat/lon numbers" });
+    }
+
+    // Places v2 ReverseGeocode request fields: QueryPosition, MaxResults, etc. :contentReference[oaicite:2]{index=2}
+    const cmd = new ReverseGeocodeCommand({
+      QueryPosition: [lon, lat], // [lng, lat]
+      MaxResults: maxResults,
+      Filter : {
+        IncludePlaceTypes: [
+          "PointAddress",
+          "Street",
+          "InterpolatedAddress"
+        ]
+      },
+      IntendedUse: "SingleUse",
+    });
+
+    const resp = await client.send(cmd);
+
+    return json(200, {
+      input: { lat, lon },
+      results: resp.ResultItems ?? [],
+    });
+  } catch (err) {
+    const message =
+      err && typeof err === "object" && "message" in err
+        ? String(err.message)
+        : "Unknown error";
+    return json(500, { error: "Places v2 request failed", message });
+  }
+};

--- a/lambda/map-layers-v2/handlers/createLayer.js
+++ b/lambda/map-layers-v2/handlers/createLayer.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const crypto = require('crypto');
+const { updateIndex, putLayerObject } = require('../lib/s3Store');
+const { json, badRequest } = require('../lib/response');
+
+// POST /map-layers   body: { apiUrl, name, createdBy }
+module.exports = async function createLayer(event) {
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return badRequest('Invalid JSON body');
+  }
+
+  const apiUrl = body.apiUrl;
+  const name = String(body.name || '').trim().slice(0, 200);
+  const createdBy = String(body.createdBy || '').slice(0, 100);
+
+  if (!apiUrl || !name) return badRequest('apiUrl and name are required');
+
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const summary = { id, name, createdBy, createdAt: now, lastUsedAt: now, markerCount: 0 };
+  const layer = { id, apiUrl, name, createdBy, createdAt: now, lastUsedAt: now, markers: [] };
+
+  await putLayerObject(apiUrl, id, layer);
+  await updateIndex(apiUrl, (index) => {
+    index.apiUrl = apiUrl;
+    index.layers.push(summary);
+  });
+
+  return json(201, summary);
+};

--- a/lambda/map-layers-v2/handlers/deleteFeature.js
+++ b/lambda/map-layers-v2/handlers/deleteFeature.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound } = require('../lib/response');
+
+// DELETE /map-layers/{id}/features/{markerId}?apiUrl=...&actorId=...
+// Soft-deletes the marker (sets deleted: true) rather than removing it, so
+// a concurrent stale edit can't resurrect a corrupted record and deletes
+// are recoverable by a human editing S3 directly if needed.
+module.exports = async function deleteFeature(event) {
+  const layerId = event.pathParameters?.id;
+  const markerId = event.pathParameters?.markerId;
+  const apiUrl = event.queryStringParameters?.apiUrl;
+  const actorId = String(event.queryStringParameters?.actorId || '').slice(0, 100);
+
+  if (!apiUrl || !layerId || !markerId) {
+    return badRequest('apiUrl, layer id and marker id are required');
+  }
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  const marker = layer.markers.find((m) => m.id === markerId);
+  if (!marker) return notFound('Marker not found');
+
+  const now = new Date().toISOString();
+  marker.deleted = true;
+  marker.updatedBy = actorId || marker.updatedBy;
+  marker.updatedAt = now;
+
+  layer.lastUsedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+
+  const markerCount = layer.markers.filter((m) => !m.deleted).length;
+  await updateIndex(apiUrl, (index) => {
+    const entry = index.layers.find((l) => l.id === layerId);
+    if (entry) {
+      entry.lastUsedAt = now;
+      entry.markerCount = markerCount;
+    }
+  });
+
+  return json(204, null);
+};

--- a/lambda/map-layers-v2/handlers/getLayer.js
+++ b/lambda/map-layers-v2/handlers/getLayer.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound } = require('../lib/response');
+
+// GET /map-layers/{id}?apiUrl=...
+// Returns the full layer (including markers) and bumps lastUsedAt --
+// viewing a layer counts as "use" so actively-watched-but-not-edited
+// layers don't age out of listLayers() mid-incident.
+module.exports = async function getLayer(event) {
+  const apiUrl = event.queryStringParameters?.apiUrl;
+  const layerId = event.pathParameters?.id;
+  if (!apiUrl || !layerId) return badRequest('apiUrl and layer id are required');
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  const now = new Date().toISOString();
+  layer.lastUsedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+  await updateIndex(apiUrl, (index) => {
+    const entry = index.layers.find((l) => l.id === layerId);
+    if (entry) entry.lastUsedAt = now;
+  });
+
+  return json(200, layer);
+};

--- a/lambda/map-layers-v2/handlers/listLayers.js
+++ b/lambda/map-layers-v2/handlers/listLayers.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { getJson, indexKey } = require('../lib/s3Store');
+const { json, badRequest } = require('../lib/response');
+
+const STALE_MS = 120 * 24 * 60 * 60 * 1000; // 120 days
+
+// GET /map-layers?apiUrl=...
+// Lists layers for an org, excluding any unused for 120+ days. The
+// underlying data is never deleted by this filter -- only omitted from
+// the listing.
+module.exports = async function listLayers(event) {
+  const apiUrl = event.queryStringParameters?.apiUrl;
+  if (!apiUrl) return badRequest('apiUrl is required');
+
+  const { data } = await getJson(indexKey(apiUrl));
+  const layers = (data?.layers || []).filter((l) => {
+    const lastUsed = new Date(l.lastUsedAt).getTime();
+    return Number.isFinite(lastUsed) && Date.now() - lastUsed <= STALE_MS;
+  });
+
+  return json(200, { layers });
+};

--- a/lambda/map-layers-v2/handlers/upsertFeature.js
+++ b/lambda/map-layers-v2/handlers/upsertFeature.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const crypto = require('crypto');
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound } = require('../lib/response');
+
+// Must stay in sync with the icon keys in
+// src/pages/tasking/components/collab_marker_icons.js (MARKER_ICON_GROUPS).
+const ICON_KEYS = new Set([
+  'fire', 'fire-extinguisher', 'water', 'house-damage', 'exclamation-triangle',
+  'skull-crossbones', 'biohazard', 'radiation', 'bolt', 'wind', 'smog',
+  'car-crash', 'tree', 'gas-pump', 'ban',
+  'ambulance', 'first-aid', 'hospital', 'user-md', 'user-injured', 'syringe',
+  'user', 'users', 'wheelchair', 'baby-carriage', 'paw',
+  'campground', 'home', 'warehouse', 'tint', 'shower',
+  'road', 'route', 'broadcast-tower', 'plug',
+  'truck', 'helicopter', 'ship', 'life-ring',
+  'map-marker-alt', 'flag', 'check-circle', 'question-circle',
+]);
+const DEFAULT_ICON = 'map-marker-alt';
+const HEX_COLOR = /^#[0-9a-fA-F]{3,8}$/;
+
+// PUT /map-layers/{id}/features   body: { apiUrl, marker: {id?, lat, lng, icon, fill, description}, actorId }
+// Missing/unknown marker.id creates a new marker; a known id overwrites it
+// (last-write-wins, same convention as the existing default-assets Lambda).
+module.exports = async function upsertFeature(event) {
+  const layerId = event.pathParameters?.id;
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return badRequest('Invalid JSON body');
+  }
+
+  const apiUrl = body.apiUrl;
+  const actorId = String(body.actorId || '').slice(0, 100);
+  const input = body.marker || {};
+
+  if (!apiUrl || !layerId) return badRequest('apiUrl and layer id are required');
+  if (typeof input.lat !== 'number' || typeof input.lng !== 'number') {
+    return badRequest('marker.lat and marker.lng must be numbers');
+  }
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  const now = new Date().toISOString();
+  const icon = ICON_KEYS.has(input.icon) ? input.icon : DEFAULT_ICON;
+  const fill = HEX_COLOR.test(input.fill || '') ? input.fill : '#2b7bbb';
+  const description = String(input.description || '').slice(0, 2000);
+
+  const existingIdx = input.id ? layer.markers.findIndex((m) => m.id === input.id) : -1;
+  let marker;
+
+  if (existingIdx >= 0) {
+    marker = {
+      ...layer.markers[existingIdx],
+      lat: input.lat,
+      lng: input.lng,
+      icon,
+      fill,
+      description,
+      updatedBy: actorId,
+      updatedAt: now,
+      deleted: false,
+    };
+    layer.markers[existingIdx] = marker;
+  } else {
+    marker = {
+      id: crypto.randomUUID(),
+      lat: input.lat,
+      lng: input.lng,
+      icon,
+      fill,
+      description,
+      createdBy: actorId,
+      createdAt: now,
+      updatedBy: actorId,
+      updatedAt: now,
+      deleted: false,
+    };
+    layer.markers.push(marker);
+  }
+
+  layer.lastUsedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+
+  const markerCount = layer.markers.filter((m) => !m.deleted).length;
+  await updateIndex(apiUrl, (index) => {
+    const entry = index.layers.find((l) => l.id === layerId);
+    if (entry) {
+      entry.lastUsedAt = now;
+      entry.markerCount = markerCount;
+    }
+  });
+
+  return json(200, marker);
+};

--- a/lambda/map-layers-v2/index.js
+++ b/lambda/map-layers-v2/index.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { json, serverError } = require('./lib/response');
+const { verifyBeaconToken } = require('./verifyBeaconToken');
+const listLayers = require('./handlers/listLayers');
+const createLayer = require('./handlers/createLayer');
+const getLayer = require('./handlers/getLayer');
+const upsertFeature = require('./handlers/upsertFeature');
+const deleteFeature = require('./handlers/deleteFeature');
+
+// Single Lambda fronting all /lad_v2/map-layers routes via API Gateway HTTP
+// API (payload format 2.0) Lambda proxy integration. Routed by
+// event.routeKey, which API Gateway sets to "<METHOD> <route path>" for
+// whichever route matched (e.g. "GET /lad_v2/map-layers/{id}"). Every route
+// except OPTIONS requires a valid `Authorization: Bearer <Beacon token>`
+// header, verified against SES's identity server (see
+// ./verifyBeaconToken.js).
+const ROUTES = {
+  'GET /lad_v2/map-layers': listLayers,
+  'POST /lad_v2/map-layers': createLayer,
+  'GET /lad_v2/map-layers/{id}': getLayer,
+  'PUT /lad_v2/map-layers/{id}/features': upsertFeature,
+  'DELETE /lad_v2/map-layers/{id}/features/{markerId}': deleteFeature,
+};
+
+exports.handler = async (event) => {
+  const method = event.requestContext?.http?.method;
+
+  if (method === 'OPTIONS') return json(204, null);
+
+  const routeKey = event.requestContext?.routeKey;
+  const handler = ROUTES[routeKey];
+
+  if (!handler) {
+    return json(404, { error: 'Not found', routeKey });
+  }
+
+  try {
+    await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+  } catch (err) {
+    return json(401, { error: 'Unauthorized', message: err?.message || String(err) });
+  }
+
+  try {
+    return await handler(event);
+  } catch (err) {
+    console.error('map-layers-v2 handler error:', err, JSON.stringify({ routeKey }));
+    return serverError();
+  }
+};

--- a/lambda/map-layers-v2/lib/response.js
+++ b/lambda/map-layers-v2/lib/response.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Locked down to the extension's own origin at deploy time is possible by
+// replacing '*' below, but the request itself is already scoped by apiUrl
+// (the org's Beacon source URL) so '*' matches the permissiveness of the
+// existing share / default-assets Lambdas this feature mirrors.
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+};
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+    body: body === null || body === undefined ? '' : JSON.stringify(body),
+  };
+}
+
+const badRequest = (message) => json(400, { error: message });
+const notFound = (message) => json(404, { error: message });
+const serverError = (message) => json(500, { error: message || 'Internal server error' });
+
+module.exports = { json, badRequest, notFound, serverError, CORS_HEADERS };

--- a/lambda/map-layers-v2/lib/s3Store.js
+++ b/lambda/map-layers-v2/lib/s3Store.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const crypto = require('crypto');
+const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3');
+
+const s3 = new S3Client({});
+const BUCKET = process.env.BUCKET_NAME;
+const S3_PREFIX = 'shared_layers';
+
+/** Namespace every org's layers under a hash of its Beacon apiUrl. */
+function orgPrefix(apiUrl) {
+  const hash = crypto.createHash('sha256').update(String(apiUrl)).digest('hex').slice(0, 24);
+  return `${S3_PREFIX}/${hash}`;
+}
+
+function indexKey(apiUrl) {
+  return `${orgPrefix(apiUrl)}/index.json`;
+}
+
+function layerKey(apiUrl, layerId) {
+  return `${orgPrefix(apiUrl)}/${layerId}.json`;
+}
+
+async function streamToString(stream) {
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/** Read a JSON object from S3. Returns { data: null, etag: null } if it doesn't exist yet. */
+async function getJson(key) {
+  try {
+    const res = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: key }));
+    const body = await streamToString(res.Body);
+    return { data: JSON.parse(body), etag: res.ETag };
+  } catch (err) {
+    if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) {
+      return { data: null, etag: null };
+    }
+    throw err;
+  }
+}
+
+async function putJson(key, data, { ifMatch, ifNoneMatch } = {}) {
+  const params = {
+    Bucket: BUCKET,
+    Key: key,
+    Body: JSON.stringify(data),
+    ContentType: 'application/json',
+  };
+  if (ifMatch) params.IfMatch = ifMatch;
+  if (ifNoneMatch) params.IfNoneMatch = ifNoneMatch;
+  await s3.send(new PutObjectCommand(params));
+}
+
+/**
+ * Read-modify-write the small per-org index.json with optimistic
+ * concurrency (S3 conditional writes) + a short retry loop, since it's the
+ * one object concurrent requests (e.g. two users creating a layer at the
+ * same moment) could race on. Individual layer objects are only ever
+ * written by requests for that one layer, so they don't need this.
+ */
+async function updateIndex(apiUrl, mutate, { retries = 3 } = {}) {
+  const key = indexKey(apiUrl);
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const { data, etag } = await getJson(key);
+    const index = data || { apiUrl, layers: [] };
+    const result = mutate(index);
+    try {
+      await putJson(key, index, etag ? { ifMatch: etag } : { ifNoneMatch: '*' });
+      return result;
+    } catch (err) {
+      const status = err.$metadata?.httpStatusCode;
+      if (status === 412 && attempt < retries) continue; // lost the race, retry
+      throw err;
+    }
+  }
+  throw new Error(`updateIndex: exhausted retries for ${key}`);
+}
+
+async function getLayerObject(apiUrl, layerId) {
+  const { data } = await getJson(layerKey(apiUrl, layerId));
+  if (!data || data.apiUrl !== apiUrl) return null; // not found, or belongs to a different org
+  return data;
+}
+
+async function putLayerObject(apiUrl, layerId, layer) {
+  await putJson(layerKey(apiUrl, layerId), layer);
+}
+
+module.exports = { orgPrefix, indexKey, layerKey, getJson, putJson, updateIndex, getLayerObject, putLayerObject };

--- a/lambda/map-layers/.gitignore
+++ b/lambda/map-layers/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.zip

--- a/lambda/map-layers/README.md
+++ b/lambda/map-layers/README.md
@@ -1,0 +1,306 @@
+# Map Layers Lambda
+
+Backend for the tasking map's collaborative map layers feature: lists/creates
+layers and reads/writes their markers, all stored as JSON objects in S3. No
+database — this mirrors the existing `share` and `default-assets` Lambdas the
+extension already calls at `https://lambda.lighthouse-extension.com/lad/...`.
+
+Frontend code that calls this: `src/pages/tasking/utils/collabLayerSync.js`
+(`LAMBDA_BASE = 'https://lambda.lighthouse-extension.com/lad/map-layers'`).
+
+## Routes
+
+| Method | Path                              | Purpose                                    |
+|--------|------------------------------------|---------------------------------------------|
+| GET    | `/lad/map-layers?apiUrl=`              | List an org's layers (excludes 120+ day idle ones) |
+| POST   | `/lad/map-layers`                      | Create a new named layer                    |
+| GET    | `/lad/map-layers/{id}?apiUrl=`         | Get a layer + its markers, bumps `lastUsedAt` |
+| PUT    | `/lad/map-layers/{id}/features`        | Create or edit a marker (last-write-wins)   |
+| DELETE | `/lad/map-layers/{id}/features/{markerId}?apiUrl=&actorId=` | Soft-delete a marker |
+
+The `/lad` prefix is part of the route paths themselves (not added by a
+custom domain base path mapping) — see the API Gateway section below.
+
+All five are served by **one** Lambda function (`index.js` routes internally
+on `event.requestContext.routeKey`). Data is namespaced per org under a hash
+of `apiUrl` (the org's Beacon source URL) — see `lib/s3Store.js`.
+
+Nothing here ever hard-deletes a layer or deletes S3 objects; the 120-day
+rule only excludes stale layers from the list response.
+
+**No AWS CLI needed** — everything below is done through the AWS Management
+Console in your browser. The one convenient shortcut: Lambda's Node.js 20.x
+and 22.x managed runtimes ship with the AWS SDK for JavaScript v3
+pre-installed, so `@aws-sdk/client-s3` doesn't need to be bundled — you can
+paste the source files straight into the Lambda console's built-in code
+editor with no zip/upload step.
+
+## 1. Create the S3 bucket
+
+1. Open the **S3 console** → **Create bucket**.
+2. **Bucket name**: something globally unique, e.g. `lighthouse-map-layers`
+   (write it down — you'll need it as an environment variable later).
+3. **AWS Region**: pick the same region you'll use for the Lambda/API Gateway
+   (match whatever region `lambda.lighthouse-extension.com` already runs in).
+4. **Block Public Access settings**: leave all four boxes checked (the
+   default) — this bucket is only ever read/written by the Lambda, never
+   public.
+5. **Bucket Versioning**: optional but recommended — turning it on gives you
+   an undo button if a bug ever corrupts a layer's JSON. Not required for
+   the app to work.
+6. Leave everything else default and click **Create bucket**.
+
+**Do not** add a lifecycle rule that expires/deletes objects under
+`shared_layers/` — the 120-day rule is a *listing* filter enforced in
+`handlers/listLayers.js`, not an S3-level delete. "Data not deleted" is a
+hard product requirement.
+
+## 2. Create the Lambda function
+
+1. Open the **Lambda console** → **Create function**.
+2. Choose **Author from scratch**.
+3. **Function name**: `lighthouse-map-layers`.
+4. **Runtime**: **Node.js 20.x** (or 22.x if offered).
+5. **Architecture**: leave as `x86_64`.
+6. Under **Permissions**, leave "Create a new role with basic Lambda
+   permissions" selected — this auto-creates an execution role with just
+   CloudWatch Logs access; you'll add S3 access to it in step 3.
+7. Click **Create function**.
+
+### Add the code
+
+The console's **Code source** panel starts with a single `index.js`. You
+need to recreate this project's file layout inside it:
+
+```
+index.js
+lib/response.js
+lib/s3Store.js
+handlers/listLayers.js
+handlers/createLayer.js
+handlers/getLayer.js
+handlers/upsertFeature.js
+handlers/deleteFeature.js
+```
+
+For each file other than `index.js`:
+
+1. In the file tree, click the **File** menu (or right-click the file list)
+   → **New File**.
+2. Type the full path including folders, e.g. `lib/response.js` — the
+   console creates the `lib` folder automatically.
+3. Paste in the contents of that file from this repo (`lambda/map-layers/`).
+
+For `index.js`, delete the placeholder content and paste in this repo's
+`index.js`.
+
+Once all 7 files are in place, click the orange **Deploy** button above the
+code editor — nothing you paste takes effect until you deploy.
+
+### Environment variable
+
+1. Go to the **Configuration** tab → **Environment variables** → **Edit**.
+2. **Add environment variable**: key `BUCKET_NAME`, value = the bucket name
+   from step 1 (e.g. `lighthouse-map-layers`).
+3. **Save**.
+
+### Timeout and memory (optional but recommended)
+
+1. **Configuration** tab → **General configuration** → **Edit**.
+2. Set **Timeout** to `10 sec` and **Memory** to `256 MB` (defaults of 3 sec
+   / 128 MB are tight once S3 round-trips are involved).
+3. **Save**.
+
+## 3. Give the function's role S3 access
+
+1. Still in the Lambda function, go to **Configuration** → **Permissions**.
+2. Click the **Role name** link (opens IAM in a new tab).
+3. On the role's page, **Add permissions** → **Create inline policy**.
+4. Switch to the **JSON** tab and paste (replace `YOUR_BUCKET_NAME`):
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Sid": "MapLayersS3Access",
+         "Effect": "Allow",
+         "Action": ["s3:GetObject", "s3:PutObject"],
+         "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME/shared_layers/*"
+       },
+       {
+         "Sid": "MapLayersS3List",
+         "Effect": "Allow",
+         "Action": "s3:ListBucket",
+         "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME",
+         "Condition": {
+           "StringLike": { "s3:prefix": "shared_layers/*" }
+         }
+       }
+     ]
+   }
+   ```
+
+   The `ListBucket` statement is easy to skip but is required: when
+   `GetObject` is called on a key that doesn't exist yet (e.g. the very
+   first request for a brand-new org, before its `index.json` has been
+   created), S3 returns `403 AccessDenied` instead of `404 NoSuchKey`
+   *unless* the caller also has `s3:ListBucket` on the bucket — otherwise it
+   won't tell you whether the object is missing or you're just not allowed
+   to see it. Without this statement you'll see errors like
+   `AccessDenied: ... not authorized to perform: s3:ListBucket` in
+   CloudWatch Logs the first time any org is used. `ListBucket` is a
+   bucket-level action so it needs the **bucket's** ARN (no trailing
+   `/shared_layers/*`), scoped back down to just that prefix via the
+   `s3:prefix` condition so the role still can't list the rest of the
+   bucket.
+
+   (CloudWatch Logs permissions are already on the role from the
+   auto-created "basic Lambda permissions" policy — no need to add those.)
+5. Click **Next**, give the policy a name like `map-layers-s3-access`, then
+   **Create policy**.
+
+## 4. Wire it into API Gateway
+
+You already have an HTTP API serving `lambda.lighthouse-extension.com/lad/...`
+for the `share` and `default-assets` routes. Add these five routes to that
+**same API** so `map-layers` shares the existing custom domain and
+certificate, rather than standing up a second one.
+
+1. Open the **API Gateway console** → find your existing API (the one
+   behind `share`/`default-assets`) → open it.
+2. In the left nav, go to **Integrations** → **Create**.
+3. Choose **Lambda** as the integration type, pick the region and select
+   `lighthouse-map-layers` as the function, then **Create**. (API Gateway
+   automatically grants this integration permission to invoke the
+   function — no separate permissions step needed, unlike the CLI/SDK
+   path.)
+4. Go to **Routes** → **Create** and add each of these five routes one at a
+   time (method + path exactly as shown, **including** the `/lad` prefix —
+   these routes live under `/lad/` directly, it isn't added later by a base
+   path mapping):
+   - `GET /lad/map-layers`
+   - `POST /lad/map-layers`
+   - `GET /lad/map-layers/{id}`
+   - `PUT /lad/map-layers/{id}/features`
+   - `DELETE /lad/map-layers/{id}/features/{markerId}`
+5. For **each** route, click it, then **Attach integration** and pick the
+   Lambda integration you created in step 3 (all five routes share the one
+   integration — that's expected, `index.js` internally routes by
+   `event.requestContext.routeKey`).
+6. If the API's default stage has **Auto-deploy** enabled (check under
+   **Stages** → `$default`), the new routes go live immediately. If not,
+   go to **Deploy** and deploy to `$default`.
+
+Since `/lad` is baked into the route paths, check the API's **Custom domain
+names** → `lambda.lighthouse-extension.com` → **API mappings**: the mapping
+for this API should have an **empty/root Path** (not `lad`), otherwise
+requests would need to go to `/lad/lad/map-layers`. If the existing mapping
+already has a `lad` path in front of routes defined *without* the prefix
+(i.e. `share`'s route is just `/share`), that mapping is serving a different
+routing convention than these new routes use — in that case, add a
+**second** API mapping for this API with an empty Path instead of reusing
+the existing one.
+
+### If you don't have an existing `/lad` API yet
+
+1. **API Gateway console** → **Create API** → **HTTP API** → **Build**.
+2. **Add integration**: Lambda, select `lighthouse-map-layers` → **Next**.
+3. Add the five routes (method + path from the table above, including the
+   `/lad` prefix) → **Next**.
+4. Stage: keep `$default` with **Auto-deploy** enabled → **Next** → **Create**.
+5. **Custom domain names** → **Create** → domain name
+   `lambda.lighthouse-extension.com`, select or request an ACM certificate
+   for that domain in the same region → **Create domain name**.
+6. On the new domain name's **API mappings** tab → **Configure API mappings**
+   → **Add new mapping** → select your API, stage `$default`, leave **Path**
+   empty (the `/lad` prefix is already part of the routes) → **Save**.
+7. Point your DNS (Route 53 or wherever the domain is hosted) at the domain
+   name's **API Gateway domain name** (regional endpoint), shown on the
+   custom domain's **Configurations** tab — usually an A/ALIAS record in
+   Route 53, or a CNAME elsewhere.
+
+### CORS
+
+Enable CORS at the API level rather than relying on the Lambda's own CORS
+headers (which are still there as a harmless fallback):
+
+1. Open your API in **API Gateway** → **CORS** (left nav) → **Configure**.
+2. **Access-Control-Allow-Origin**: `*`
+3. **Access-Control-Allow-Headers**: `Content-Type`
+4. **Access-Control-Allow-Methods**: `GET, POST, PUT, DELETE, OPTIONS`
+5. **Save**.
+
+With this enabled, API Gateway answers `OPTIONS` preflight requests itself
+— you don't need to create explicit `OPTIONS` routes.
+
+## 5. Test it
+
+**Quickest option — Lambda console's built-in Test feature**, which invokes
+the function directly without going through API Gateway at all:
+
+1. On the function's page, go to the **Test** tab.
+2. **Create new event**, paste an event JSON shaped like this (this example
+   tests `createLayer`):
+
+   ```json
+   {
+     "requestContext": {
+       "http": { "method": "POST" },
+       "routeKey": "POST /lad/map-layers"
+     },
+     "body": "{\"apiUrl\":\"https://your-org.beacon.example.org\",\"name\":\"Test Layer\",\"createdBy\":\"tester\"}"
+   }
+   ```
+
+3. **Test** → check the returned JSON has `statusCode: 201` and a `body`
+   containing the new layer's `id`.
+4. To test `listLayers`, use:
+
+   ```json
+   {
+     "requestContext": {
+       "http": { "method": "GET" },
+       "routeKey": "GET /lad/map-layers"
+     },
+     "queryStringParameters": { "apiUrl": "https://your-org.beacon.example.org" }
+   }
+   ```
+
+   and confirm the layer you created shows up in `body`.
+
+**Through the real URL**, once routes are deployed:
+
+- `GET` requests can be tested by pasting the URL straight into a browser
+  tab, e.g.:
+  `https://lambda.lighthouse-extension.com/lad/map-layers?apiUrl=https://your-org.beacon.example.org`
+- For `POST`/`PUT`/`DELETE` (which need a JSON body), use a tool like
+  [Postman](https://www.postman.com/) or Insomnia rather than a browser —
+  point it at the same URL, method, and a JSON body matching the shapes in
+  the routes table above.
+
+## Notes
+
+- **Concurrency**: the per-org `index.json` (layer list/summaries) uses S3
+  conditional writes (`IfMatch`/`IfNoneMatch`) with a 3-attempt retry to
+  survive two users creating/updating layers at the same moment. Individual
+  layer/marker writes are last-write-wins (no retry needed — only one
+  request at a time touches a given layer object in the update path).
+- **Validation**: handlers clamp string lengths (name ≤200 chars,
+  description ≤2000 chars) and validate `icon` against a fixed allow-list
+  (`ICON_KEYS` in `handlers/upsertFeature.js`, kept in sync with
+  `src/pages/tasking/components/collab_marker_icons.js`) and `fill` against
+  a hex-color pattern, but there's no hard cap on markers-per-layer or
+  layers-per-org — add one in `handlers/createLayer.js` /
+  `handlers/upsertFeature.js` if you
+  need it.
+- **SDK version**: relying on the Lambda runtime's pre-installed AWS SDK
+  (rather than bundling your own `node_modules`) means the SDK version can
+  shift when AWS updates the managed runtime. Fine for this workload; if you
+  ever want a pinned version, you'd need to package `node_modules` into a
+  zip and upload that instead of using the inline code editor.
+- **Logs**: `console.error` calls land in the function's CloudWatch Logs —
+  from the function's page, **Monitor** tab → **View CloudWatch logs**.
+- **Cost**: this is a low-traffic, tiny-payload workload (S3 GET/PUT + a
+  small Lambda) — expect it to sit well within the AWS free tier for any
+  realistic number of concurrent incidents/users.

--- a/lambda/map-layers/handlers/createLayer.js
+++ b/lambda/map-layers/handlers/createLayer.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const crypto = require('crypto');
+const { updateIndex, putLayerObject } = require('../lib/s3Store');
+const { json, badRequest } = require('../lib/response');
+
+// POST /map-layers   body: { apiUrl, name, createdBy }
+module.exports = async function createLayer(event) {
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return badRequest('Invalid JSON body');
+  }
+
+  const apiUrl = body.apiUrl;
+  const name = String(body.name || '').trim().slice(0, 200);
+  const createdBy = String(body.createdBy || '').slice(0, 100);
+
+  if (!apiUrl || !name) return badRequest('apiUrl and name are required');
+
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const summary = { id, name, createdBy, createdAt: now, lastUsedAt: now, markerCount: 0 };
+  const layer = { id, apiUrl, name, createdBy, createdAt: now, lastUsedAt: now, markers: [] };
+
+  await putLayerObject(apiUrl, id, layer);
+  await updateIndex(apiUrl, (index) => {
+    index.apiUrl = apiUrl;
+    index.layers.push(summary);
+  });
+
+  return json(201, summary);
+};

--- a/lambda/map-layers/handlers/deleteFeature.js
+++ b/lambda/map-layers/handlers/deleteFeature.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound } = require('../lib/response');
+
+// DELETE /map-layers/{id}/features/{markerId}?apiUrl=...&actorId=...
+// Soft-deletes the marker (sets deleted: true) rather than removing it, so
+// a concurrent stale edit can't resurrect a corrupted record and deletes
+// are recoverable by a human editing S3 directly if needed.
+module.exports = async function deleteFeature(event) {
+  const layerId = event.pathParameters?.id;
+  const markerId = event.pathParameters?.markerId;
+  const apiUrl = event.queryStringParameters?.apiUrl;
+  const actorId = String(event.queryStringParameters?.actorId || '').slice(0, 100);
+
+  if (!apiUrl || !layerId || !markerId) {
+    return badRequest('apiUrl, layer id and marker id are required');
+  }
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  const marker = layer.markers.find((m) => m.id === markerId);
+  if (!marker) return notFound('Marker not found');
+
+  const now = new Date().toISOString();
+  marker.deleted = true;
+  marker.updatedBy = actorId || marker.updatedBy;
+  marker.updatedAt = now;
+
+  layer.lastUsedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+
+  const markerCount = layer.markers.filter((m) => !m.deleted).length;
+  await updateIndex(apiUrl, (index) => {
+    const entry = index.layers.find((l) => l.id === layerId);
+    if (entry) {
+      entry.lastUsedAt = now;
+      entry.markerCount = markerCount;
+    }
+  });
+
+  return json(204, null);
+};

--- a/lambda/map-layers/handlers/getLayer.js
+++ b/lambda/map-layers/handlers/getLayer.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound } = require('../lib/response');
+
+// GET /map-layers/{id}?apiUrl=...
+// Returns the full layer (including markers) and bumps lastUsedAt --
+// viewing a layer counts as "use" so actively-watched-but-not-edited
+// layers don't age out of listLayers() mid-incident.
+module.exports = async function getLayer(event) {
+  const apiUrl = event.queryStringParameters?.apiUrl;
+  const layerId = event.pathParameters?.id;
+  if (!apiUrl || !layerId) return badRequest('apiUrl and layer id are required');
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  const now = new Date().toISOString();
+  layer.lastUsedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+  await updateIndex(apiUrl, (index) => {
+    const entry = index.layers.find((l) => l.id === layerId);
+    if (entry) entry.lastUsedAt = now;
+  });
+
+  return json(200, layer);
+};

--- a/lambda/map-layers/handlers/listLayers.js
+++ b/lambda/map-layers/handlers/listLayers.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { getJson, indexKey } = require('../lib/s3Store');
+const { json, badRequest } = require('../lib/response');
+
+const STALE_MS = 120 * 24 * 60 * 60 * 1000; // 120 days
+
+// GET /map-layers?apiUrl=...
+// Lists layers for an org, excluding any unused for 120+ days. The
+// underlying data is never deleted by this filter -- only omitted from
+// the listing.
+module.exports = async function listLayers(event) {
+  const apiUrl = event.queryStringParameters?.apiUrl;
+  if (!apiUrl) return badRequest('apiUrl is required');
+
+  const { data } = await getJson(indexKey(apiUrl));
+  const layers = (data?.layers || []).filter((l) => {
+    const lastUsed = new Date(l.lastUsedAt).getTime();
+    return Number.isFinite(lastUsed) && Date.now() - lastUsed <= STALE_MS;
+  });
+
+  return json(200, { layers });
+};

--- a/lambda/map-layers/handlers/upsertFeature.js
+++ b/lambda/map-layers/handlers/upsertFeature.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const crypto = require('crypto');
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound } = require('../lib/response');
+
+// Must stay in sync with the icon keys in
+// src/pages/tasking/components/collab_marker_icons.js (MARKER_ICON_GROUPS).
+const ICON_KEYS = new Set([
+  'fire', 'fire-extinguisher', 'water', 'house-damage', 'exclamation-triangle',
+  'skull-crossbones', 'biohazard', 'radiation', 'bolt', 'wind', 'smog',
+  'car-crash', 'tree', 'gas-pump', 'ban',
+  'ambulance', 'first-aid', 'hospital', 'user-md', 'user-injured', 'syringe',
+  'user', 'users', 'wheelchair', 'baby-carriage', 'paw',
+  'campground', 'home', 'warehouse', 'tint', 'shower',
+  'road', 'route', 'broadcast-tower', 'plug',
+  'truck', 'helicopter', 'ship', 'life-ring',
+  'map-marker-alt', 'flag', 'check-circle', 'question-circle',
+]);
+const DEFAULT_ICON = 'map-marker-alt';
+const HEX_COLOR = /^#[0-9a-fA-F]{3,8}$/;
+
+// PUT /map-layers/{id}/features   body: { apiUrl, marker: {id?, lat, lng, icon, fill, description}, actorId }
+// Missing/unknown marker.id creates a new marker; a known id overwrites it
+// (last-write-wins, same convention as the existing default-assets Lambda).
+module.exports = async function upsertFeature(event) {
+  const layerId = event.pathParameters?.id;
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return badRequest('Invalid JSON body');
+  }
+
+  const apiUrl = body.apiUrl;
+  const actorId = String(body.actorId || '').slice(0, 100);
+  const input = body.marker || {};
+
+  if (!apiUrl || !layerId) return badRequest('apiUrl and layer id are required');
+  if (typeof input.lat !== 'number' || typeof input.lng !== 'number') {
+    return badRequest('marker.lat and marker.lng must be numbers');
+  }
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  const now = new Date().toISOString();
+  const icon = ICON_KEYS.has(input.icon) ? input.icon : DEFAULT_ICON;
+  const fill = HEX_COLOR.test(input.fill || '') ? input.fill : '#2b7bbb';
+  const description = String(input.description || '').slice(0, 2000);
+
+  const existingIdx = input.id ? layer.markers.findIndex((m) => m.id === input.id) : -1;
+  let marker;
+
+  if (existingIdx >= 0) {
+    marker = {
+      ...layer.markers[existingIdx],
+      lat: input.lat,
+      lng: input.lng,
+      icon,
+      fill,
+      description,
+      updatedBy: actorId,
+      updatedAt: now,
+      deleted: false,
+    };
+    layer.markers[existingIdx] = marker;
+  } else {
+    marker = {
+      id: crypto.randomUUID(),
+      lat: input.lat,
+      lng: input.lng,
+      icon,
+      fill,
+      description,
+      createdBy: actorId,
+      createdAt: now,
+      updatedBy: actorId,
+      updatedAt: now,
+      deleted: false,
+    };
+    layer.markers.push(marker);
+  }
+
+  layer.lastUsedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+
+  const markerCount = layer.markers.filter((m) => !m.deleted).length;
+  await updateIndex(apiUrl, (index) => {
+    const entry = index.layers.find((l) => l.id === layerId);
+    if (entry) {
+      entry.lastUsedAt = now;
+      entry.markerCount = markerCount;
+    }
+  });
+
+  return json(200, marker);
+};

--- a/lambda/map-layers/index.js
+++ b/lambda/map-layers/index.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { json, serverError } = require('./lib/response');
+const listLayers = require('./handlers/listLayers');
+const createLayer = require('./handlers/createLayer');
+const getLayer = require('./handlers/getLayer');
+const upsertFeature = require('./handlers/upsertFeature');
+const deleteFeature = require('./handlers/deleteFeature');
+
+// Single Lambda fronting all /lad/map-layers routes via API Gateway HTTP
+// API (payload format 2.0) Lambda proxy integration. Routed by
+// event.routeKey, which API Gateway sets to "<METHOD> <route path>" for
+// whichever route matched (e.g. "GET /lad/map-layers/{id}") -- see the
+// README for how these routes are created. The routes themselves are
+// defined with the "/lad" prefix (matching the other Lighthouse Lambdas at
+// lambda.lighthouse-extension.com/lad/...), not added by a base path
+// mapping, so the custom domain's API mapping should not add another one.
+const ROUTES = {
+  'GET /lad/map-layers': listLayers,
+  'POST /lad/map-layers': createLayer,
+  'GET /lad/map-layers/{id}': getLayer,
+  'PUT /lad/map-layers/{id}/features': upsertFeature,
+  'DELETE /lad/map-layers/{id}/features/{markerId}': deleteFeature,
+};
+
+exports.handler = async (event) => {
+  const method = event.requestContext?.http?.method;
+
+  if (method === 'OPTIONS') return json(204, null);
+
+  const routeKey = event.requestContext?.routeKey;
+  const handler = ROUTES[routeKey];
+
+  if (!handler) {
+    return json(404, { error: 'Not found', routeKey });
+  }
+
+  try {
+    return await handler(event);
+  } catch (err) {
+    console.error('map-layers handler error:', err, JSON.stringify({ routeKey }));
+    return serverError();
+  }
+};

--- a/lambda/map-layers/lib/response.js
+++ b/lambda/map-layers/lib/response.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Locked down to the extension's own origin at deploy time is possible by
+// replacing '*' below, but the request itself is already scoped by apiUrl
+// (the org's Beacon source URL) so '*' matches the permissiveness of the
+// existing share / default-assets Lambdas this feature mirrors.
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+};
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+    body: body === null || body === undefined ? '' : JSON.stringify(body),
+  };
+}
+
+const badRequest = (message) => json(400, { error: message });
+const notFound = (message) => json(404, { error: message });
+const serverError = (message) => json(500, { error: message || 'Internal server error' });
+
+module.exports = { json, badRequest, notFound, serverError, CORS_HEADERS };

--- a/lambda/map-layers/lib/s3Store.js
+++ b/lambda/map-layers/lib/s3Store.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const crypto = require('crypto');
+const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3');
+
+const s3 = new S3Client({});
+const BUCKET = process.env.BUCKET_NAME;
+const S3_PREFIX = 'shared_layers';
+
+/** Namespace every org's layers under a hash of its Beacon apiUrl. */
+function orgPrefix(apiUrl) {
+  const hash = crypto.createHash('sha256').update(String(apiUrl)).digest('hex').slice(0, 24);
+  return `${S3_PREFIX}/${hash}`;
+}
+
+function indexKey(apiUrl) {
+  return `${orgPrefix(apiUrl)}/index.json`;
+}
+
+function layerKey(apiUrl, layerId) {
+  return `${orgPrefix(apiUrl)}/${layerId}.json`;
+}
+
+async function streamToString(stream) {
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/** Read a JSON object from S3. Returns { data: null, etag: null } if it doesn't exist yet. */
+async function getJson(key) {
+  try {
+    const res = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: key }));
+    const body = await streamToString(res.Body);
+    return { data: JSON.parse(body), etag: res.ETag };
+  } catch (err) {
+    if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) {
+      return { data: null, etag: null };
+    }
+    throw err;
+  }
+}
+
+async function putJson(key, data, { ifMatch, ifNoneMatch } = {}) {
+  const params = {
+    Bucket: BUCKET,
+    Key: key,
+    Body: JSON.stringify(data),
+    ContentType: 'application/json',
+  };
+  if (ifMatch) params.IfMatch = ifMatch;
+  if (ifNoneMatch) params.IfNoneMatch = ifNoneMatch;
+  await s3.send(new PutObjectCommand(params));
+}
+
+/**
+ * Read-modify-write the small per-org index.json with optimistic
+ * concurrency (S3 conditional writes) + a short retry loop, since it's the
+ * one object concurrent requests (e.g. two users creating a layer at the
+ * same moment) could race on. Individual layer objects are only ever
+ * written by requests for that one layer, so they don't need this.
+ */
+async function updateIndex(apiUrl, mutate, { retries = 3 } = {}) {
+  const key = indexKey(apiUrl);
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const { data, etag } = await getJson(key);
+    const index = data || { apiUrl, layers: [] };
+    const result = mutate(index);
+    try {
+      await putJson(key, index, etag ? { ifMatch: etag } : { ifNoneMatch: '*' });
+      return result;
+    } catch (err) {
+      const status = err.$metadata?.httpStatusCode;
+      if (status === 412 && attempt < retries) continue; // lost the race, retry
+      throw err;
+    }
+  }
+  throw new Error(`updateIndex: exhausted retries for ${key}`);
+}
+
+async function getLayerObject(apiUrl, layerId) {
+  const { data } = await getJson(layerKey(apiUrl, layerId));
+  if (!data || data.apiUrl !== apiUrl) return null; // not found, or belongs to a different org
+  return data;
+}
+
+async function putLayerObject(apiUrl, layerId, layer) {
+  await putJson(layerKey(apiUrl, layerId), layer);
+}
+
+module.exports = { orgPrefix, indexKey, layerKey, getJson, putJson, updateIndex, getLayerObject, putLayerObject };

--- a/lambda/map-layers/package.json
+++ b/lambda/map-layers/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lighthouse-map-layers-lambda",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Lambda backend for the Lighthouse tasking map's collaborative map layers feature (list/create layers, read/write markers) backed by S3.",
+  "main": "index.js",
+  "scripts": {
+    "package": "npm ci --omit=dev && rm -rf dist && mkdir -p dist && zip -r dist/function.zip index.js lib handlers node_modules package.json"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.658.0"
+  }
+}

--- a/lambda/route-v2/index.mjs
+++ b/lambda/route-v2/index.mjs
@@ -1,0 +1,95 @@
+import { GeoRoutesClient, CalculateRoutesCommand } from "@aws-sdk/client-geo-routes";
+import { verifyBeaconToken } from "./verifyBeaconToken.mjs";
+
+const client = new GeoRoutesClient({});
+
+const CORS_HEADERS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "OPTIONS,POST",
+  "access-control-allow-headers": "content-type,authorization",
+};
+
+function json(statusCode, obj) {
+  return {
+    statusCode,
+    headers: { "content-type": "application/json", ...CORS_HEADERS },
+    body: JSON.stringify(obj),
+  };
+}
+
+function mapTravelMode(v) {
+  // v2 valid values: Car | Pedestrian | Scooter | Truck :contentReference[oaicite:3]{index=3}
+  if (!v) return "Car";
+  const x = String(v).toLowerCase();
+  if (x === "walking" || x === "walk" || x === "pedestrian") return "Pedestrian";
+  if (x === "car") return "Car";
+  if (x === "truck") return "Truck";
+  if (x === "scooter") return "Scooter";
+  return "Car";
+}
+
+export const handler = async (event) => {
+  if (event.requestContext?.http?.method === "OPTIONS") {
+    return { statusCode: 204, headers: CORS_HEADERS, body: "" };
+  }
+
+  try {
+    await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+  } catch (err) {
+    return json(401, { error: "Unauthorized", message: err?.message || String(err) });
+  }
+
+  let body;
+  try {
+    body = event.body ? JSON.parse(event.body) : {};
+  } catch {
+    return json(400, { error: "Invalid JSON body" });
+  }
+
+  const coordinates = body.coordinates;
+  if (!Array.isArray(coordinates) || coordinates.length < 2) {
+    return json(400, { error: "coordinates must be an array of at least 2 [lng,lat] points" });
+  }
+  for (const c of coordinates) {
+    if (!Array.isArray(c) || c.length !== 2 || typeof c[0] !== "number" || typeof c[1] !== "number") {
+      return json(400, { error: "each coordinate must be [lng:number, lat:number]" });
+    }
+  }
+
+  const origin = coordinates[0];
+  const destination = coordinates[coordinates.length - 1];
+  const waypoints = coordinates.slice(1, -1).map((pos) => ({ Position: pos }));
+
+  const travelMode = mapTravelMode(body.travelMode);
+
+  // Request:
+  // - leg geometry so you can draw the line (Simple => LineString is returned) :contentReference[oaicite:4]{index=4}
+  // - travel step instructions (gives Instruction strings) :contentReference[oaicite:5]{index=5}
+  // - span features Distance/Names/RouteNumbers for "via M1" computation :contentReference[oaicite:6]{index=6}
+  const cmd = new CalculateRoutesCommand({
+    Origin: origin,
+    Destination: destination,
+    ...(waypoints.length ? { Waypoints: waypoints } : {}),
+    TravelMode: travelMode,
+
+    DepartNow: body.departNow === true ? true : undefined,
+    DepartureTime: body.departureTime || undefined,
+
+    LegGeometryFormat: "Simple",
+    //TravelStepType: "Default",
+    MaxAlternatives: body.maxAlternatives || 0,
+    LegAdditionalFeatures: [],
+    //SpanAdditionalFeatures: ["Distance", "Names", "RouteNumbers"],
+  });
+
+  try {
+    const resp = await client.send(cmd);
+    return json(200, resp?.Routes)
+  } catch (err) {
+    console.error(err);
+    return json(500, {
+      error: "Route calculation failed",
+      detail: err?.name || err?.message || "unknown",
+    });
+  }
+};

--- a/lambda/share-v2/index.mjs
+++ b/lambda/share-v2/index.mjs
@@ -1,0 +1,206 @@
+// index.mjs
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand
+} from "@aws-sdk/client-s3";
+import { verifyBeaconToken } from "./verifyBeaconToken.mjs";
+
+const s3 = new S3Client({});
+const BUCKET_NAME = process.env.BUCKET_NAME;
+const CONFIG_PREFIX = process.env.CONFIG_PREFIX || "";
+
+const SHARED_PREFS_PREFIX = buildBasePrefix(CONFIG_PREFIX, "shared_prefs");
+
+export const handler = async (event) => {
+  try {
+    const method = event.requestContext?.http?.method || "GET";
+    const query = event.queryStringParameters || {};
+    const rawBody = event.body;
+
+    if (method === "OPTIONS") {
+      const reqHeaders =
+        event.headers?.["access-control-request-headers"] ||
+        event.headers?.["Access-Control-Request-Headers"];
+
+      return {
+        statusCode: 204,
+        headers: {
+          ...corsHeaders(reqHeaders),
+          "Access-Control-Max-Age": "86400"
+        },
+        body: ""
+      };
+    }
+
+    try {
+      await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+    } catch (err) {
+      return {
+        statusCode: 401,
+        headers: corsHeaders(),
+        body: JSON.stringify({ message: "Unauthorized", error: err?.message || String(err) })
+      };
+    }
+
+    if (method === "POST" && !query.id) {
+      return await handleCreateConfig(rawBody);
+    }
+
+    if (method === "GET" && query.id) {
+      return await handleGetConfig(query.id);
+    }
+
+    return {
+      statusCode: 400,
+      headers: corsHeaders(),
+      body: JSON.stringify({ message: "Unsupported request" })
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      headers: corsHeaders(),
+      body: JSON.stringify({
+        message: "Internal Server Error",
+        error: err?.message || String(err)
+      })
+    };
+  }
+};
+
+function corsHeaders(requestedHeaders) {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "OPTIONS,GET,POST",
+    "Access-Control-Allow-Headers": requestedHeaders || "Content-Type, Authorization"
+  };
+}
+
+function buildBasePrefix(...parts) {
+  return parts
+    .filter(Boolean)
+    .map((p) => String(p).replace(/^\/+|\/+$/g, ""))
+    .filter(Boolean)
+    .join("/") + "/";
+}
+
+const ALPHABET = "234679ACDEFGHJKMNPQRTUVWXYZ";
+
+function generateId() {
+  let out = "";
+  for (let i = 0; i < 4; i++) {
+    out += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
+  }
+  return out;
+}
+
+function buildConfigKey(id) {
+  return `${SHARED_PREFS_PREFIX}${id}.json`;
+}
+
+async function handleCreateConfig(rawBody) {
+  if (!rawBody) {
+    return {
+      statusCode: 400,
+      headers: corsHeaders(),
+      body: JSON.stringify({ message: "Missing body" })
+    };
+  }
+
+  let config;
+  try {
+    const parsed = JSON.parse(rawBody);
+    config = parsed.config ?? parsed;
+  } catch {
+    return {
+      statusCode: 400,
+      headers: corsHeaders(),
+      body: JSON.stringify({ message: "Invalid JSON body" })
+    };
+  }
+
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return {
+      statusCode: 400,
+      headers: corsHeaders(),
+      body: JSON.stringify({ message: "Missing or invalid config" })
+    };
+  }
+
+  const id = generateId();
+  const key = buildConfigKey(id);
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET_NAME,
+      Key: key,
+      Body: JSON.stringify(config),
+      ContentType: "application/json"
+    })
+  );
+
+  return {
+    statusCode: 201,
+    headers: { ...corsHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify({ id })
+  };
+}
+
+async function handleGetConfig(id) {
+  const key = buildConfigKey(id);
+
+  try {
+    const result = await s3.send(
+      new GetObjectCommand({
+        Bucket: BUCKET_NAME,
+        Key: key
+      })
+    );
+
+    const bodyString = await streamToString(result.Body);
+
+    let config;
+    try {
+      config = JSON.parse(bodyString);
+    } catch {
+      return {
+        statusCode: 500,
+        headers: corsHeaders(),
+        body: JSON.stringify({ message: "Stored config is invalid JSON" })
+      };
+    }
+
+    return {
+      statusCode: 200,
+      headers: { ...corsHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ config })
+    };
+  } catch (err) {
+    if (err.name === "NoSuchKey" || err.$metadata?.httpStatusCode === 404) {
+      return {
+        statusCode: 404,
+        headers: corsHeaders(),
+        body: JSON.stringify({ message: "Config not found" })
+      };
+    }
+
+    console.error(err);
+    return {
+      statusCode: 500,
+      headers: corsHeaders(),
+      body: JSON.stringify({ message: "Error fetching config" })
+    };
+  }
+}
+
+function streamToString(stream) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    stream.on("data", (chunk) => chunks.push(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf-8"));
+    });
+  });
+}

--- a/lambda/shared/verifyBeaconToken.js
+++ b/lambda/shared/verifyBeaconToken.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// SES's Beacon identity server (Duende/IdentityServer4). Configured via
+// deployment env vars, never derived from the token or request, so a
+// caller can't point verification at a JWKS they control.
+const TRUSTED_ISS = process.env.TRUSTED_ISS;
+const JWKS_URI = process.env.JWKS_URI;
+const EXPECTED_AUD = process.env.EXPECTED_AUD;
+const REQUIRED_SCOPE = 'beaconApi';
+
+// jose ships ESM-only; a CommonJS module has to load it via dynamic
+// import(), which Node supports from CJS too. Cached in module scope so it
+// only happens once per warm Lambda instance.
+let josePromise;
+function loadJose() {
+  if (!josePromise) josePromise = import('jose');
+  return josePromise;
+}
+
+let jwksPromise;
+function getJwks() {
+  if (!jwksPromise) {
+    jwksPromise = loadJose().then(({ createRemoteJWKSet }) => createRemoteJWKSet(new URL(JWKS_URI)));
+  }
+  return jwksPromise;
+}
+
+/**
+ * Verify an `Authorization: Bearer <token>` header is a currently-valid
+ * Beacon access token. Throws on any failure; returns the token's claims
+ * on success.
+ */
+async function verifyBeaconToken(authorizationHeader) {
+  const match = /^Bearer (.+)$/.exec(authorizationHeader || '');
+  if (!match) throw new Error('Missing or malformed Authorization header');
+
+  const [{ jwtVerify }, jwks] = await Promise.all([loadJose(), getJwks()]);
+
+  const { payload } = await jwtVerify(match[1], jwks, {
+    issuer: TRUSTED_ISS,
+    audience: EXPECTED_AUD,
+    algorithms: ['RS256'],
+  });
+
+  const scopes = Array.isArray(payload.scope) ? payload.scope : String(payload.scope || '').split(' ');
+  if (!scopes.includes(REQUIRED_SCOPE)) {
+    throw new Error(`Token missing required scope: ${REQUIRED_SCOPE}`);
+  }
+
+  return payload;
+}
+
+module.exports = { verifyBeaconToken };

--- a/lambda/shared/verifyBeaconToken.mjs
+++ b/lambda/shared/verifyBeaconToken.mjs
@@ -1,0 +1,35 @@
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+// SES's Beacon identity server (Duende/IdentityServer4). Configured via
+// deployment env vars, never derived from the token or request, so a
+// caller can't point verification at a JWKS they control.
+const TRUSTED_ISS = process.env.TRUSTED_ISS;
+const JWKS_URI = process.env.JWKS_URI;
+const EXPECTED_AUD = process.env.EXPECTED_AUD;
+const REQUIRED_SCOPE = 'beaconApi';
+
+// Module-scope: persists (and caches fetched keys) across warm invocations.
+const JWKS = createRemoteJWKSet(new URL(JWKS_URI));
+
+/**
+ * Verify an `Authorization: Bearer <token>` header is a currently-valid
+ * Beacon access token. Throws on any failure; returns the token's claims
+ * on success.
+ */
+export async function verifyBeaconToken(authorizationHeader) {
+  const match = /^Bearer (.+)$/.exec(authorizationHeader || '');
+  if (!match) throw new Error('Missing or malformed Authorization header');
+
+  const { payload } = await jwtVerify(match[1], JWKS, {
+    issuer: TRUSTED_ISS,
+    audience: EXPECTED_AUD,
+    algorithms: ['RS256'],
+  });
+
+  const scopes = Array.isArray(payload.scope) ? payload.scope : String(payload.scope || '').split(' ');
+  if (!scopes.includes(REQUIRED_SCOPE)) {
+    throw new Error(`Token missing required scope: ${REQUIRED_SCOPE}`);
+  }
+
+  return payload;
+}

--- a/src/contentscripts/jobs/create.js
+++ b/src/contentscripts/jobs/create.js
@@ -32,6 +32,9 @@ window.addEventListener("message", function(event) {
       $('#nearest-lhq-text').text('Searching...')
       $('#nearest-rescue-lhq-text').text('Searching...')
       $('#nearest-rescue-drive-lhq-text').text('Searching...')
+      // Sent by injectscripts/jobs/create.js, which runs in the page's own
+      // JS context and already has `user.accessToken` available directly.
+      const token = event.data.token;
       $.getJSON(chrome.runtime.getURL("resources/SES_HQs.geojson"), function (data) {
         let distances = []
         let rescueDistances = []
@@ -143,9 +146,12 @@ window.addEventListener("message", function(event) {
 
                 let promise = new Promise((resolve, reject) => {
                   $.ajax({
-                    url: "https://lambda.lighthouse-extension.com/lad/route",
+                    url: "https://lambda.lighthouse-extension.com/lad_v2/route",
                     method: "POST",
                     contentType: "application/json",
+                    beforeSend: function (n) {
+                      if (token) n.setRequestHeader('Authorization', 'Bearer ' + token);
+                    },
                     data: body,
                     dataType: "json",
                     success: function(data) {

--- a/src/injectscripts/jobs/create.js
+++ b/src/injectscripts/jobs/create.js
@@ -241,6 +241,7 @@ $(document).ready(function () {
                   report: accreditations,
                   lat: vm.latitude.peek(),
                   lng: vm.longitude.peek(),
+                  token: user.accessToken,
                 },
                 '*',
               );
@@ -253,6 +254,7 @@ $(document).ready(function () {
                 report: accreditations,
                 lat: vm.latitude.peek(),
                 lng: vm.longitude.peek(),
+                token: user.accessToken,
               },
               '*',
             );
@@ -266,6 +268,7 @@ $(document).ready(function () {
               report: null,
               lat: vm.latitude.peek(),
               lng: vm.longitude.peek(),
+              token: user.accessToken,
             },
             '*',
           );
@@ -287,6 +290,7 @@ $(document).ready(function () {
                   report: accreditations,
                   lat: vm.latitude.peek(),
                   lng: vm.longitude.peek(),
+                  token: user.accessToken,
                 },
                 '*',
               );
@@ -299,6 +303,7 @@ $(document).ready(function () {
                 report: accreditations,
                 lat: vm.latitude.peek(),
                 lng: vm.longitude.peek(),
+                token: user.accessToken,
               },
               '*',
             );
@@ -312,6 +317,7 @@ $(document).ready(function () {
               report: null,
               lat: vm.latitude.peek(),
               lng: vm.longitude.peek(),
+              token: user.accessToken,
             },
             '*',
           );
@@ -334,6 +340,7 @@ $(document).ready(function () {
                   report: accreditations,
                   lat: vm.latitude.peek(),
                   lng: vm.longitude.peek(),
+                  token: user.accessToken,
                 },
                 '*',
               );
@@ -346,6 +353,7 @@ $(document).ready(function () {
                 report: accreditations,
                 lat: vm.latitude.peek(),
                 lng: vm.longitude.peek(),
+                token: user.accessToken,
               },
               '*',
             );
@@ -359,6 +367,7 @@ $(document).ready(function () {
               report: null,
               lat: vm.latitude.peek(),
               lng: vm.longitude.peek(),
+              token: user.accessToken,
             },
             '*',
           );
@@ -442,6 +451,7 @@ $(document).ready(function () {
                   report: accreditations,
                   lat: newAddress.latitude,
                   lng: newAddress.longitude,
+                  token: user.accessToken,
                 },
                 '*',
               );
@@ -454,6 +464,7 @@ $(document).ready(function () {
                 report: accreditations,
                 lat: newAddress.latitude,
                 lng: newAddress.longitude,
+                token: user.accessToken,
               },
               '*',
             );
@@ -466,6 +477,7 @@ $(document).ready(function () {
               report: null,
               lat: newAddress.latitude,
               lng: newAddress.longitude,
+              token: user.accessToken,
             },
             '*',
           );

--- a/src/injectscripts/jobs/view.js
+++ b/src/injectscripts/jobs/view.js
@@ -663,8 +663,9 @@ function renderNearestAssets({ teamFilter, activeOnly, resultsToDisplay, cb }) {
                 }
 
                 const router = new AmazonLocationRouter({
-                  serviceUrl: "https://lambda.lighthouse-extension.com/lad/route",
+                  serviceUrl: "https://lambda.lighthouse-extension.com/lad_v2/route",
                   travelMode: "Car",
+                  headers: { Authorization: "Bearer " + user.accessToken },
                 });
 
                 var routingControl = L.Routing.control({

--- a/src/pages/tasking/components/mapContextMenu.js
+++ b/src/pages/tasking/components/mapContextMenu.js
@@ -36,12 +36,13 @@ const createJobUrl = (result) => {
 
 export function installMapContextMenu({
     map,
-    geocodeEndpoint = 'https://lambda.lighthouse-extension.com/lad/geocode',
+    geocodeEndpoint = 'https://lambda.lighthouse-extension.com/lad_v2/geocode',
     geocodeMarkerIcon = null,            // pass your defaultSvgIcon if you want
     geocodeRedMarkerIcon = null,         // pass your defaultRedSvgIcon if you want
     geocodeMaxResults = 10,
     canAddMarker = null,                 // () => boolean -- show/hide the "Add marker" item
     onAddMarker = null,                  // (latlng) => void -- invoked when it's clicked
+    getToken = null,                     // () => Promise<string> -- Beacon access token
 }) {
     const ctxMenu = document.getElementById("mapContextMenu");
     const btnSearch = document.getElementById("ctxSearchHere");
@@ -143,7 +144,11 @@ export function installMapContextMenu({
             url.searchParams.set('lat', String(lastLatLng.lat));
             url.searchParams.set('lon', String(lastLatLng.lng));
 
-            const res = await fetch(url.toString(), { method: 'GET' });
+            const token = getToken ? await getToken() : null;
+            const res = await fetch(url.toString(), {
+                method: 'GET',
+                headers: token ? { Authorization: `Bearer ${token}` } : {},
+            });
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             json = await res.json();
         } catch (e) {

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -33,7 +33,7 @@ import { registerAcronymTextBinding } from "./components/acronymText.js";
 
 import { Asset } from './models/Asset.js';
 import { Tasking } from './models/Tasking.js';
-import { Team, bumpDefaultAssetTick, setDefaultAssetApiUrl } from './models/Team.js';
+import { Team, bumpDefaultAssetTick, setDefaultAssetApiUrl, setDefaultAssetTokenGetter } from './models/Team.js';
 import { Job } from './models/Job.js';
 import { Sector } from './models/Sector.js';
 import { Tag } from "./models/Tag.js";
@@ -206,6 +206,7 @@ const markerActorId = params.personId;
 
 // Tell Team model which API URL to use for shared default-asset pushes
 setDefaultAssetApiUrl(sourceUrl);
+setDefaultAssetTokenGetter(() => getToken());
 
 var ko;
 var myViewModel;
@@ -232,10 +233,11 @@ const map = L.map('map', {
 
 installMapContextMenu({
     map,
-    geocodeEndpoint: 'https://lambda.lighthouse-extension.com/lad/geocode',
+    geocodeEndpoint: 'https://lambda.lighthouse-extension.com/lad_v2/geocode',
     geocodeMarkerIcon: defaultSvgIcon,
     geocodeRedMarkerIcon: defaultRedSvgIcon,
     geocodeMaxResults: 10,
+    getToken,
     onGeocodeResultClicked: (_r) => {
         // TODO: replace with real action
     },
@@ -244,7 +246,7 @@ installMapContextMenu({
     // callbacks only run later, on an actual right-click, by which point
     // it's fully populated.
     canAddMarker: () => getVisibleCollabLayers(myViewModel).length > 0,
-    onAddMarker: (latlng) => startAddMarkerFlow(myViewModel, sourceUrl, markerActorId, latlng),
+    onAddMarker: (latlng) => startAddMarkerFlow(myViewModel, sourceUrl, markerActorId, latlng, getToken),
 });
 
 
@@ -270,7 +272,8 @@ const polylineMeasure = L.control.polylineMeasure({
 polylineMeasure.addTo(map);
 
 const geocoder = new AwsLambdaGeocoderProvider({
-    endpoint: 'https://lambda.lighthouse-extension.com/lad/geocode',
+    endpoint: 'https://lambda.lighthouse-extension.com/lad_v2/geocode',
+    getToken,
 });
 
 const searchControl = new GeoSearchControl({
@@ -375,6 +378,11 @@ esri.basemapLayer('Topographic', { ignoreDeprecationWarning: true }).addTo(map);
 function VM() {
 
     const self = this;
+
+    // Exposed so nested viewmodels/utils that already hold a reference to
+    // the root VM (e.g. MapVM's `root` param) can get the current Beacon
+    // token without threading a new constructor param through every layer.
+    self.getToken = getToken;
 
     self.mapVM = new MapVM(map, self);
 
@@ -1383,6 +1391,7 @@ function VM() {
             });
         },
         fetchAllSectors: (hqs) => self.fetchAllSectors(hqs),
+        getToken: () => getToken(),
         apiUrl: sourceUrl,
         userId: params.userId,
     };
@@ -1944,7 +1953,8 @@ function VM() {
 
         if (multiAssetTeamIds.length === 0) return;
 
-        fetchSharedDefaults(sourceUrl, multiAssetTeamIds)
+        getToken()
+            .then(token => fetchSharedDefaults(sourceUrl, multiAssetTeamIds, token))
             .then(() => {
                 // Force all Team.defaultAsset() computeds to re-evaluate
                 bumpDefaultAssetTick();
@@ -3022,7 +3032,7 @@ function VM() {
     registerBOMFloodWarningBoundariesLayer(self, sourceUrl);
     registerBOMFireWeatherDistrictsLayer(self, sourceUrl);
     registerRainRadarLayer(self, map);
-    registerCollabLayers(self, sourceUrl, markerActorId);
+    registerCollabLayers(self, sourceUrl, markerActorId, getToken);
 
     // --- Layers Drawer (under zoom)
     const LayersDrawer = L.Control.extend({

--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -40,15 +40,15 @@ function visibleCollabLayers(vm) {
  * getOverlayDefsForControl — no separate "enabled set" is needed since
  * polling is a no-op while the layer isn't visible.
  */
-function registerLayerPolling(vm, apiUrl, layer, actorId) {
+function registerLayerPolling(vm, apiUrl, layer, actorId, getToken) {
     const key = layerKeyFor(layer.id);
     vm.mapVM.registerPollingLayer(key, {
         label: layer.name,
         menuGroup: "Collaborative Layers",
         refreshMs: REFRESH_MS,
         visibleByDefault: false,
-        fetchFn: () => fetchLayerMarkers(apiUrl, layer.id),
-        drawFn: (layerGroup, data) => drawCollabMarkers(vm, layerGroup, data, apiUrl, layer.id, key, actorId),
+        fetchFn: async () => fetchLayerMarkers(apiUrl, layer.id, await getToken()),
+        drawFn: (layerGroup, data) => drawCollabMarkers(vm, layerGroup, data, apiUrl, layer.id, key, actorId, getToken),
     });
 }
 
@@ -57,10 +57,10 @@ function registerLayerPolling(vm, apiUrl, layer, actorId) {
  * MapVM for the config modal to bind to, and register/refresh polling
  * layers for any layer not already registered.
  */
-export async function refreshCollabLayerList(vm, apiUrl, actorId) {
-    const layers = await listLayers(apiUrl);
+export async function refreshCollabLayerList(vm, apiUrl, actorId, getToken) {
+    const layers = await listLayers(apiUrl, await getToken());
     vm.mapVM.collabLayers(layers);
-    layers.forEach((layer) => registerLayerPolling(vm, apiUrl, layer, actorId));
+    layers.forEach((layer) => registerLayerPolling(vm, apiUrl, layer, actorId, getToken));
     vm.mapVM.layersDrawer?.refresh?.();
     return layers;
 }
@@ -72,30 +72,30 @@ export async function refreshCollabLayerList(vm, apiUrl, actorId) {
  * components/mapContextMenu.js + startAddMarkerFlow/getVisibleCollabLayers
  * above) rather than a second contextmenu listener here.
  */
-export async function registerCollabLayers(vm, apiUrl, actorId) {
-    await refreshCollabLayerList(vm, apiUrl, actorId);
+export async function registerCollabLayers(vm, apiUrl, actorId, getToken) {
+    await refreshCollabLayerList(vm, apiUrl, actorId, getToken);
 }
 
 /** Create a new named layer, register its polling layer immediately, and refresh the drawer. */
-export async function createCollabLayer(vm, apiUrl, name, actorId) {
-    const layer = await createLayer(apiUrl, name, actorId);
+export async function createCollabLayer(vm, apiUrl, name, actorId, getToken) {
+    const layer = await createLayer(apiUrl, name, actorId, await getToken());
     if (!layer) return null;
     const list = vm.mapVM.collabLayers();
     vm.mapVM.collabLayers([...list, layer]);
-    registerLayerPolling(vm, apiUrl, layer, actorId);
+    registerLayerPolling(vm, apiUrl, layer, actorId, getToken);
     vm.mapVM.layersDrawer?.refresh?.();
     return layer;
 }
 
 // ── Drawing ──────────────────────────────────────────────────────────
 
-function drawCollabMarkers(vm, layerGroup, data, apiUrl, layerId, key, actorId) {
+function drawCollabMarkers(vm, layerGroup, data, apiUrl, layerId, key, actorId, getToken) {
     const markers = (data?.markers || []).filter((m) => !m.deleted);
     markers.forEach((marker) => {
         const icon = buildMarkerBadgeIcon({ icon: marker.icon, fill: marker.fill || DEFAULT_FILL });
 
         const leafletMarker = L.marker([marker.lat, marker.lng], { icon });
-        leafletMarker.bindPopup(() => buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId), {
+        leafletMarker.bindPopup(() => buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken), {
             minWidth: 240,
             maxWidth: 280,
         });
@@ -106,7 +106,7 @@ function drawCollabMarkers(vm, layerGroup, data, apiUrl, layerId, key, actorId) 
 // Any marker on a visible layer can be edited/deleted -- protection against
 // accidental changes comes from requiring an explicit Edit/Delete button
 // click (and a confirm step for delete), not from a separate "edit mode".
-function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId) {
+function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken) {
     const el = document.createElement("div");
     el.className = "collab-marker-popup";
 
@@ -137,7 +137,7 @@ function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId) {
 
     editBtn.addEventListener("click", () => {
         vm.mapVM.map.closePopup();
-        openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, L.latLng(marker.lat, marker.lng));
+        openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, L.latLng(marker.lat, marker.lng), getToken);
     });
 
     deleteBtn.addEventListener("click", () => {
@@ -149,7 +149,7 @@ function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId) {
         actionsBox.classList.remove("d-none");
     });
     confirmDeleteBtn.addEventListener("click", async () => {
-        await deleteMarker(apiUrl, layerId, marker.id, actorId);
+        await deleteMarker(apiUrl, layerId, marker.id, actorId, await getToken());
         vm.mapVM.refreshPollingLayer(key);
     });
 
@@ -200,7 +200,7 @@ function buildColorSwatchesHtml(selectedFill) {
  * popup's own content -- so opening/closing either one never changes the
  * popup's size or makes it reposition itself.
  */
-function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng) {
+function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getToken) {
     let icon = marker?.icon || DEFAULT_MARKER_ICON_KEY;
     let fill = marker?.fill || DEFAULT_FILL;
 
@@ -295,7 +295,7 @@ function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng) {
             description,
         };
         vm.mapVM.map.closePopup(popup);
-        await upsertMarker(apiUrl, layerId, payload, actorId);
+        await upsertMarker(apiUrl, layerId, payload, actorId, await getToken());
         vm.mapVM.refreshPollingLayer(key);
     });
 }
@@ -372,7 +372,7 @@ function closeContextMenu() {
     }
 }
 
-function showLayerPickerMenu(vm, apiUrl, actorId, layers, containerPoint, latlng) {
+function showLayerPickerMenu(vm, apiUrl, actorId, layers, containerPoint, latlng, getToken) {
     closeContextMenu();
 
     const map = vm.mapVM.map;
@@ -403,7 +403,7 @@ function showLayerPickerMenu(vm, apiUrl, actorId, layers, containerPoint, latlng
         item.title = layer.name;
         item.addEventListener("click", () => {
             closeContextMenu();
-            openMarkerForm(vm, apiUrl, layer.id, layerKeyFor(layer.id), actorId, null, latlng);
+            openMarkerForm(vm, apiUrl, layer.id, layerKeyFor(layer.id), actorId, null, latlng, getToken);
         });
         itemsBox.appendChild(item);
     });
@@ -435,17 +435,17 @@ export function getVisibleCollabLayers(vm) {
  * than one, shows a small picker so the user chooses which layer receives
  * the new marker.
  */
-export function startAddMarkerFlow(vm, apiUrl, actorId, latlng) {
+export function startAddMarkerFlow(vm, apiUrl, actorId, latlng, getToken) {
     closeContextMenu();
 
     const visible = visibleCollabLayers(vm);
     if (visible.length === 0) return;
 
     if (visible.length === 1) {
-        openMarkerForm(vm, apiUrl, visible[0].id, layerKeyFor(visible[0].id), actorId, null, latlng);
+        openMarkerForm(vm, apiUrl, visible[0].id, layerKeyFor(visible[0].id), actorId, null, latlng, getToken);
         return;
     }
 
     const containerPoint = vm.mapVM.map.latLngToContainerPoint(latlng);
-    showLayerPickerMenu(vm, apiUrl, actorId, visible, containerPoint, latlng);
+    showLayerPickerMenu(vm, apiUrl, actorId, visible, containerPoint, latlng, getToken);
 }

--- a/src/pages/tasking/models/Team.js
+++ b/src/pages/tasking/models/Team.js
@@ -50,6 +50,12 @@ let _apiUrl = null;
 /** Called once from main.js after params are resolved. */
 export function setDefaultAssetApiUrl(url) { _apiUrl = url; }
 
+/** Async getter for the current Beacon access token, e.g. `() => getToken()`. */
+let _getToken = null;
+
+/** Called once from main.js after params are resolved. */
+export function setDefaultAssetTokenGetter(getTokenFn) { _getToken = getTokenFn; }
+
 function _setDefaultAsset(teamId, assetId) {
     const map = loadSharedMapping();
 
@@ -72,8 +78,8 @@ function _setDefaultAsset(teamId, assetId) {
     _defaultAssetTick(_defaultAssetTick() + 1);
 
     // Push to Lambda / S3 backend so other browsers pick it up (fire-and-forget)
-    if (_apiUrl) {
-        pushSharedDefault(_apiUrl, teamId, assetId);
+    if (_apiUrl && _getToken) {
+        Promise.resolve(_getToken()).then((token) => pushSharedDefault(_apiUrl, teamId, assetId, token));
     }
 }
 
@@ -160,7 +166,8 @@ export function Team(data = {}, deps = {}) {
     self.trackableAssets.subscribe(assets => {
         if (assets.length > 1 && !_hadMultipleAssets && _apiUrl) {
             _hadMultipleAssets = true;
-            fetchSharedDefaults(_apiUrl, [String(self.id())])
+            Promise.resolve(_getToken?.())
+                .then(token => fetchSharedDefaults(_apiUrl, [String(self.id())], token))
                 .then(() => _defaultAssetTick(_defaultAssetTick() + 1))
                 .catch(() => { /* im not empty i promise */ });
         } else if (assets.length <= 1) {
@@ -258,7 +265,8 @@ export function Team(data = {}, deps = {}) {
         self.refreshData();
 
         if (_apiUrl && (self.trackableAssets?.() || []).length > 1) {
-            fetchSharedDefaults(_apiUrl, [String(self.id())])
+            Promise.resolve(_getToken?.())
+                .then(token => fetchSharedDefaults(_apiUrl, [String(self.id())], token))
                 .then(() => _defaultAssetTick(_defaultAssetTick() + 1))
                 .catch(() => {/* im not empty i promise */});
         }
@@ -288,7 +296,8 @@ export function Team(data = {}, deps = {}) {
 
         // If this team has multiple assets, refresh shared default mapping
         if (_apiUrl && (self.trackableAssets?.() || []).length > 1) {
-            fetchSharedDefaults(_apiUrl, [String(self.id())])
+            Promise.resolve(_getToken?.())
+                .then(token => fetchSharedDefaults(_apiUrl, [String(self.id())], token))
                 .then(() => _defaultAssetTick(_defaultAssetTick() + 1))
                 .catch(() => {/* im not empty i promise */});
         }

--- a/src/pages/tasking/utils/batchRoute.js
+++ b/src/pages/tasking/utils/batchRoute.js
@@ -12,7 +12,7 @@
  * @module batchRoute
  */
 
-const ROUTE_URL = "https://lambda.lighthouse-extension.com/lad/route";
+const ROUTE_URL = "https://lambda.lighthouse-extension.com/lad_v2/route";
 
 /**
  * @typedef {Object} RouteSummary
@@ -31,12 +31,14 @@ const ROUTE_URL = "https://lambda.lighthouse-extension.com/lad/route";
  * @param {number}  [opts.timeoutMs=10000]     Per-request timeout.
  * @param {AbortSignal} [opts.signal]          Optional abort signal to
  *   cancel all in-flight requests.
+ * @param {() => Promise<string>} [opts.getToken]  Beacon access token getter.
  * @returns {Promise<(RouteSummary|null)[]>}
  *   Array aligned with `pairs`.  Each entry is either a summary object or
  *   `null` if that individual route failed.
  */
 export async function batchRoute(pairs, opts = {}) {
-    const { travelMode = "Car", timeoutMs = 10000, signal } = opts;
+    const { travelMode = "Car", timeoutMs = 10000, signal, getToken } = opts;
+    const token = getToken ? await getToken() : null;
 
     const promises = pairs.map(({ fromLat, fromLng, toLat, toLng }) => {
         const controller = new AbortController();
@@ -57,7 +59,10 @@ export async function batchRoute(pairs, opts = {}) {
 
         return fetch(ROUTE_URL, {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: {
+                "content-type": "application/json",
+                ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            },
             body: JSON.stringify(payload),
             signal: controller.signal,
         })

--- a/src/pages/tasking/utils/collabLayerSync.js
+++ b/src/pages/tasking/utils/collabLayerSync.js
@@ -11,7 +11,7 @@
  * before firing the remote write.
  */
 
-const LAMBDA_BASE = 'https://lambda.lighthouse-extension.com/lad/map-layers';
+const LAMBDA_BASE = 'https://lambda.lighthouse-extension.com/lad_v2/map-layers';
 
 const LS_INDEX_KEY = 'lh_collabLayers_index'; // cached layer list for the current org
 const layerCacheKey = (layerId) => `lh_collabLayer_${layerId}`;
@@ -57,14 +57,15 @@ function saveCachedLayer(layerId, layer) {
  * List collaborative layers for an org (layers unused for 120+ days are
  * excluded server-side, not deleted).
  * @param {string} apiUrl
+ * @param {string} token  Beacon access token (Authorization: Bearer).
  * @returns {Promise<Array<Object>>}
  */
-export async function listLayers(apiUrl) {
+export async function listLayers(apiUrl, token) {
     if (!apiUrl) return loadCachedLayerIndex();
 
     try {
         const url = `${LAMBDA_BASE}?apiUrl=${encodeURIComponent(apiUrl)}`;
-        const res = await fetch(url, { method: 'GET', headers: { Accept: 'application/json' } });
+        const res = await fetch(url, { method: 'GET', headers: { Accept: 'application/json', Authorization: `Bearer ${token}` } });
         if (!res.ok) {
             console.warn('[collabLayerSync] list failed:', res.status);
             return loadCachedLayerIndex();
@@ -83,16 +84,17 @@ export async function listLayers(apiUrl) {
  * @param {string} apiUrl
  * @param {string} name
  * @param {string} actorId
+ * @param {string} token  Beacon access token (Authorization: Bearer).
  * @returns {Promise<Object|null>} the created layer summary, or null on failure
  */
-export async function createLayer(apiUrl, name, actorId) {
+export async function createLayer(apiUrl, name, actorId, token) {
     const trimmed = (name || '').trim();
     if (!apiUrl || !trimmed) return null;
 
     try {
         const res = await fetch(LAMBDA_BASE, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
             body: JSON.stringify({ apiUrl, name: trimmed, createdBy: String(actorId) }),
         });
         if (!res.ok) {
@@ -119,14 +121,15 @@ export async function createLayer(apiUrl, name, actorId) {
  * layer won't age out of listLayers()).
  * @param {string} apiUrl
  * @param {string} layerId
+ * @param {string} token  Beacon access token (Authorization: Bearer).
  * @returns {Promise<Object|null>} the layer, including its markers array
  */
-export async function fetchLayerMarkers(apiUrl, layerId) {
+export async function fetchLayerMarkers(apiUrl, layerId, token) {
     if (!apiUrl || !layerId) return loadCachedLayer(layerId);
 
     try {
         const url = `${LAMBDA_BASE}/${encodeURIComponent(layerId)}?apiUrl=${encodeURIComponent(apiUrl)}`;
-        const res = await fetch(url, { method: 'GET', headers: { Accept: 'application/json' } });
+        const res = await fetch(url, { method: 'GET', headers: { Accept: 'application/json', Authorization: `Bearer ${token}` } });
         if (!res.ok) {
             console.warn('[collabLayerSync] fetchLayerMarkers failed:', res.status);
             return loadCachedLayer(layerId);
@@ -147,9 +150,10 @@ export async function fetchLayerMarkers(apiUrl, layerId) {
  * @param {string} layerId
  * @param {{id?: string, lat: number, lng: number, shape: string, fill: string, stroke: string, description: string}} marker
  * @param {string} actorId
+ * @param {string} token  Beacon access token (Authorization: Bearer).
  * @returns {Promise<Object|null>} the saved marker (with server-assigned id/timestamps), or null on failure
  */
-export async function upsertMarker(apiUrl, layerId, marker, actorId) {
+export async function upsertMarker(apiUrl, layerId, marker, actorId, token) {
     if (!apiUrl || !layerId || !marker) return null;
 
     // Optimistic local update
@@ -176,7 +180,7 @@ export async function upsertMarker(apiUrl, layerId, marker, actorId) {
     try {
         const res = await fetch(`${LAMBDA_BASE}/${encodeURIComponent(layerId)}/features`, {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
             body: JSON.stringify({ apiUrl, marker, actorId: String(actorId) }),
         });
         if (!res.ok) {
@@ -205,9 +209,10 @@ export async function upsertMarker(apiUrl, layerId, marker, actorId) {
  * @param {string} layerId
  * @param {string} markerId
  * @param {string} actorId
+ * @param {string} token  Beacon access token (Authorization: Bearer).
  * @returns {Promise<void>}
  */
-export async function deleteMarker(apiUrl, layerId, markerId, actorId) {
+export async function deleteMarker(apiUrl, layerId, markerId, actorId, token) {
     if (!apiUrl || !layerId || !markerId) return;
 
     // Optimistic local update
@@ -220,7 +225,7 @@ export async function deleteMarker(apiUrl, layerId, markerId, actorId) {
     try {
         const url = `${LAMBDA_BASE}/${encodeURIComponent(layerId)}/features/${encodeURIComponent(markerId)}` +
             `?apiUrl=${encodeURIComponent(apiUrl)}&actorId=${encodeURIComponent(actorId)}`;
-        await fetch(url, { method: 'DELETE' });
+        await fetch(url, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } });
     } catch (err) {
         console.warn('[collabLayerSync] deleteMarker error:', err);
     }

--- a/src/pages/tasking/utils/defaultAssetSync.js
+++ b/src/pages/tasking/utils/defaultAssetSync.js
@@ -13,7 +13,7 @@
  * doesn't pull the entire universe.
  */
 
-const LAMBDA_BASE = 'https://lambda.lighthouse-extension.com/lad/default-assets';
+const LAMBDA_BASE = 'https://lambda.lighthouse-extension.com/lad_v2/default-assets';
 const LS_KEY      = 'lh_sharedDefaultAssets';   // localStorage key for cached mapping
 const LS_TS_KEY   = 'lh_sharedDefaultAssets_ts'; // timestamp of last successful fetch
 
@@ -52,15 +52,16 @@ export function saveSharedMapping(mapping) {
  *
  * @param {string}   apiUrl    The Beacon source URL (namespace).
  * @param {string[]} teamIds   Array of team ID strings.
+ * @param {string}   token     Beacon access token (Authorization: Bearer).
  * @returns {Promise<Object<string, string>>}  teamId → assetId map
  */
-export async function fetchSharedDefaults(apiUrl, teamIds) {
+export async function fetchSharedDefaults(apiUrl, teamIds, token) {
     if (!teamIds || teamIds.length === 0) return loadSharedMapping();
 
     const url = `${LAMBDA_BASE}?apiUrl=${encodeURIComponent(apiUrl)}&teamIds=${teamIds.join(',')}`;
 
     try {
-        const res = await fetch(url, { method: 'GET' });
+        const res = await fetch(url, { method: 'GET', headers: { 'Authorization': `Bearer ${token}` } });
         if (!res.ok) {
             console.warn('[defaultAssetSync] GET failed:', res.status);
             return loadSharedMapping(); // fall back to cache
@@ -100,9 +101,10 @@ export async function fetchSharedDefaults(apiUrl, teamIds) {
  * @param {string} apiUrl   The Beacon source URL (namespace).
  * @param {string} teamId
  * @param {string} assetId
+ * @param {string} token    Beacon access token (Authorization: Bearer).
  * @returns {Promise<void>}
  */
-export async function pushSharedDefault(apiUrl, teamId, assetId) {
+export async function pushSharedDefault(apiUrl, teamId, assetId, token) {
     if (!assetId) return; // nothing to push
 
     // Optimistic local update
@@ -114,7 +116,7 @@ export async function pushSharedDefault(apiUrl, teamId, assetId) {
     try {
         await fetch(LAMBDA_BASE, {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
             body: JSON.stringify({
                 apiUrl,
                 teamId: String(teamId),

--- a/src/pages/tasking/utils/geocode.js
+++ b/src/pages/tasking/utils/geocode.js
@@ -1,8 +1,9 @@
 // AwsLambdaGeocoderProvider.js
 export class AwsLambdaGeocoderProvider {
-  constructor({ endpoint, fetchOptions } = {}) {
+  constructor({ endpoint, fetchOptions, getToken } = {}) {
     this.endpoint = endpoint.replace(/\/$/, '');
     this.fetchOptions = fetchOptions; // optional: headers, credentials, etc.
+    this.getToken = getToken; // optional: () => Promise<string> -- Beacon access token
   }
 
   // leaflet-geosearch calls: provider.search({ query: string })
@@ -12,9 +13,17 @@ export class AwsLambdaGeocoderProvider {
     const url = new URL(this.endpoint);
     url.searchParams.set('q', query.trim());
 
+    // Computed fresh per call (not baked into fetchOptions at construction)
+    // since this provider instance is long-lived and the token can expire.
+    const token = this.getToken ? await this.getToken() : null;
+
     const res = await fetch(url.toString(), {
       method: 'GET',
       ...this.fetchOptions,
+      headers: {
+        ...this.fetchOptions?.headers,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
     });
 
     if (!res.ok) {

--- a/src/pages/tasking/viewmodels/AssetPopUp.js
+++ b/src/pages/tasking/viewmodels/AssetPopUp.js
@@ -39,7 +39,7 @@ export class AssetPopupViewModel {
 
 
 
-  drawRouteToJob = (tasking) => {
+  drawRouteToJob = async (tasking) => {
     const from = tasking.getTeamLatLng();
     const to = tasking.getJobLatLng();
     if (!from || !to) {
@@ -48,9 +48,11 @@ export class AssetPopupViewModel {
     }
     this.routeLoading(true);
 
+    const token = await this.api.getToken();
     const router = new AmazonLocationRouter({
-      serviceUrl: "https://lambda.lighthouse-extension.com/lad/route",
+      serviceUrl: "https://lambda.lighthouse-extension.com/lad_v2/route",
       travelMode: "Car",
+      headers: { Authorization: `Bearer ${token}` },
     });
 
     const routeControl = L.Routing.control({

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -7,12 +7,17 @@ import { createCollabLayer } from '../mapLayers/collabLayer.js';
 
 
 
-const FUNCTION_URL = "https://lambda.lighthouse-extension.com/lad/share";
+const FUNCTION_URL = "https://lambda.lighthouse-extension.com/lad_v2/share";
 
 
 
 export function ConfigVM(root, deps) {
     const self = this;
+
+    // Exposed publicly so code holding a ConfigVM reference (e.g.
+    // InstantTaskViewModel's `config`) can get the current Beacon token
+    // without its own deps plumbing.
+    self.getToken = deps.getToken;
 
     const LAYOUT_PRESETS = [
         'map-right-teams-top',
@@ -264,7 +269,7 @@ export function ConfigVM(root, deps) {
         self.collabLayerError('');
         self.creatingCollabLayer(true);
         try {
-            const layer = await createCollabLayer(root, deps.apiUrl, name, deps.userId);
+            const layer = await createCollabLayer(root, deps.apiUrl, name, deps.userId, deps.getToken);
             if (!layer) throw new Error('Create failed');
             self.newLayerName('');
         } catch (err) {
@@ -845,10 +850,11 @@ export function ConfigVM(root, deps) {
 
         try {
             const savedConfig = buildConfig();
+            const token = await deps.getToken();
 
             const res = await fetch(FUNCTION_URL, {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
                 body: JSON.stringify({ config: savedConfig })
             });
 
@@ -882,10 +888,11 @@ export function ConfigVM(root, deps) {
         try {
             // Adjust to match your handler: expects ?id=...
             const url = `${FUNCTION_URL}?id=${encodeURIComponent(id)}`;
+            const token = await deps.getToken();
 
             const res = await fetch(url, {
                 method: "GET",
-                headers: { "Accept": "application/json" }
+                headers: { "Accept": "application/json", "Authorization": `Bearer ${token}` }
             });
 
             if (!res.ok) {

--- a/src/pages/tasking/viewmodels/InstantTask.js
+++ b/src/pages/tasking/viewmodels/InstantTask.js
@@ -310,7 +310,7 @@ export class InstantTaskViewModel {
         const controller = new AbortController();
         this._routeAbort = controller;
 
-        batchRoute(pairs, { signal: controller.signal })
+        batchRoute(pairs, { signal: controller.signal, getToken: this.config?.getToken })
             .then(results => {
                 if (controller.signal.aborted) return;
 

--- a/src/pages/tasking/viewmodels/JobPopUp.js
+++ b/src/pages/tasking/viewmodels/JobPopUp.js
@@ -50,7 +50,7 @@ export class JobPopupViewModel {
 
 
 
-    drawRouteToAsset = (tasking) => {
+    drawRouteToAsset = async (tasking) => {
         const from = tasking.getTeamLatLng();
         const to = tasking.getJobLatLng();
         if (!from || !to) {
@@ -58,9 +58,11 @@ export class JobPopupViewModel {
             return;
         }
 
+        const token = await this.api.getToken();
         const router = new AmazonLocationRouter({
-            serviceUrl: "https://lambda.lighthouse-extension.com/lad/route",
+            serviceUrl: "https://lambda.lighthouse-extension.com/lad_v2/route",
             travelMode: "Car",
+            headers: { Authorization: `Bearer ${token}` },
         });
 
         this.routeLoading(true);

--- a/src/pages/tasking/viewmodels/Map.js
+++ b/src/pages/tasking/viewmodels/Map.js
@@ -913,6 +913,8 @@ export function MapVM(Lmap, root) {
   });
 
   const PopupStuff = {
+    getToken: () => root.getToken(),
+
     flyToBounds: (bounds, { opts }) => {
       self._flyingToBounds = true;
       self.map.flyToBounds(bounds, opts);


### PR DESCRIPTION
The lambda.lighthouse-extension.com/lad/... endpoints accepted requests from anyone with the URL. Add /lad_v2/... copies of all five Lambdas (share, default-assets, map-layers, route, geocode) that verify the caller's existing Beacon access token (RS256 JWT, verified locally against SES's identity server JWKS) before doing anything -- no new login step, no token minted by us.

route/geocode also required threading a token into two places outside the tasking SPA: src/contentscripts/jobs/create.js (a real content script, reads the token from chrome.storage.local) and src/injectscripts/jobs/view.js (a true page-context inject script, uses the page's own `user.accessToken` global directly). The injectscripts/jobs/create.js counterpart now also forwards `user.accessToken` via postMessage to its content-script pair, which needed it for its own route-Lambda call.

Also fixes three call sites in models/Team.js that were still calling fetchSharedDefaults() with the pre-auth two-arg signature, sending a literal "Bearer undefined" header.

Also un-ignore lambda/ (it was fully git-ignored, so none of this source -- old or new -- was previously tracked).