### PR TITLE
Add comments to collaborative map markers; replace marker icon set

### DIFF
--- a/lambda/map-layers-v2/handlers/addMarkerComment.js
+++ b/lambda/map-layers-v2/handlers/addMarkerComment.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound } = require('../lib/response');
+
+// POST /map-layers/{id}/features/{markerId}/comments
+// body: { apiUrl, actorId, opsLogId }
+//
+// Appends the id of a client-side-created Operations Log entry to the
+// marker's comment thread. Like upsertFeature's opsLogId, this Lambda only
+// stores the pointer -- the comment's text/author lives entirely in that
+// Ops Log entry and is resolved via BeaconClient.operationslog.get().
+module.exports = async function addMarkerComment(event) {
+  const layerId = event.pathParameters?.id;
+  const markerId = event.pathParameters?.markerId;
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return badRequest('Invalid JSON body');
+  }
+
+  const apiUrl = body.apiUrl;
+  const actorId = String(body.actorId || '').slice(0, 100);
+  const opsLogId = Number(body.opsLogId);
+
+  if (!apiUrl || !layerId || !markerId) {
+    return badRequest('apiUrl, layer id and marker id are required');
+  }
+  if (!Number.isFinite(opsLogId)) return badRequest('opsLogId must be a number');
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  const marker = layer.markers.find((m) => m.id === markerId);
+  if (!marker) return notFound('Marker not found');
+
+  marker.commentOpsLogIds = Array.isArray(marker.commentOpsLogIds) ? marker.commentOpsLogIds : [];
+  marker.commentOpsLogIds.push(opsLogId);
+
+  const now = new Date().toISOString();
+  marker.updatedBy = actorId || marker.updatedBy;
+  marker.updatedAt = now;
+
+  layer.lastUsedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+
+  await updateIndex(apiUrl, (index) => {
+    const entry = index.layers.find((l) => l.id === layerId);
+    if (entry) entry.lastUsedAt = now;
+  });
+
+  return json(200, marker);
+};

--- a/lambda/map-layers-v2/handlers/upsertFeature.js
+++ b/lambda/map-layers-v2/handlers/upsertFeature.js
@@ -7,22 +7,25 @@ const { json, badRequest, notFound } = require('../lib/response');
 // Must stay in sync with the icon keys in
 // src/pages/tasking/components/collab_marker_icons.js (MARKER_ICON_GROUPS).
 const ICON_KEYS = new Set([
-  'fire', 'fire-extinguisher', 'water', 'house-damage', 'exclamation-triangle',
-  'skull-crossbones', 'biohazard', 'radiation', 'bolt', 'wind', 'smog',
-  'car-crash', 'tree', 'gas-pump', 'ban',
-  'ambulance', 'first-aid', 'hospital', 'user-md', 'user-injured', 'syringe',
-  'user', 'users', 'wheelchair', 'baby-carriage', 'paw',
-  'campground', 'home', 'warehouse', 'tint', 'shower',
-  'road', 'route', 'broadcast-tower', 'plug',
-  'truck', 'helicopter', 'ship', 'life-ring',
-  'map-marker-alt', 'flag', 'check-circle', 'question-circle',
+  'exclamation-triangle', 'fire-alt', 'cloud-showers-heavy', 'wind', 'snowflake', 'water', 'gas-pump',
+  'ambulance', 'car-side', 'truck-monster', 'shuttle-van', 'helicopter', 'ship', 'plane',
+  'users', 'dog',
+  'utensils', 'shopping-cart',
+  'eye', 'camera', 'comments',
+  'flag', 'thumbtack', 'times', 'minus-circle', 'question-circle',
 ]);
-const DEFAULT_ICON = 'map-marker-alt';
+const DEFAULT_ICON = 'thumbtack';
 const HEX_COLOR = /^#[0-9a-fA-F]{3,8}$/;
 
-// PUT /map-layers/{id}/features   body: { apiUrl, marker: {id?, lat, lng, icon, fill, description}, actorId }
+// PUT /map-layers/{id}/features   body: { apiUrl, marker: {id?, lat, lng, icon, fill, opsLogId}, actorId }
 // Missing/unknown marker.id creates a new marker; a known id overwrites it
 // (last-write-wins, same convention as the existing default-assets Lambda).
+//
+// The marker record itself only holds GPS position, style (icon/fill), and
+// pointers into the Operations Log -- opsLogId for the title/description
+// entry and commentOpsLogIds for the comment thread. The Ops Log is the
+// source of truth for all of that text; the client resolves the pointers
+// via BeaconClient.operationslog.get() when rendering a marker.
 module.exports = async function upsertFeature(event) {
   const layerId = event.pathParameters?.id;
   let body;
@@ -47,7 +50,15 @@ module.exports = async function upsertFeature(event) {
   const now = new Date().toISOString();
   const icon = ICON_KEYS.has(input.icon) ? input.icon : DEFAULT_ICON;
   const fill = HEX_COLOR.test(input.fill || '') ? input.fill : '#2b7bbb';
-  const description = String(input.description || '').slice(0, 2000);
+
+  // Id of the Operations Log entry logged (client-side) for this drop/edit,
+  // stamped onto the marker so the title/description can be looked up
+  // later via BeaconClient.operationslog.get(). A Beacon Ops Log entry
+  // can't be edited by anyone but its author, so editing a marker always
+  // creates a *new* entry client-side and points opsLogId at it rather
+  // than mutating the old one. Omitted/invalid values leave the marker's
+  // existing opsLogId (if any) untouched.
+  const opsLogId = Number.isFinite(Number(input.opsLogId)) && input.opsLogId !== '' ? Number(input.opsLogId) : undefined;
 
   const existingIdx = input.id ? layer.markers.findIndex((m) => m.id === input.id) : -1;
   let marker;
@@ -59,11 +70,11 @@ module.exports = async function upsertFeature(event) {
       lng: input.lng,
       icon,
       fill,
-      description,
       updatedBy: actorId,
       updatedAt: now,
       deleted: false,
     };
+    if (opsLogId !== undefined) marker.opsLogId = opsLogId;
     layer.markers[existingIdx] = marker;
   } else {
     marker = {
@@ -72,13 +83,14 @@ module.exports = async function upsertFeature(event) {
       lng: input.lng,
       icon,
       fill,
-      description,
+      commentOpsLogIds: [],
       createdBy: actorId,
       createdAt: now,
       updatedBy: actorId,
       updatedAt: now,
       deleted: false,
     };
+    if (opsLogId !== undefined) marker.opsLogId = opsLogId;
     layer.markers.push(marker);
   }
 

--- a/lambda/map-layers-v2/index.js
+++ b/lambda/map-layers-v2/index.js
@@ -7,6 +7,7 @@ const createLayer = require('./handlers/createLayer');
 const getLayer = require('./handlers/getLayer');
 const upsertFeature = require('./handlers/upsertFeature');
 const deleteFeature = require('./handlers/deleteFeature');
+const addMarkerComment = require('./handlers/addMarkerComment');
 
 // Single Lambda fronting all /lad_v2/map-layers routes via API Gateway HTTP
 // API (payload format 2.0) Lambda proxy integration. Routed by
@@ -21,6 +22,7 @@ const ROUTES = {
   'GET /lad_v2/map-layers/{id}': getLayer,
   'PUT /lad_v2/map-layers/{id}/features': upsertFeature,
   'DELETE /lad_v2/map-layers/{id}/features/{markerId}': deleteFeature,
+  'POST /lad_v2/map-layers/{id}/features/{markerId}/comments': addMarkerComment,
 };
 
 exports.handler = async (event) => {

--- a/src/pages/tasking/components/collab_marker_icons.js
+++ b/src/pages/tasking/components/collab_marker_icons.js
@@ -2,8 +2,9 @@ import L from 'leaflet';
 
 /**
  * Curated set of Font Awesome 5 Free icons relevant to emergency-service
- * field marking (hazards, medical, welfare, shelter, infrastructure,
- * vehicles/rescue, status). Grouped for a scannable picker UI.
+ * field marking (hazards/weather, vehicles/rescue, people/animals,
+ * resources/supplies, observation/comms, status). Grouped for a scannable
+ * picker UI.
  *
  * Every `fa` class here is confirmed present in the bundled
  * @fortawesome/fontawesome-free 5.15.4 solid set -- don't add an icon
@@ -11,80 +12,58 @@ import L from 'leaflet';
  */
 export const MARKER_ICON_GROUPS = [
     {
-        group: 'Hazards',
+        group: 'Hazards & Weather',
         icons: [
-            { key: 'fire', label: 'Fire', fa: 'fa-fire' },
-            { key: 'fire-extinguisher', label: 'Fire (controlled)', fa: 'fa-fire-extinguisher' },
-            { key: 'water', label: 'Flooding', fa: 'fa-water' },
-            { key: 'house-damage', label: 'Structural damage', fa: 'fa-house-damage' },
             { key: 'exclamation-triangle', label: 'Hazard', fa: 'fa-exclamation-triangle' },
-            { key: 'skull-crossbones', label: 'Danger / poison', fa: 'fa-skull-crossbones' },
-            { key: 'biohazard', label: 'Biohazard', fa: 'fa-biohazard' },
-            { key: 'radiation', label: 'Radiation', fa: 'fa-radiation' },
-            { key: 'bolt', label: 'Downed power line', fa: 'fa-bolt' },
-            { key: 'wind', label: 'Storm / wind damage', fa: 'fa-wind' },
-            { key: 'smog', label: 'Smoke / air hazard', fa: 'fa-smog' },
-            { key: 'car-crash', label: 'Vehicle accident', fa: 'fa-car-crash' },
-            { key: 'tree', label: 'Fallen tree', fa: 'fa-tree' },
+            { key: 'fire-alt', label: 'Fire', fa: 'fa-fire-alt' },
+            { key: 'cloud-showers-heavy', label: 'Heavy rain', fa: 'fa-cloud-showers-heavy' },
+            { key: 'wind', label: 'Storm / high wind', fa: 'fa-wind' },
+            { key: 'snowflake', label: 'Snow / ice', fa: 'fa-snowflake' },
+            { key: 'water', label: 'Flooding', fa: 'fa-water' },
             { key: 'gas-pump', label: 'Fuel / gas hazard', fa: 'fa-gas-pump' },
-            { key: 'ban', label: 'Road closed', fa: 'fa-ban' },
-        ],
-    },
-    {
-        group: 'Medical',
-        icons: [
-            { key: 'ambulance', label: 'Ambulance', fa: 'fa-ambulance' },
-            { key: 'first-aid', label: 'First aid', fa: 'fa-first-aid' },
-            { key: 'hospital', label: 'Hospital', fa: 'fa-hospital' },
-            { key: 'user-md', label: 'Medical personnel', fa: 'fa-user-md' },
-            { key: 'user-injured', label: 'Injured person', fa: 'fa-user-injured' },
-            { key: 'syringe', label: 'Medical supplies', fa: 'fa-syringe' },
-        ],
-    },
-    {
-        group: 'People',
-        icons: [
-            { key: 'user', label: 'Person', fa: 'fa-user' },
-            { key: 'users', label: 'Group of people', fa: 'fa-users' },
-            { key: 'wheelchair', label: 'Accessibility needs', fa: 'fa-wheelchair' },
-            { key: 'baby-carriage', label: 'Infant / child', fa: 'fa-baby-carriage' },
-            { key: 'paw', label: 'Animal / livestock', fa: 'fa-paw' },
-        ],
-    },
-    {
-        group: 'Shelter & Resources',
-        icons: [
-            { key: 'campground', label: 'Evacuation centre', fa: 'fa-campground' },
-            { key: 'home', label: 'Shelter / house', fa: 'fa-home' },
-            { key: 'warehouse', label: 'Supply depot', fa: 'fa-warehouse' },
-            { key: 'tint', label: 'Water supply', fa: 'fa-tint' },
-            { key: 'shower', label: 'Sanitation', fa: 'fa-shower' },
-        ],
-    },
-    {
-        group: 'Infrastructure',
-        icons: [
-            { key: 'road', label: 'Road / route', fa: 'fa-road' },
-            { key: 'route', label: 'Evacuation route', fa: 'fa-route' },
-            { key: 'broadcast-tower', label: 'Communications', fa: 'fa-broadcast-tower' },
-            { key: 'plug', label: 'Power / utility', fa: 'fa-plug' },
         ],
     },
     {
         group: 'Vehicles & Rescue',
         icons: [
-            { key: 'truck', label: 'Truck', fa: 'fa-truck' },
+            { key: 'ambulance', label: 'Ambulance', fa: 'fa-ambulance' },
+            { key: 'car-side', label: 'Car', fa: 'fa-car-side' },
+            { key: 'truck-monster', label: '4x4 / off-road truck', fa: 'fa-truck-monster' },
+            { key: 'shuttle-van', label: 'Shuttle van', fa: 'fa-shuttle-van' },
             { key: 'helicopter', label: 'Helicopter', fa: 'fa-helicopter' },
             { key: 'ship', label: 'Boat', fa: 'fa-ship' },
-            { key: 'life-ring', label: 'Rescue', fa: 'fa-life-ring' },
+            { key: 'plane', label: 'Aircraft', fa: 'fa-plane' },
         ],
     },
     {
-        group: 'Status',
+        group: 'People & Animals',
         icons: [
-            { key: 'map-marker-alt', label: 'General marker', fa: 'fa-map-marker-alt' },
+            { key: 'users', label: 'Group of people', fa: 'fa-users' },
+            { key: 'dog', label: 'Animal / pet', fa: 'fa-dog' },
+        ],
+    },
+    {
+        group: 'Resources & Supplies',
+        icons: [
+            { key: 'utensils', label: 'Food', fa: 'fa-utensils' },
+            { key: 'shopping-cart', label: 'Supplies', fa: 'fa-shopping-cart' },
+        ],
+    },
+    {
+        group: 'Observation & Comms',
+        icons: [
+            { key: 'eye', label: 'Observation point', fa: 'fa-eye' },
+            { key: 'camera', label: 'Photo evidence', fa: 'fa-camera' },
+            { key: 'comments', label: 'Discussion / comments', fa: 'fa-comments' },
+        ],
+    },
+    {
+        group: 'Status & Markers',
+        icons: [
             { key: 'flag', label: 'Checkpoint', fa: 'fa-flag' },
-            { key: 'check-circle', label: 'Cleared / complete', fa: 'fa-check-circle' },
+            { key: 'thumbtack', label: 'Pinned location', fa: 'fa-thumbtack' },
+            { key: 'times', label: 'Cancelled / closed', fa: 'fa-times' },
+            { key: 'minus-circle', label: 'Unavailable', fa: 'fa-minus-circle' },
             { key: 'question-circle', label: 'Unknown / needs check', fa: 'fa-question-circle' },
         ],
     },
@@ -96,7 +75,7 @@ export const MARKER_ICONS_BY_KEY = MARKER_ICON_GROUPS.reduce((acc, g) => {
     return acc;
 }, {});
 
-export const DEFAULT_MARKER_ICON_KEY = 'map-marker-alt';
+export const DEFAULT_MARKER_ICON_KEY = 'thumbtack';
 
 /**
  * Preset badge-color swatches for the marker form -- chosen to stay

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -2581,6 +2581,17 @@ function VM() {
         });
     }
 
+    // Fetches a single Ops Log entry by id. Used by the collaborative map
+    // layers feature, which stores only an entry id on each marker and
+    // treats the Ops Log entry itself as the source of truth for the
+    // marker's title/description/comments (see mapLayers/collabLayer.js).
+    self.getOpsLogEntry = async function (entryId, cb) {
+        const t = await getToken();   // blocks here until token is ready
+        BeaconClient.operationslog.get(entryId, apiHost, params.userId, t, function (data) {
+            cb(data);
+        });
+    }
+
     self.updateTeamStatus = function (tasking, status, payload, cb) {
         BeaconClient.tasking.updateTeamStatus(apiHost, tasking.id(), status, payload, token, function (data) {
             tasking.job.fetchTasking({ force: true });

--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -6,12 +6,27 @@ import {
     fetchLayerMarkers,
     upsertMarker,
     deleteMarker,
+    addMarkerComment,
 } from "../utils/collabLayerSync.js";
 
 const REFRESH_MS = 10000; // polling only fires while the layer is visible (registerPollingLayer's hasLayer gate)
 const DEFAULT_FILL = MARKER_COLOR_SWATCHES[5]; // blue -- also the first swatch highlighted as "active" for a new marker
 
+// Purely an aesthetic guardrail, not a backend one (the Lambda/Ops Log
+// don't enforce a length at all) -- keeps a description or comment from
+// growing into an unreadable wall of text that blows out the map popup's
+// bounded width. Enforced client-side only, via maxlength on the textareas.
+const TEXT_CHAR_LIMIT = 300;
+
 const layerKeyFor = (layerId) => `collab-${layerId}`;
+
+// Layer keys with an interactive popup (a marker's view popup, or the
+// create/edit form) currently open. The polling refresh's drawFn rebuilds
+// every marker on the layer from scratch each tick (layerGroup.clearLayers()
+// + redraw), which would otherwise silently close whatever popup the user
+// has open -- e.g. fading it out mid-keystroke while typing a comment or
+// editing a description. registerLayerPolling's skipIfBusy checks this.
+const busyLayerKeys = new Set();
 
 function timeAgo(iso) {
     if (!iso) return "";
@@ -23,6 +38,31 @@ function timeAgo(iso) {
     const hrs = Math.round(mins / 60);
     if (hrs < 24) return `${hrs}h ago`;
     return `${Math.round(hrs / 24)}d ago`;
+}
+
+const escHtml = (s) => String(s || "").replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+}[c]));
+
+/**
+ * Wires a live "n/limit" counter to a textarea's sibling `.collab-char-
+ * counter` element, colouring it up as the limit approaches/hits so the
+ * limit reads as guidance rather than a hard wall -- there's nothing on
+ * the backend enforcing it, `maxlength` on the textarea itself is what
+ * actually stops typing past it.
+ */
+function wireCharCounter(textareaEl, limit) {
+    const counterEl = textareaEl.parentElement.querySelector(".collab-char-counter");
+    if (!counterEl) return;
+
+    const update = () => {
+        const len = textareaEl.value.length;
+        counterEl.textContent = `${len}/${limit}`;
+        counterEl.classList.toggle("collab-char-counter-warn", len >= limit * 0.9 && len < limit);
+        counterEl.classList.toggle("collab-char-counter-limit", len >= limit);
+    };
+    textareaEl.addEventListener("input", update);
+    update();
 }
 
 /** Collaborative layers currently toggled visible on the map. */
@@ -49,6 +89,7 @@ function registerLayerPolling(vm, apiUrl, layer, actorId, getToken) {
         visibleByDefault: false,
         fetchFn: async () => fetchLayerMarkers(apiUrl, layer.id, await getToken()),
         drawFn: (layerGroup, data) => drawCollabMarkers(vm, layerGroup, data, apiUrl, layer.id, key, actorId, getToken),
+        skipIfBusy: () => busyLayerKeys.has(key),
     });
 }
 
@@ -60,7 +101,13 @@ function registerLayerPolling(vm, apiUrl, layer, actorId, getToken) {
 export async function refreshCollabLayerList(vm, apiUrl, actorId, getToken) {
     const layers = await listLayers(apiUrl, await getToken());
     vm.mapVM.collabLayers(layers);
-    layers.forEach((layer) => registerLayerPolling(vm, apiUrl, layer, actorId, getToken));
+    // Only register layers we haven't seen yet -- re-registering an already
+    // visible layer would hand it a brand new (empty) layerGroup that never
+    // gets added to the map, silently blanking it out until its View switch
+    // is toggled off and back on.
+    layers
+        .filter((layer) => !vm.mapVM.onlineLayers.has(layerKeyFor(layer.id)))
+        .forEach((layer) => registerLayerPolling(vm, apiUrl, layer, actorId, getToken));
     vm.mapVM.layersDrawer?.refresh?.();
     return layers;
 }
@@ -82,8 +129,14 @@ export async function createCollabLayer(vm, apiUrl, name, actorId, getToken) {
     if (!layer) return null;
     const list = vm.mapVM.collabLayers();
     vm.mapVM.collabLayers([...list, layer]);
+    const key = layerKeyFor(layer.id);
     registerLayerPolling(vm, apiUrl, layer, actorId, getToken);
+    // Auto-show layers the user just created -- matches the 'ov.<drawerKey>'
+    // flag both the layers drawer (main.js) and the Config modal's View
+    // switch (Config.js collabLayerRows) read to decide initial visibility.
+    localStorage.setItem(`ov.online-${key}`, '1');
     vm.mapVM.layersDrawer?.refresh?.();
+    vm.mapVM.refreshPollingLayer(key);
     return layer;
 }
 
@@ -95,10 +148,23 @@ function drawCollabMarkers(vm, layerGroup, data, apiUrl, layerId, key, actorId, 
         const icon = buildMarkerBadgeIcon({ icon: marker.icon, fill: marker.fill || DEFAULT_FILL });
 
         const leafletMarker = L.marker([marker.lat, marker.lng], { icon });
-        leafletMarker.bindPopup(() => buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken), {
-            minWidth: 240,
-            maxWidth: 280,
+
+        // Bind a concrete, already-built element rather than Leaflet's
+        // "content factory function" form of bindPopup -- that form gets
+        // re-invoked on every popup.update() call, not just on open, and
+        // loadMarkerContent() below calls update() after each async Ops
+        // Log fetch. A function-content popup would rebuild itself (and
+        // re-fetch, and re-update(), ...) in an unbounded loop. Fetching is
+        // instead deferred to the "popupopen" event so a marker's Ops Log
+        // entry is only pulled once the user actually clicks it.
+        const { el, state } = buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken, leafletMarker);
+        leafletMarker.bindPopup(el, { minWidth: 260, maxWidth: 320 });
+        leafletMarker.on("popupopen", () => {
+            busyLayerKeys.add(key);
+            loadMarkerContent(vm, marker, el, leafletMarker, state);
         });
+        leafletMarker.on("popupclose", () => busyLayerKeys.delete(key));
+
         layerGroup.addLayer(leafletMarker);
     });
 }
@@ -106,17 +172,24 @@ function drawCollabMarkers(vm, layerGroup, data, apiUrl, layerId, key, actorId, 
 // Any marker on a visible layer can be edited/deleted -- protection against
 // accidental changes comes from requiring an explicit Edit/Delete button
 // click (and a confirm step for delete), not from a separate "edit mode".
-function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken) {
+//
+// The marker record only carries GPS/style + Ops Log entry ids -- title,
+// description and comment text are all resolved live from the Ops Log
+// (source of truth), fetched lazily on "popupopen" (see drawCollabMarkers).
+function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken, leafletMarker) {
     const el = document.createElement("div");
     el.className = "collab-marker-popup";
 
-    const escHtml = (s) => String(s || "").replace(/[&<>"']/g, (c) => ({
-        "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
-    }[c]));
-
     el.innerHTML = `
-        <div class="collab-marker-desc">${escHtml(marker.description) || "<em>No description</em>"}</div>
-        <div class="collab-marker-meta">Added by <span class="collab-marker-author">user ${escHtml(marker.createdBy)}</span>${marker.updatedAt ? ` · updated ${timeAgo(marker.updatedAt)}` : ""}</div>
+        <div class="collab-marker-title">Loading…</div>
+        <div class="collab-marker-desc"></div>
+        <div class="collab-marker-meta"></div>
+        <div class="collab-marker-comments"></div>
+        <div class="collab-marker-comment-form">
+            <textarea class="collab-comment-input" placeholder="Add a comment…" rows="2" maxlength="${TEXT_CHAR_LIMIT}"></textarea>
+            <div class="collab-char-counter"></div>
+            <button type="button" class="btn btn-sm btn-outline-primary collab-add-comment-btn">Comment</button>
+        </div>
         <div class="collab-marker-actions">
             <button type="button" class="btn btn-sm btn-outline-secondary collab-edit-marker-btn">Edit</button>
             <button type="button" class="btn btn-sm btn-outline-danger collab-delete-marker-btn">Delete</button>
@@ -134,10 +207,13 @@ function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken)
     const actionsBox = el.querySelector(".collab-marker-actions");
     const confirmDeleteBtn = el.querySelector(".collab-confirm-delete-btn");
     const cancelDeleteBtn = el.querySelector(".collab-cancel-delete-btn");
+    const commentInput = el.querySelector(".collab-comment-input");
+    const addCommentBtn = el.querySelector(".collab-add-comment-btn");
+    wireCharCounter(commentInput, TEXT_CHAR_LIMIT);
 
     editBtn.addEventListener("click", () => {
         vm.mapVM.map.closePopup();
-        openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, L.latLng(marker.lat, marker.lng), getToken);
+        openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, L.latLng(marker.lat, marker.lng), getToken, state.mainEntry);
     });
 
     deleteBtn.addEventListener("click", () => {
@@ -149,22 +225,185 @@ function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken)
         actionsBox.classList.remove("d-none");
     });
     confirmDeleteBtn.addEventListener("click", async () => {
+        // Whatever title/description the marker currently resolves to (or
+        // blank, if the Ops Log lookup above hasn't landed yet) becomes the
+        // deletion audit entry's content -- there's nothing left to stamp
+        // an opsLogId onto afterwards, so it only lives in the Ops Log.
+        const title = stripSubjectPrefix(state.mainEntry?.Subject);
+        const description = stripAuditFooter(state.mainEntry?.Text);
+        vm.mapVM.map.closePopup(); // clears busyLayerKeys (via "popupclose") before the refresh below
+        await logMarkerAudit(vm, "deleted", layerId, marker, title, description);
         await deleteMarker(apiUrl, layerId, marker.id, actorId, await getToken());
         vm.mapVM.refreshPollingLayer(key);
     });
 
-    // Resolve the raw user id shown above into a display name once it's
-    // available (cached/deduped by vm.resolvePersonName). The placeholder
-    // stays if the marker's own popup gets closed/rebuilt before this
-    // resolves -- updating a detached node is a harmless no-op.
-    if (marker.createdBy && vm.resolvePersonName) {
-        const authorEl = el.querySelector(".collab-marker-author");
-        vm.resolvePersonName(marker.createdBy).then((name) => {
-            if (authorEl && name) authorEl.textContent = name;
-        });
+    addCommentBtn.addEventListener("click", async () => {
+        const text = commentInput.value.trim();
+        if (!text) return;
+        addCommentBtn.disabled = true;
+        try {
+            const opsLogId = await logMarkerComment(vm, layerId, marker, text);
+            if (opsLogId == null) return;
+            await addMarkerComment(apiUrl, layerId, marker.id, opsLogId, actorId, await getToken());
+            marker.commentOpsLogIds = Array.isArray(marker.commentOpsLogIds) ? [...marker.commentOpsLogIds, opsLogId] : [opsLogId];
+            commentInput.value = "";
+            await renderComments(vm, el.querySelector(".collab-marker-comments"), marker, leafletMarker);
+        } finally {
+            addCommentBtn.disabled = false;
+        }
+    });
+
+    // Populated on "popupopen" (see drawCollabMarkers) via loadMarkerContent,
+    // which fetches the marker's title/description/comments from the Ops
+    // Log. `state.mainEntry` is stashed there so the Edit/Delete handlers
+    // above can read whatever title and description are currently showing.
+    const state = { mainEntry: null };
+
+    return { el, state };
+}
+
+function loadMarkerContent(vm, marker, el, leafletMarker, state) {
+    const titleEl = el.querySelector(".collab-marker-title");
+    const descEl = el.querySelector(".collab-marker-desc");
+    const metaEl = el.querySelector(".collab-marker-meta");
+
+    return fetchOpsLogEntry(vm, marker.opsLogId).then((entry) => {
+        state.mainEntry = entry;
+        if (entry) {
+            titleEl.textContent = stripSubjectPrefix(entry.Subject) || "Untitled marker";
+            descEl.textContent = stripAuditFooter(entry.Text);
+            const author = entry.CreatedBy?.FullName || (marker.createdBy ? `user ${marker.createdBy}` : "Unknown");
+            metaEl.textContent = `Added by ${author}${marker.updatedAt ? ` · updated ${timeAgo(marker.updatedAt)}` : ""}`;
+        } else {
+            titleEl.textContent = "Untitled marker";
+            descEl.innerHTML = "<em>Ops Log entry unavailable</em>";
+            metaEl.textContent = marker.createdBy ? `Added by user ${marker.createdBy}` : "";
+        }
+        leafletMarker.getPopup()?.update();
+        return renderComments(vm, el.querySelector(".collab-marker-comments"), marker, leafletMarker);
+    });
+}
+
+function renderComments(vm, commentsEl, marker, leafletMarker) {
+    const ids = Array.isArray(marker.commentOpsLogIds) ? marker.commentOpsLogIds : [];
+    if (!ids.length) {
+        commentsEl.innerHTML = "";
+        return Promise.resolve();
     }
 
-    return el;
+    commentsEl.innerHTML = `<div class="collab-marker-comments-loading">Loading comments…</div>`;
+    leafletMarker.getPopup()?.update();
+
+    return Promise.all(ids.map((id) => fetchOpsLogEntry(vm, id))).then((entries) => {
+        commentsEl.innerHTML = entries
+            .filter(Boolean)
+            .sort((a, b) => new Date(a.TimeLogged || 0) - new Date(b.TimeLogged || 0))
+            .map((c) => `
+                <div class="collab-marker-comment">
+                    <div class="collab-marker-comment-text">${escHtml(stripAuditFooter(c.Text))}</div>
+                    <div class="collab-marker-comment-meta">${escHtml(c.CreatedBy?.FullName || "Unknown")} · ${timeAgo(c.TimeLogged)}</div>
+                </div>
+            `).join("");
+        leafletMarker.getPopup()?.update();
+    });
+}
+
+// ── Ops Log audit trail ──────────────────────────────────────────────
+//
+// Every marker create/edit/delete/comment is logged to Beacon's Operations
+// Log, and the Ops Log is the source of truth for the marker's title,
+// description and comment thread -- the marker record itself only stores
+// GPS/style plus the entry ids (opsLogId, commentOpsLogIds), resolved back
+// via BeaconClient.operationslog.get() (loadMarkerContent/renderComments
+// above). A Beacon Ops Log entry can only be edited by its author, so
+// editing a marker always creates a *new* entry and re-points opsLogId at
+// it rather than mutating the old one -- comments work the same way, each
+// one just its own entry appended to commentOpsLogIds. Tag 4 is a
+// known-good TagIds value confirmed to work against the live API -- there
+// isn't a dedicated "map marker" tag to select instead.
+const MARKER_AUDIT_TAG_ID = 4;
+
+// Every entry this feature creates gets this prefix on its Subject, so it's
+// identifiable at a glance among an entity's other Ops Log entries in
+// Beacon itself.
+const AUDIT_SUBJECT_PREFIX = "Lighthouse LAD - ";
+
+// The full audit detail (coords/icon/colour/layer/action) is appended to
+// Text after this marker so it's captured in the Ops Log entry itself, but
+// the marker popup only ever shows what's *before* it -- just the user's
+// own title/description/comment, not the surrounding metadata. Deliberately
+// distinctive so it'll never collide with anything a user actually types.
+const AUDIT_FOOTER_MARKER = "\n\n————— Lighthouse LAD marker details —————\n";
+
+function buildMarkerAuditFooter(action, layerName, marker) {
+    const coords = `${marker.lat.toFixed(5)}, ${marker.lng.toFixed(5)}`;
+    return `${AUDIT_FOOTER_MARKER}Collaborative marker ${action} on layer "${layerName}" at ${coords}. Icon: ${marker.icon}, colour: ${marker.fill}.`;
+}
+
+/** Strips the audit-detail footer back off an Ops Log entry's Text for display. */
+function stripAuditFooter(text) {
+    const idx = (text || "").indexOf(AUDIT_FOOTER_MARKER);
+    return idx === -1 ? (text || "") : text.slice(0, idx);
+}
+
+/** Strips the "Lighthouse LAD - " prefix back off an Ops Log entry's Subject for display. */
+function stripSubjectPrefix(subject) {
+    return subject && subject.startsWith(AUDIT_SUBJECT_PREFIX) ? subject.slice(AUDIT_SUBJECT_PREFIX.length) : (subject || "");
+}
+
+function createOpsLogAuditEntry(vm, subject, text) {
+    if (typeof vm.createOpsLogEntry !== "function") return Promise.resolve(null);
+
+    const payload = {
+        Subject: `${AUDIT_SUBJECT_PREFIX}${subject}`,
+        Text: text,
+        Important: false,
+        Restricted: false,
+        ActionRequired: false,
+        TagIds: [MARKER_AUDIT_TAG_ID],
+        TimeLogged: new Date().toISOString(),
+    };
+
+    return new Promise((resolve) => {
+        vm.createOpsLogEntry(payload, (result) => resolve(result?.Id ?? null));
+    });
+}
+
+/**
+ * Log a marker create/edit/delete to the Operations Log and resolve with
+ * the new entry's id (or null if unavailable/failed) so it can be attached
+ * to the marker as its opsLogId.
+ *
+ * The Subject always leads with "Collaborative marker <action>" -- same as
+ * a comment's fixed "Collaborative marker comment" -- so what happened is
+ * clear at a glance in Beacon's Ops Log list without opening the entry;
+ * the user's own title (if any) is appended for extra context, but never
+ * stands in for it alone the way it used to.
+ */
+function logMarkerAudit(vm, action, layerId, marker, title, description) {
+    const layerName = vm.mapVM.collabLayers().find((l) => l.id === layerId)?.name || layerId;
+    const subject = `Collaborative marker ${action}${title ? ` - ${title}` : ""}`;
+    const text = `${description || ""}${buildMarkerAuditFooter(action, layerName, marker)}`;
+    return createOpsLogAuditEntry(vm, subject, text);
+}
+
+/**
+ * Log a comment on a marker to the Operations Log and resolve with the new
+ * entry's id (or null if unavailable/failed) so it can be appended to the
+ * marker's commentOpsLogIds.
+ */
+function logMarkerComment(vm, layerId, marker, commentText) {
+    const layerName = vm.mapVM.collabLayers().find((l) => l.id === layerId)?.name || layerId;
+    const text = `${commentText}${buildMarkerAuditFooter("commented on", layerName, marker)}`;
+    return createOpsLogAuditEntry(vm, "Collaborative marker comment", text);
+}
+
+/** Fetch a single Ops Log entry by id, resolving null if unavailable/failed. */
+function fetchOpsLogEntry(vm, entryId) {
+    if (entryId == null || typeof vm.getOpsLogEntry !== "function") return Promise.resolve(null);
+    return new Promise((resolve) => {
+        vm.getOpsLogEntry(entryId, (result) => resolve(result || null));
+    });
 }
 
 // ── Marker create/edit form (inline popup) ──────────────────────────
@@ -194,13 +433,19 @@ function buildColorSwatchesHtml(selectedFill) {
  * Open an inline popup form (create if `marker` is null, edit otherwise)
  * at the given latlng. Only an explicit Save click writes data.
  *
+ * `currentEntry` is the marker's currently-resolved Ops Log entry (from
+ * loadMarkerContent, via the popup's Edit button) so the title/description
+ * fields can be prefilled without a second fetch -- it's undefined for a
+ * brand new marker, or if the lookup hadn't landed yet when Edit was
+ * clicked, in which case the fields just start blank.
+ *
  * Icon and color are each picked from a small dropdown toggle button, with
  * a live preview badge showing the combined result. Both dropdowns render
  * as floating panels appended to the map container -- outside the Leaflet
  * popup's own content -- so opening/closing either one never changes the
  * popup's size or makes it reposition itself.
  */
-function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getToken) {
+function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getToken, currentEntry) {
     let icon = marker?.icon || DEFAULT_MARKER_ICON_KEY;
     let fill = marker?.fill || DEFAULT_FILL;
 
@@ -223,7 +468,10 @@ function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getTo
                 <i class="fas fa-caret-down ms-auto"></i>
             </button>
         </div>
-        <textarea class="collab-desc-input" placeholder="Description" rows="2">${marker?.description || ""}</textarea>
+        <input type="text" class="collab-title-input" placeholder="Title" maxlength="200" value="${escHtml(stripSubjectPrefix(currentEntry?.Subject))}">
+        <textarea class="collab-desc-input" placeholder="Description" rows="2" maxlength="${TEXT_CHAR_LIMIT}">${escHtml(stripAuditFooter(currentEntry?.Text))}</textarea>
+        <div class="collab-char-counter"></div>
+        <div class="collab-marker-audit-notice"><i class="fas fa-info-circle"></i> All marker actions -- create, edit, delete, and comments -- create an Ops Log entries.</div>
         <div class="collab-form-actions">
             <button type="button" class="btn btn-sm btn-secondary collab-cancel-btn">Cancel</button>
             <button type="button" class="btn btn-sm btn-primary collab-save-btn">Save</button>
@@ -233,6 +481,8 @@ function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getTo
     const previewEl = el.querySelector(".collab-style-preview");
     const iconToggle = el.querySelector(".collab-icon-toggle");
     const colorToggle = el.querySelector(".collab-color-toggle");
+
+    wireCharCounter(el.querySelector(".collab-desc-input"), TEXT_CHAR_LIMIT);
 
     const renderPreview = () => {
         previewEl.innerHTML = `<span class="collab-marker-badge"><i class="fas ${faClassForIconKey(icon)}"></i></span>`;
@@ -278,13 +528,21 @@ function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getTo
         .setContent(el)
         .openOn(vm.mapVM.map);
 
-    popup.on("remove", closeFloatingDropdown);
+    // Keeps the layer's poll-driven redraw (registerLayerPolling's
+    // skipIfBusy) from clearing+rebuilding every marker -- and closing this
+    // form -- out from under whatever the user is mid-typing.
+    busyLayerKeys.add(key);
+    popup.on("remove", () => {
+        busyLayerKeys.delete(key);
+        closeFloatingDropdown();
+    });
 
     el.querySelector(".collab-cancel-btn").addEventListener("click", () => {
         vm.mapVM.map.closePopup(popup);
     });
 
     el.querySelector(".collab-save-btn").addEventListener("click", async () => {
+        const title = el.querySelector(".collab-title-input").value.trim();
         const description = el.querySelector(".collab-desc-input").value.trim();
         const payload = {
             id: marker?.id,
@@ -292,9 +550,12 @@ function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getTo
             lng: latlng.lng,
             icon,
             fill,
-            description,
         };
         vm.mapVM.map.closePopup(popup);
+
+        const opsLogId = await logMarkerAudit(vm, marker ? "edited" : "created", layerId, payload, title, description);
+        if (opsLogId != null) payload.opsLogId = opsLogId;
+
         await upsertMarker(apiUrl, layerId, payload, actorId, await getToken());
         vm.mapVM.refreshPollingLayer(key);
     });

--- a/src/pages/tasking/utils/collabLayerSync.js
+++ b/src/pages/tasking/utils/collabLayerSync.js
@@ -148,7 +148,9 @@ export async function fetchLayerMarkers(apiUrl, layerId, token) {
  * update to the cached layer before firing the remote write.
  * @param {string} apiUrl
  * @param {string} layerId
- * @param {{id?: string, lat: number, lng: number, shape: string, fill: string, stroke: string, description: string}} marker
+ * @param {{id?: string, lat: number, lng: number, icon: string, fill: string, opsLogId?: number}} marker
+ *   Title/description aren't stored here -- they live in the Ops Log entry
+ *   `opsLogId` points at (see mapLayers/collabLayer.js).
  * @param {string} actorId
  * @param {string} token  Beacon access token (Authorization: Bearer).
  * @returns {Promise<Object|null>} the saved marker (with server-assigned id/timestamps), or null on failure
@@ -228,5 +230,57 @@ export async function deleteMarker(apiUrl, layerId, markerId, actorId, token) {
         await fetch(url, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } });
     } catch (err) {
         console.warn('[collabLayerSync] deleteMarker error:', err);
+    }
+}
+
+/**
+ * Attach a comment -- an Ops Log entry id already created client-side --
+ * to a marker's comment thread. Applies an optimistic local update to the
+ * cached layer before firing the remote write.
+ * @param {string} apiUrl
+ * @param {string} layerId
+ * @param {string} markerId
+ * @param {number} opsLogId  Id of the comment's Ops Log entry.
+ * @param {string} actorId
+ * @param {string} token  Beacon access token (Authorization: Bearer).
+ * @returns {Promise<Object|null>} the updated marker, or null on failure
+ */
+export async function addMarkerComment(apiUrl, layerId, markerId, opsLogId, actorId, token) {
+    if (!apiUrl || !layerId || !markerId || opsLogId == null) return null;
+
+    // Optimistic local update
+    const cached = loadCachedLayer(layerId);
+    if (cached && Array.isArray(cached.markers)) {
+        const m = cached.markers.find((mk) => mk.id === markerId);
+        if (m) {
+            m.commentOpsLogIds = Array.isArray(m.commentOpsLogIds) ? [...m.commentOpsLogIds, opsLogId] : [opsLogId];
+            saveCachedLayer(layerId, cached);
+        }
+    }
+
+    try {
+        const url = `${LAMBDA_BASE}/${encodeURIComponent(layerId)}/features/${encodeURIComponent(markerId)}/comments`;
+        const res = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+            body: JSON.stringify({ apiUrl, opsLogId, actorId: String(actorId) }),
+        });
+        if (!res.ok) {
+            throw new Error(`addMarkerComment failed with status ${res.status}`);
+        }
+        const saved = await res.json();
+
+        // Reconcile with server-confirmed state
+        const latest = loadCachedLayer(layerId) || cached;
+        if (latest && Array.isArray(latest.markers)) {
+            const i = latest.markers.findIndex((mk) => mk.id === markerId);
+            if (i >= 0) latest.markers[i] = saved;
+            saveCachedLayer(layerId, latest);
+        }
+
+        return saved;
+    } catch (err) {
+        console.warn('[collabLayerSync] addMarkerComment error:', err);
+        return null;
     }
 }

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -3,7 +3,7 @@ import ko from 'knockout';
 
 import * as bootstrap from 'bootstrap5'; // Modal, Tooltip, etc.
 import { Enum } from '../utils/enum.js';
-import { createCollabLayer } from '../mapLayers/collabLayer.js';
+import { createCollabLayer, refreshCollabLayerList } from '../mapLayers/collabLayer.js';
 
 
 
@@ -200,6 +200,7 @@ export function ConfigVM(root, deps) {
     self.creatingCollabLayer = ko.observable(false);
     self.collabLayerError = ko.observable('');
     self.collabLayerSearch = ko.observable(''); // filters the (possibly long) layer list below
+    self.refreshingCollabLayers = ko.observable(false);
 
     function relativeTime(iso) {
         if (!iso) return 'never';
@@ -277,6 +278,24 @@ export function ConfigVM(root, deps) {
             self.collabLayerError('Failed to create layer. Try again later.');
         } finally {
             self.creatingCollabLayer(false);
+        }
+    };
+
+    // Re-pulls the org's layer list from the server -- picks up layers
+    // created by other users since this page loaded (createCollabLayer
+    // above only accounts for layers *this* session created).
+    self.refreshCollabLayers = async () => {
+        if (!deps.apiUrl || self.refreshingCollabLayers()) return;
+
+        self.collabLayerError('');
+        self.refreshingCollabLayers(true);
+        try {
+            await refreshCollabLayerList(root, deps.apiUrl, deps.userId, deps.getToken);
+        } catch (err) {
+            console.error('Error refreshing collaborative layers:', err);
+            self.collabLayerError('Failed to refresh layer list. Try again later.');
+        } finally {
+            self.refreshingCollabLayers(false);
         }
     };
 

--- a/src/pages/tasking/viewmodels/Map.js
+++ b/src/pages/tasking/viewmodels/Map.js
@@ -514,6 +514,13 @@ export function MapVM(Lmap, root) {
       visibleByDefault: opts.visibleByDefault === true,
       fetchFn: opts.fetchFn,
       drawFn: opts.drawFn,
+      // Optional () => boolean. When it returns true, a poll tick is
+      // skipped entirely rather than fetch+redrawing -- for layers whose
+      // drawFn rebuilds every marker from scratch (clearLayers()), redrawing
+      // out from under an open popup would silently close it, e.g. while a
+      // user is mid-edit. See mapLayers/collabLayer.js for the only current
+      // user of this.
+      skipIfBusy: opts.skipIfBusy,
       timerId: null,
       menuGroup: opts.menuGroup || null,
     };
@@ -522,6 +529,7 @@ export function MapVM(Lmap, root) {
     // Only fetch/draw if the layer is actually on the map
     async function refreshIfVisible() {
       if (!self.map.hasLayer(layerGroup)) return;
+      if (entry.skipIfBusy?.()) return;
 
       try {
         const data = await entry.fetchFn();
@@ -559,6 +567,7 @@ export function MapVM(Lmap, root) {
     async function run() {
       // bail if layer is not currently visible on the map
       if (!self.map.hasLayer(entry.layerGroup)) return;
+      if (entry.skipIfBusy?.()) return;
 
       try {
         const data = await entry.fetchFn();

--- a/src/shared/BeaconClient/operationslog.js
+++ b/src/shared/BeaconClient/operationslog.js
@@ -32,11 +32,11 @@ export function get(entryId, host, userId = 'notPassed', token, callback) {
     cache: false,
     dataType: 'json',
     complete: function(response, textStatus) {
+      if (typeof callback !== "function") return;
       if (textStatus == 'success') {
-        let results = response.responseJSON;
-        if (typeof callback === "function") {
-          callback(results);
-        }
+        callback(response.responseJSON);
+      } else {
+        callback(null);
       }
     }
   })

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2791,9 +2791,15 @@
 
                                                 <hr class="my-4">
 
-                                                <h6 class="fw-semibold mb-2">
-                                                    <i class="fa fa-users me-1"></i>Collaborative Layers
-                                                </h6>
+                                                <div class="d-flex align-items-center justify-content-between mb-2">
+                                                    <h6 class="fw-semibold mb-0">
+                                                        <i class="fa fa-users me-1"></i>Collaborative Layers
+                                                    </h6>
+                                                    <button class="btn btn-sm btn-outline-secondary py-0 px-2" type="button" title="Refresh layer list"
+                                                        data-bind="click: config.refreshCollabLayers, disable: config.refreshingCollabLayers">
+                                                        <i class="fa fa-sync" data-bind="css: { 'fa-spin': config.refreshingCollabLayers }"></i>
+                                                    </button>
+                                                </div>
                                                 <p class="small text-muted mb-3">
                                                     Shared marker layers that everyone in your organisation can see and
                                                     edit together. Enable View to show a layer on the map — once

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2608,13 +2608,79 @@ overflow: hidden;
   font-size: 12px;
   min-width: 200px;
 }
+.collab-marker-title {
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 2px;
+}
 .collab-marker-desc {
   margin-bottom: 4px;
+  white-space: pre-wrap;
 }
 .collab-marker-meta {
   color: #888;
   font-size: 11px;
   margin-bottom: 6px;
+}
+.collab-marker-comments {
+  border-top: 1px solid #eee;
+  margin-bottom: 6px;
+}
+.collab-marker-comments:empty {
+  border-top: none;
+  margin-bottom: 0;
+}
+.collab-marker-comments-loading {
+  color: #888;
+  font-size: 11px;
+  padding: 6px 0 2px;
+}
+.collab-marker-comment {
+  padding: 6px 0 2px;
+  border-bottom: 1px solid #f2f2f2;
+}
+.collab-marker-comment:last-child {
+  border-bottom: none;
+}
+.collab-marker-comment-text {
+  white-space: pre-wrap;
+}
+.collab-marker-comment-meta {
+  color: #888;
+  font-size: 10.5px;
+  margin-top: 2px;
+}
+.collab-marker-comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+.collab-marker-comment-form .collab-comment-input {
+  width: 100%;
+  font-size: 12px;
+}
+.collab-marker-comment-form .collab-add-comment-btn {
+  align-self: flex-end;
+  font-size: 10px;
+  padding: 1px 6px;
+  line-height: 1.4;
+}
+/* Aesthetic-only text limit indicator (description/comment textareas) --
+   never affects layout beyond its own line, so it can't destabilize the
+   popup's size the way growing/shrinking the textarea itself would. */
+.collab-char-counter {
+  text-align: right;
+  font-size: 10px;
+  color: #999;
+  margin-top: -2px;
+}
+.collab-char-counter-warn {
+  color: #c07a00;
+}
+.collab-char-counter-limit {
+  color: #c0392b;
+  font-weight: 600;
 }
 .collab-marker-actions,
 .collab-marker-confirm {
@@ -2808,10 +2874,31 @@ overflow: hidden;
   background: #eaf2fc;
   color: #2b6cb0;
 }
+.collab-title-input {
+  width: 100%;
+  margin-bottom: 6px;
+  font-size: 12px;
+  padding: 4px 6px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
 .collab-desc-input {
   width: 100%;
   margin-bottom: 6px;
   font-size: 12px;
+}
+.collab-marker-audit-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+  color: #888;
+  font-size: 10.5px;
+  line-height: 1.35;
+  margin-bottom: 8px;
+}
+.collab-marker-audit-notice .fa-info-circle {
+  margin-top: 1px;
+  flex-shrink: 0;
 }
 .collab-form-actions {
   display: flex;


### PR DESCRIPTION
## Summary
- Adds a threaded comment log to collaborative tasking-layer markers. Marker title/description and comments are resolved through the Beacon Operations Log (pointers stored on the marker, text lives in Ops Log entries) rather than free text on the marker record, via a new `addMarkerComment` Lambda handler.
- Replaces the marker icon picker's 42-icon/7-group set with a curated 26-icon/6-group set: Hazards & Weather, Vehicles & Rescue, People & Animals, Resources & Supplies, Observation & Comms, Status & Markers.
- Updates the `map-layers-v2` Lambda's `ICON_KEYS` allowlist and `DEFAULT_ICON` to match the new set — this list is server-side validation and must stay in sync with `MARKER_ICON_GROUPS`, or new icon keys get silently rejected and swapped for the default.
- Skips a layer's poll tick entirely (`skipIfBusy`) instead of fetch+redrawing when a marker's edit popup is open, so an in-progress edit isn't closed out from under the user.
- Adds `refreshCollabLayers` to pull in layers other users created since page load.

## Test plan
- [ ] Drop a new marker on a collaborative layer, confirm the icon picker shows the new 6 groups / 26 icons and the badge renders correctly
- [ ] Add a comment to a marker, reload the page, confirm the comment thread persists via the Ops Log
- [ ] Edit a marker's icon to a value from the old set (simulating stale client state) and confirm it falls back to the new default (`thumbtack`) rather than erroring
- [ ] Confirm layer polling doesn't close an open marker popup mid-edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)