### PR TITLE
Fix map-layers index.json retry to catch S3's actual conflict status

### DIFF
--- a/lambda/map-layers-v2/lib/s3Store.js
+++ b/lambda/map-layers-v2/lib/s3Store.js
@@ -71,7 +71,10 @@ async function updateIndex(apiUrl, mutate, { retries = 3 } = {}) {
       return result;
     } catch (err) {
       const status = err.$metadata?.httpStatusCode;
-      if (status === 412 && attempt < retries) continue; // lost the race, retry
+      // S3's conditional-write feature (IfMatch/IfNoneMatch on PutObject)
+      // reports a lost race as 409 ConditionalRequestConflict, not the 412
+      // Precondition Failed other conditional S3 operations use.
+      if ((status === 409 || status === 412) && attempt < retries) continue; // lost the race, retry
       throw err;
     }
   }

--- a/lambda/map-layers/lib/s3Store.js
+++ b/lambda/map-layers/lib/s3Store.js
@@ -71,7 +71,10 @@ async function updateIndex(apiUrl, mutate, { retries = 3 } = {}) {
       return result;
     } catch (err) {
       const status = err.$metadata?.httpStatusCode;
-      if (status === 412 && attempt < retries) continue; // lost the race, retry
+      // S3's conditional-write feature (IfMatch/IfNoneMatch on PutObject)
+      // reports a lost race as 409 ConditionalRequestConflict, not the 412
+      // Precondition Failed other conditional S3 operations use.
+      if ((status === 409 || status === 412) && attempt < retries) continue; // lost the race, retry
       throw err;
     }
   }


### PR DESCRIPTION
## Summary
- Users reported intermittent 500s on `GET /lad_v2/map-layers/{id}` (e.g. `.../886ceb01-297c-4e03-88e0-5a24fe62b373?apiUrl=https://beacon.ses.nsw.gov.au`).
- CloudWatch showed the actual cause: `updateIndex()`'s retry-on-lost-race logic only checked for HTTP `412`, but S3's conditional-write feature (`IfMatch`/`IfNoneMatch` on `PutObject`) reports a lost race as **409 `ConditionalRequestConflict`**, not 412. So the retry never engaged — the very first race threw straight up to the handler's top-level catch and became a 500.
- Confirmed the S3 key in the errors (`shared_layers/f06950feab5523778e425a19/index.json`) is the SHA-256 hash of `https://beacon.ses.nsw.gov.au` — same org as the reported example, recurring every 5–30 minutes on the `getLayer` handler's `lastUsedAt` bump (every layer view writes back to the shared index).
- Applied the same one-line fix to both `lambda/map-layers-v2` (the current auth-gated version) and `lambda/map-layers` (the older v1 copy, still live on `LH-MapLayers` with ~450 req/day) since they share identical code.

## Test plan
- [x] `node --check` on both changed files
- [x] Deployed to `LH-MapLayersv2` via `aws lambda update-function-code`, verified the live code contains the fix
- [x] Smoke-invoked post-deploy — still correctly returns 401 for a request with no Authorization header (no regression)
- [ ] `LH-MapLayers` (v1) fix is in this PR but **not yet deployed** — deploy separately once merged
- [ ] Watch `Lighthouse-Beacon-Lambda-Usage` CloudWatch dashboard / Logs Insights for `ConditionalRequestConflict` to confirm it stops recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)