### PR TITLE
Allow multiple trusted Beacon token issuers

### DIFF
--- a/lambda/shared/verifyBeaconToken.js
+++ b/lambda/shared/verifyBeaconToken.js
@@ -1,11 +1,14 @@
 'use strict';
 
-// SES's Beacon identity server (Duende/IdentityServer4). Configured via
-// deployment env vars, never derived from the token or request, so a
-// caller can't point verification at a JWKS they control.
-const TRUSTED_ISS = process.env.TRUSTED_ISS;
-const JWKS_URI = process.env.JWKS_URI;
-const EXPECTED_AUD = process.env.EXPECTED_AUD;
+// SES's Beacon identity server (Duende/IdentityServer4) runs one instance
+// per environment (prod, train, ...), each issuing tokens with a different
+// `iss` and its own signing keys at `<iss>/.well-known/jwks`. The allowed
+// issuers are configured via a deployment env var, never derived from the
+// token itself, so a caller can't point verification at a JWKS they control.
+const TRUSTED_ISS = (process.env.TRUSTED_ISS || '')
+  .split(',')
+  .map((iss) => iss.trim())
+  .filter(Boolean);
 const REQUIRED_SCOPE = 'beaconApi';
 
 // jose ships ESM-only; a CommonJS module has to load it via dynamic
@@ -17,12 +20,14 @@ function loadJose() {
   return josePromise;
 }
 
-let jwksPromise;
-function getJwks() {
-  if (!jwksPromise) {
-    jwksPromise = loadJose().then(({ createRemoteJWKSet }) => createRemoteJWKSet(new URL(JWKS_URI)));
+// One remote JWKS per trusted issuer, cached across warm invocations.
+const jwksByIssuer = new Map();
+async function getJwks(iss) {
+  if (!jwksByIssuer.has(iss)) {
+    const { createRemoteJWKSet } = await loadJose();
+    jwksByIssuer.set(iss, createRemoteJWKSet(new URL(`${iss}/.well-known/jwks`)));
   }
-  return jwksPromise;
+  return jwksByIssuer.get(iss);
 }
 
 /**
@@ -34,11 +39,27 @@ async function verifyBeaconToken(authorizationHeader) {
   const match = /^Bearer (.+)$/.exec(authorizationHeader || '');
   if (!match) throw new Error('Missing or malformed Authorization header');
 
-  const [{ jwtVerify }, jwks] = await Promise.all([loadJose(), getJwks()]);
+  const { jwtVerify, decodeJwt } = await loadJose();
+
+  // This iss is unverified until jwtVerify checks it below - it's only
+  // used to pick which allow-listed issuer's JWKS to fetch, never to
+  // build a URL from an untrusted value.
+  let unverifiedIss;
+  try {
+    unverifiedIss = decodeJwt(match[1]).iss;
+  } catch {
+    throw new Error('Malformed token');
+  }
+
+  if (!TRUSTED_ISS.includes(unverifiedIss)) {
+    throw new Error(`Untrusted token issuer: ${unverifiedIss}`);
+  }
+
+  const jwks = await getJwks(unverifiedIss);
 
   const { payload } = await jwtVerify(match[1], jwks, {
-    issuer: TRUSTED_ISS,
-    audience: EXPECTED_AUD,
+    issuer: unverifiedIss,
+    audience: `${unverifiedIss}/resources`,
     algorithms: ['RS256'],
   });
 

--- a/lambda/shared/verifyBeaconToken.mjs
+++ b/lambda/shared/verifyBeaconToken.mjs
@@ -1,15 +1,24 @@
-import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 
-// SES's Beacon identity server (Duende/IdentityServer4). Configured via
-// deployment env vars, never derived from the token or request, so a
-// caller can't point verification at a JWKS they control.
-const TRUSTED_ISS = process.env.TRUSTED_ISS;
-const JWKS_URI = process.env.JWKS_URI;
-const EXPECTED_AUD = process.env.EXPECTED_AUD;
+// SES's Beacon identity server (Duende/IdentityServer4) runs one instance
+// per environment (prod, train, ...), each issuing tokens with a different
+// `iss` and its own signing keys at `<iss>/.well-known/jwks`. The allowed
+// issuers are configured via a deployment env var, never derived from the
+// token itself, so a caller can't point verification at a JWKS they control.
+const TRUSTED_ISS = (process.env.TRUSTED_ISS || '')
+  .split(',')
+  .map((iss) => iss.trim())
+  .filter(Boolean);
 const REQUIRED_SCOPE = 'beaconApi';
 
-// Module-scope: persists (and caches fetched keys) across warm invocations.
-const JWKS = createRemoteJWKSet(new URL(JWKS_URI));
+// One remote JWKS per trusted issuer, cached across warm invocations.
+const jwksByIssuer = new Map();
+function getJwks(iss) {
+  if (!jwksByIssuer.has(iss)) {
+    jwksByIssuer.set(iss, createRemoteJWKSet(new URL(`${iss}/.well-known/jwks`)));
+  }
+  return jwksByIssuer.get(iss);
+}
 
 /**
  * Verify an `Authorization: Bearer <token>` header is a currently-valid
@@ -20,9 +29,25 @@ export async function verifyBeaconToken(authorizationHeader) {
   const match = /^Bearer (.+)$/.exec(authorizationHeader || '');
   if (!match) throw new Error('Missing or malformed Authorization header');
 
-  const { payload } = await jwtVerify(match[1], JWKS, {
-    issuer: TRUSTED_ISS,
-    audience: EXPECTED_AUD,
+  // This iss is unverified until jwtVerify checks it below - it's only
+  // used to pick which allow-listed issuer's JWKS to fetch, never to
+  // build a URL from an untrusted value.
+  let unverifiedIss;
+  try {
+    unverifiedIss = decodeJwt(match[1]).iss;
+  } catch {
+    throw new Error('Malformed token');
+  }
+
+  if (!TRUSTED_ISS.includes(unverifiedIss)) {
+    throw new Error(`Untrusted token issuer: ${unverifiedIss}`);
+  }
+
+  const jwks = getJwks(unverifiedIss);
+
+  const { payload } = await jwtVerify(match[1], jwks, {
+    issuer: unverifiedIss,
+    audience: `${unverifiedIss}/resources`,
     algorithms: ['RS256'],
   });
 


### PR DESCRIPTION
## Summary
- `TRUSTED_ISS` is now a comma-separated allow-list instead of a single issuer, so the Beacon auth check can trust more than one identity server deployment (e.g. prod and train) at once.
- The JWKS endpoint and expected audience are derived per-issuer (`<iss>/.well-known/jwks`, `<iss>/resources`) from the matched trusted issuer, instead of requiring separate `JWKS_URI`/`EXPECTED_AUD` lists to stay in sync.
- The unverified token `iss` is only used to pick which allow-listed issuer's JWKS to check against; `jwtVerify` still cryptographically re-validates the issuer and signature.

## Test plan
- [x] Deployed the updated `verifyBeaconToken.js`/`.mjs` to `LH-MapLayersv2`, `LH-GeoCodeLADv2`, `LH-RouteLADv2`, `LH-ShareLADv2`, `LH-defaultAssetv2` and updated their `TRUSTED_ISS` env vars to include both `identity.ses.nsw.gov.au` and `identitytrain.ses.nsw.gov.au`.
- [x] Verified a train-issued token against `LH-MapLayersv2` now passes auth (previously failed with `unexpected "iss" claim value`).
- [x] `node --check` on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)