### PR TITLE
Log Beacon-authenticated user on each lad_v2 Lambda invocation

### DIFF
--- a/lambda/default-assets-v2/index.mjs
+++ b/lambda/default-assets-v2/index.mjs
@@ -98,11 +98,13 @@ export const handler = async (event) => {
         return respond(204, '');
     }
 
+    let claims;
     try {
-        await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+        claims = await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
     } catch (err) {
         return respond(401, { error: 'Unauthorized', message: err?.message || String(err) });
     }
+    console.log(JSON.stringify({ msg: 'beacon_auth', fn: 'default-assets-v2', userId: claims.sub || claims.client_id || 'unknown', method }));
 
     try {
         // ---------- GET: Bulk fetch for a list of team IDs ----------

--- a/lambda/geocode-v2/index.mjs
+++ b/lambda/geocode-v2/index.mjs
@@ -26,11 +26,13 @@ export const handler = async (event) => {
     return { statusCode: 204, headers: corsHeaders, body: "" };
   }
 
+  let claims;
   try {
-    await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+    claims = await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
   } catch (err) {
     return json(401, { error: "Unauthorized", message: err?.message || String(err) });
   }
+  console.log(JSON.stringify({ msg: "beacon_auth", fn: "geocode-v2", userId: claims.sub || claims.client_id || "unknown" }));
 
   const qsp = event?.queryStringParameters || {};
 

--- a/lambda/map-layers-v2/index.js
+++ b/lambda/map-layers-v2/index.js
@@ -35,11 +35,13 @@ exports.handler = async (event) => {
     return json(404, { error: 'Not found', routeKey });
   }
 
+  let claims;
   try {
-    await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+    claims = await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
   } catch (err) {
     return json(401, { error: 'Unauthorized', message: err?.message || String(err) });
   }
+  console.log(JSON.stringify({ msg: 'beacon_auth', fn: 'map-layers-v2', userId: claims.sub || claims.client_id || 'unknown', route: routeKey }));
 
   try {
     return await handler(event);

--- a/lambda/route-v2/index.mjs
+++ b/lambda/route-v2/index.mjs
@@ -33,11 +33,13 @@ export const handler = async (event) => {
     return { statusCode: 204, headers: CORS_HEADERS, body: "" };
   }
 
+  let claims;
   try {
-    await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+    claims = await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
   } catch (err) {
     return json(401, { error: "Unauthorized", message: err?.message || String(err) });
   }
+  console.log(JSON.stringify({ msg: "beacon_auth", fn: "route-v2", userId: claims.sub || claims.client_id || "unknown" }));
 
   let body;
   try {

--- a/lambda/share-v2/index.mjs
+++ b/lambda/share-v2/index.mjs
@@ -33,8 +33,9 @@ export const handler = async (event) => {
       };
     }
 
+    let claims;
     try {
-      await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
+      claims = await verifyBeaconToken(event.headers?.authorization || event.headers?.Authorization);
     } catch (err) {
       return {
         statusCode: 401,
@@ -42,6 +43,7 @@ export const handler = async (event) => {
         body: JSON.stringify({ message: "Unauthorized", error: err?.message || String(err) })
       };
     }
+    console.log(JSON.stringify({ msg: "beacon_auth", fn: "share-v2", userId: claims.sub || claims.client_id || "unknown", method }));
 
     if (method === "POST" && !query.id) {
       return await handleCreateConfig(rawBody);


### PR DESCRIPTION
## Summary
- Each of the five Beacon-auth-gated Lambdas (`map-layers-v2`, `default-assets-v2`, `geocode-v2`, `route-v2`, `share-v2`) verified the caller's token but discarded its claims afterward.
- Capture the returned claims and emit one structured `console.log` line (`{msg:"beacon_auth", fn, userId, route/method}`) per successful auth, so CloudWatch Logs Insights can break usage down per authenticated user, not just aggregate invocation counts.
- `userId` is the token's `sub` claim, falling back to `client_id` for any non-user (machine) token.

## Test plan
- [x] All 5 files pass `node --check`
- [x] Deployed to the live `LH-*v2` Lambdas via `aws lambda update-function-code`; re-downloaded each and confirmed the `beacon_auth` log line is present in the deployed source
- [x] Smoke-invoked `LH-MapLayersv2` post-deploy — still correctly returns 401 for a request with no Authorization header (no regression)
- [x] Built CloudWatch dashboard `Lighthouse-Beacon-Lambda-Usage` (per-user/function invocation table, hourly trend, distinct-user counts) against the new log field

🤖 Generated with [Claude Code](https://claude.com/claude-code)