### PR TITLE
Add per-layer permissions (read-only, delete, comments) to collaborative map layers

### DIFF
--- a/lambda/map-layers-v2/handlers/addMarkerComment.js
+++ b/lambda/map-layers-v2/handlers/addMarkerComment.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
-const { json, badRequest, notFound } = require('../lib/response');
+const { json, badRequest, notFound, forbidden } = require('../lib/response');
 
 // POST /map-layers/{id}/features/{markerId}/comments
 // body: { apiUrl, actorId, opsLogId }
@@ -34,6 +34,10 @@ module.exports = async function addMarkerComment(event) {
 
   const marker = layer.markers.find((m) => m.id === markerId);
   if (!marker) return notFound('Marker not found');
+
+  if (layer.disableComments) {
+    return forbidden('Comments are disabled on this layer');
+  }
 
   marker.commentOpsLogIds = Array.isArray(marker.commentOpsLogIds) ? marker.commentOpsLogIds : [];
   marker.commentOpsLogIds.push(opsLogId);

--- a/lambda/map-layers-v2/handlers/createLayer.js
+++ b/lambda/map-layers-v2/handlers/createLayer.js
@@ -4,8 +4,26 @@ const crypto = require('crypto');
 const { updateIndex, putLayerObject } = require('../lib/s3Store');
 const { json, badRequest } = require('../lib/response');
 
-// POST /map-layers   body: { apiUrl, name, createdBy }
-module.exports = async function createLayer(event) {
+// POST /map-layers   body: { apiUrl, name, createdBy, readOnly?, allowDeleteByOthers?, disableComments? }
+//
+// The three permission flags are fixed at creation time -- there's no
+// "edit layer settings" flow, so every handler that reads them back off the
+// stored layer/summary can treat them as immutable for that layer's
+// lifetime.
+//   - readOnly (default false): only the creator may create/edit/delete
+//     markers; everyone else may still comment (unless disableComments).
+//     Enforced in upsertFeature.js / deleteFeature.js.
+//   - allowDeleteByOthers (default true): whether anyone, vs. only the
+//     creator, may delete the layer itself. Enforced in deleteLayer.js.
+//   - disableComments (default false): blocks comments for everyone,
+//     including the creator. Enforced in addMarkerComment.js.
+//
+// "The creator" for all of the above means `createdByMemberId` --
+// `claims.sub`, the Beacon member id off the caller's own verified token --
+// not the client-supplied `createdBy` (actorId/personId), which is only
+// bookkeeping/display metadata a caller could set to anything. See
+// index.js, which passes the verified claims into every handler.
+module.exports = async function createLayer(event, claims) {
   let body;
   try {
     body = JSON.parse(event.body || '{}');
@@ -16,13 +34,23 @@ module.exports = async function createLayer(event) {
   const apiUrl = body.apiUrl;
   const name = String(body.name || '').trim().slice(0, 200);
   const createdBy = String(body.createdBy || '').slice(0, 100);
+  const createdByMemberId = String(claims?.sub || '');
+  const readOnly = body.readOnly === true;
+  const allowDeleteByOthers = body.allowDeleteByOthers !== false;
+  const disableComments = body.disableComments === true;
 
   if (!apiUrl || !name) return badRequest('apiUrl and name are required');
 
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
-  const summary = { id, name, createdBy, createdAt: now, lastUsedAt: now, markerCount: 0 };
-  const layer = { id, apiUrl, name, createdBy, createdAt: now, lastUsedAt: now, markers: [] };
+  const summary = {
+    id, name, createdBy, createdByMemberId, createdAt: now, lastUsedAt: now, markerCount: 0,
+    readOnly, allowDeleteByOthers, disableComments,
+  };
+  const layer = {
+    id, apiUrl, name, createdBy, createdByMemberId, createdAt: now, lastUsedAt: now, markers: [],
+    readOnly, allowDeleteByOthers, disableComments,
+  };
 
   await putLayerObject(apiUrl, id, layer);
   await updateIndex(apiUrl, (index) => {

--- a/lambda/map-layers-v2/handlers/deleteFeature.js
+++ b/lambda/map-layers-v2/handlers/deleteFeature.js
@@ -1,17 +1,20 @@
 'use strict';
 
 const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
-const { json, badRequest, notFound } = require('../lib/response');
+const { json, badRequest, notFound, forbidden } = require('../lib/response');
 
 // DELETE /map-layers/{id}/features/{markerId}?apiUrl=...&actorId=...
 // Soft-deletes the marker (sets deleted: true) rather than removing it, so
 // a concurrent stale edit can't resurrect a corrupted record and deletes
 // are recoverable by a human editing S3 directly if needed.
-module.exports = async function deleteFeature(event) {
+module.exports = async function deleteFeature(event, claims) {
   const layerId = event.pathParameters?.id;
   const markerId = event.pathParameters?.markerId;
   const apiUrl = event.queryStringParameters?.apiUrl;
+  // actorId is client-supplied bookkeeping (stamped as updatedBy) -- never
+  // used for authorization, see memberId below.
   const actorId = String(event.queryStringParameters?.actorId || '').slice(0, 100);
+  const memberId = String(claims?.sub || '');
 
   if (!apiUrl || !layerId || !markerId) {
     return badRequest('apiUrl, layer id and marker id are required');
@@ -22,6 +25,13 @@ module.exports = async function deleteFeature(event) {
 
   const marker = layer.markers.find((m) => m.id === markerId);
   if (!marker) return notFound('Marker not found');
+
+  // Same rule as upsertFeature.js: a read-only layer restricts marker
+  // writes (including delete) to the layer's creator, authorized against
+  // the verified token's memberId.
+  if (layer.readOnly && memberId !== layer.createdByMemberId) {
+    return forbidden('Only the layer creator can delete markers on this read-only layer');
+  }
 
   const now = new Date().toISOString();
   marker.deleted = true;

--- a/lambda/map-layers-v2/handlers/deleteLayer.js
+++ b/lambda/map-layers-v2/handlers/deleteLayer.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound, forbidden } = require('../lib/response');
+
+// DELETE /map-layers/{id}?apiUrl=...&actorId=...
+//
+// Soft-deletes the layer: marks it `deleted: true` on the S3 object (so
+// getLayerObject treats it as not-found everywhere -- get/upsert/delete
+// feature, add comment) and drops it from the org's index so it stops
+// appearing in listLayers(). The object itself is never removed from S3,
+// matching the same "never truly delete" recoverability the marker
+// soft-delete and the listLayers staleness filter already rely on.
+module.exports = async function deleteLayer(event, claims) {
+  const layerId = event.pathParameters?.id;
+  const apiUrl = event.queryStringParameters?.apiUrl;
+  // actorId is client-supplied bookkeeping (stamped as deletedBy) -- never
+  // used for authorization, see memberId below.
+  const actorId = String(event.queryStringParameters?.actorId || '').slice(0, 100);
+  const memberId = String(claims?.sub || '');
+
+  if (!apiUrl || !layerId) return badRequest('apiUrl and layer id are required');
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  if (layer.allowDeleteByOthers === false && memberId !== layer.createdByMemberId) {
+    return forbidden('Only the layer creator can delete this layer');
+  }
+
+  const now = new Date().toISOString();
+  layer.deleted = true;
+  layer.deletedBy = actorId;
+  layer.deletedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+
+  await updateIndex(apiUrl, (index) => {
+    index.layers = (index.layers || []).filter((l) => l.id !== layerId);
+  });
+
+  return json(204, null);
+};

--- a/lambda/map-layers-v2/handlers/upsertFeature.js
+++ b/lambda/map-layers-v2/handlers/upsertFeature.js
@@ -2,7 +2,7 @@
 
 const crypto = require('crypto');
 const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
-const { json, badRequest, notFound } = require('../lib/response');
+const { json, badRequest, notFound, forbidden } = require('../lib/response');
 
 // Must stay in sync with the icon keys in
 // src/pages/tasking/components/collab_marker_icons.js (MARKER_ICON_GROUPS).
@@ -26,7 +26,7 @@ const HEX_COLOR = /^#[0-9a-fA-F]{3,8}$/;
 // entry and commentOpsLogIds for the comment thread. The Ops Log is the
 // source of truth for all of that text; the client resolves the pointers
 // via BeaconClient.operationslog.get() when rendering a marker.
-module.exports = async function upsertFeature(event) {
+module.exports = async function upsertFeature(event, claims) {
   const layerId = event.pathParameters?.id;
   let body;
   try {
@@ -36,7 +36,11 @@ module.exports = async function upsertFeature(event) {
   }
 
   const apiUrl = body.apiUrl;
+  // actorId is client-supplied bookkeeping (stamped onto the marker as
+  // createdBy/updatedBy for display) -- never used for authorization, see
+  // memberId below.
   const actorId = String(body.actorId || '').slice(0, 100);
+  const memberId = String(claims?.sub || '');
   const input = body.marker || {};
 
   if (!apiUrl || !layerId) return badRequest('apiUrl and layer id are required');
@@ -46,6 +50,14 @@ module.exports = async function upsertFeature(event) {
 
   const layer = await getLayerObject(apiUrl, layerId);
   if (!layer) return notFound('Layer not found');
+
+  // On a read-only layer, only the layer's creator may create/edit markers
+  // -- everyone else is limited to commenting (see addMarkerComment.js).
+  // Authorized against the verified token's memberId, not the
+  // client-supplied actorId.
+  if (layer.readOnly && memberId !== layer.createdByMemberId) {
+    return forbidden('Only the layer creator can add or edit markers on this read-only layer');
+  }
 
   const now = new Date().toISOString();
   const icon = ICON_KEYS.has(input.icon) ? input.icon : DEFAULT_ICON;

--- a/lambda/map-layers-v2/index.js
+++ b/lambda/map-layers-v2/index.js
@@ -8,6 +8,7 @@ const getLayer = require('./handlers/getLayer');
 const upsertFeature = require('./handlers/upsertFeature');
 const deleteFeature = require('./handlers/deleteFeature');
 const addMarkerComment = require('./handlers/addMarkerComment');
+const deleteLayer = require('./handlers/deleteLayer');
 
 // Single Lambda fronting all /lad_v2/map-layers routes via API Gateway HTTP
 // API (payload format 2.0) Lambda proxy integration. Routed by
@@ -20,6 +21,7 @@ const ROUTES = {
   'GET /lad_v2/map-layers': listLayers,
   'POST /lad_v2/map-layers': createLayer,
   'GET /lad_v2/map-layers/{id}': getLayer,
+  'DELETE /lad_v2/map-layers/{id}': deleteLayer,
   'PUT /lad_v2/map-layers/{id}/features': upsertFeature,
   'DELETE /lad_v2/map-layers/{id}/features/{markerId}': deleteFeature,
   'POST /lad_v2/map-layers/{id}/features/{markerId}/comments': addMarkerComment,
@@ -46,7 +48,13 @@ exports.handler = async (event) => {
   console.log(JSON.stringify({ msg: 'beacon_auth', fn: 'map-layers-v2', userId: claims.sub || claims.client_id || 'unknown', route: routeKey }));
 
   try {
-    return await handler(event);
+    // `claims` (the verified token payload) is passed through so
+    // permission-sensitive handlers (createLayer, upsertFeature,
+    // deleteFeature, deleteLayer) can authorize against claims.sub -- the
+    // Beacon member id, tamper-proof since it comes from a signature-
+    // verified JWT -- rather than any client-supplied actorId field, which
+    // a caller could set to whatever it wants.
+    return await handler(event, claims);
   } catch (err) {
     console.error('map-layers-v2 handler error:', err, JSON.stringify({ routeKey }));
     return serverError();

--- a/lambda/map-layers-v2/lib/response.js
+++ b/lambda/map-layers-v2/lib/response.js
@@ -19,7 +19,8 @@ function json(statusCode, body) {
 }
 
 const badRequest = (message) => json(400, { error: message });
+const forbidden = (message) => json(403, { error: message });
 const notFound = (message) => json(404, { error: message });
 const serverError = (message) => json(500, { error: message || 'Internal server error' });
 
-module.exports = { json, badRequest, notFound, serverError, CORS_HEADERS };
+module.exports = { json, badRequest, forbidden, notFound, serverError, CORS_HEADERS };

--- a/lambda/map-layers-v2/lib/s3Store.js
+++ b/lambda/map-layers-v2/lib/s3Store.js
@@ -83,7 +83,9 @@ async function updateIndex(apiUrl, mutate, { retries = 3 } = {}) {
 
 async function getLayerObject(apiUrl, layerId) {
   const { data } = await getJson(layerKey(apiUrl, layerId));
-  if (!data || data.apiUrl !== apiUrl) return null; // not found, or belongs to a different org
+  // Not found, belongs to a different org, or soft-deleted (see deleteLayer
+  // handler) -- all treated identically as "not found" by every caller.
+  if (!data || data.apiUrl !== apiUrl || data.deleted) return null;
   return data;
 }
 

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -169,12 +169,42 @@ const defaultRedSvgIcon = L.divIcon({
     popupAnchor: [0, -36],
 });
 
+// Beacon member id (the JWT's `sub` claim), decoded from the access token
+// purely for UI purposes -- deciding whether to show/hide the collaborative
+// map layers' Edit/Delete-marker, Add-marker and Delete-layer controls for
+// read-only/delete-restricted layers. This has to be `sub` specifically
+// (not params.personId or params.userId) because it's what
+// lambda/map-layers-v2's verifyBeaconToken.js hands the Lambda as the
+// caller's *verified* identity -- the Lambda is the one that actually
+// enforces these permissions from its own signature-checked copy of the
+// token; decoding it again here just lets the UI predict that outcome
+// instead of the user hitting a 403 after the fact. No verification happens
+// client-side -- an untrusted decode would be pointless as a security
+// control, which is exactly why enforcement lives server-side.
+let currentMemberId = null;
+
+function decodeJwtSub(jwt) {
+    try {
+        const payloadB64 = jwt.split('.')[1];
+        const json = atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/'));
+        return JSON.parse(json)?.sub || null;
+    } catch {
+        return null;
+    }
+}
+
+/** Sync getter for the current member id -- see currentMemberId above. */
+function getMemberId() {
+    return currentMemberId;
+}
+
 /**
  * Set the current token and wake any waiters.
  */
 function setToken(newToken, newTokenExp) {
     token = newToken;
     tokenExp = newTokenExp;
+    currentMemberId = decodeJwtSub(newToken);
 
     if (resolveTokenReady) {
         // First token arrival unblocks anyone awaiting getToken()
@@ -245,8 +275,8 @@ installMapContextMenu({
     // existing `var myViewModel;` module-level pattern below) -- these
     // callbacks only run later, on an actual right-click, by which point
     // it's fully populated.
-    canAddMarker: () => getVisibleCollabLayers(myViewModel).length > 0,
-    onAddMarker: (latlng) => startAddMarkerFlow(myViewModel, sourceUrl, markerActorId, latlng, getToken),
+    canAddMarker: () => getVisibleCollabLayers(myViewModel, getMemberId).length > 0,
+    onAddMarker: (latlng) => startAddMarkerFlow(myViewModel, sourceUrl, markerActorId, latlng, getToken, getMemberId),
 });
 
 
@@ -1394,6 +1424,15 @@ function VM() {
         getToken: () => getToken(),
         apiUrl: sourceUrl,
         userId: params.userId,
+        // Collaborative-layer actions (create/delete layer) are attributed
+        // (for display/audit only) using the same identity as every
+        // marker/comment op on that layer (markerActorId, i.e.
+        // params.personId), not params.userId.
+        actorId: markerActorId,
+        // Sync getter for the verified Beacon member id (JWT `sub`) -- see
+        // getMemberId above. Used by Config.js to decide whether the
+        // Delete-layer button is enabled for a given row.
+        getMemberId,
     };
 
     self.config = new ConfigVM(self, configDeps);
@@ -3043,7 +3082,7 @@ function VM() {
     registerBOMFloodWarningBoundariesLayer(self, sourceUrl);
     registerBOMFireWeatherDistrictsLayer(self, sourceUrl);
     registerRainRadarLayer(self, map);
-    registerCollabLayers(self, sourceUrl, markerActorId, getToken);
+    registerCollabLayers(self, sourceUrl, markerActorId, getToken, getMemberId);
 
     // --- Layers Drawer (under zoom)
     const LayersDrawer = L.Control.extend({

--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -3,6 +3,7 @@ import { MARKER_ICON_GROUPS, DEFAULT_MARKER_ICON_KEY, MARKER_COLOR_SWATCHES, bui
 import {
     listLayers,
     createLayer,
+    deleteLayer,
     fetchLayerMarkers,
     upsertMarker,
     deleteMarker,
@@ -85,6 +86,30 @@ function visibleCollabLayers(vm) {
     });
 }
 
+// ── Permissions ──────────────────────────────────────────────────────
+//
+// A layer's readOnly / allowDeleteByOthers / disableComments flags are set
+// once at creation time (see Config.js's createCollabLayer form) and never
+// change afterward, so there's no staleness concern reading them straight
+// off whatever layer object is already in hand. The Lambda enforces all
+// three independently and authoritatively (see lambda/map-layers-v2) --
+// this client-side gating only decides what to show/hide so a user isn't
+// invited to attempt something that will just come back as a 403.
+//
+// `getMemberId` is a sync () => string|null, the current user's Beacon
+// member id decoded from their own access token (main.js) -- the same
+// identity the Lambda authorizes against via the token's verified `sub`
+// claim, which is why it's what's compared to a layer's
+// `createdByMemberId` rather than the actorId/personId used for
+// createdBy/updatedBy bookkeeping elsewhere in this feature.
+
+/** Whether the current user may create/edit/delete markers on `layer`. */
+function canWriteMarkers(layer, getMemberId) {
+    if (!layer?.readOnly) return true;
+    const memberId = getMemberId?.();
+    return !!memberId && memberId === layer.createdByMemberId;
+}
+
 /**
  * Register the polling Leaflet layer for a single collaborative layer.
  * Visibility is controlled entirely by the existing layers drawer /
@@ -92,7 +117,7 @@ function visibleCollabLayers(vm) {
  * getOverlayDefsForControl — no separate "enabled set" is needed since
  * polling is a no-op while the layer isn't visible.
  */
-function registerLayerPolling(vm, apiUrl, layer, actorId, getToken) {
+function registerLayerPolling(vm, apiUrl, layer, actorId, getToken, getMemberId) {
     const key = layerKeyFor(layer.id);
     vm.mapVM.registerPollingLayer(key, {
         label: layer.name,
@@ -100,7 +125,7 @@ function registerLayerPolling(vm, apiUrl, layer, actorId, getToken) {
         refreshMs: REFRESH_MS,
         visibleByDefault: false,
         fetchFn: async () => fetchLayerMarkers(apiUrl, layer.id, await getToken()),
-        drawFn: (layerGroup, data) => drawCollabMarkers(vm, layerGroup, data, apiUrl, layer.id, key, actorId, getToken),
+        drawFn: (layerGroup, data) => drawCollabMarkers(vm, layerGroup, data, apiUrl, layer, key, actorId, getToken, getMemberId),
         skipIfBusy: () => busyLayerKeys.has(key),
     });
 }
@@ -110,7 +135,7 @@ function registerLayerPolling(vm, apiUrl, layer, actorId, getToken) {
  * MapVM for the config modal to bind to, and register/refresh polling
  * layers for any layer not already registered.
  */
-export async function refreshCollabLayerList(vm, apiUrl, actorId, getToken) {
+export async function refreshCollabLayerList(vm, apiUrl, actorId, getToken, getMemberId) {
     const layers = await listLayers(apiUrl, await getToken());
     vm.mapVM.collabLayers(layers);
     // Only register layers we haven't seen yet -- re-registering an already
@@ -119,7 +144,7 @@ export async function refreshCollabLayerList(vm, apiUrl, actorId, getToken) {
     // is toggled off and back on.
     layers
         .filter((layer) => !vm.mapVM.onlineLayers.has(layerKeyFor(layer.id)))
-        .forEach((layer) => registerLayerPolling(vm, apiUrl, layer, actorId, getToken));
+        .forEach((layer) => registerLayerPolling(vm, apiUrl, layer, actorId, getToken, getMemberId));
     vm.mapVM.layersDrawer?.refresh?.();
     return layers;
 }
@@ -131,18 +156,18 @@ export async function refreshCollabLayerList(vm, apiUrl, actorId, getToken) {
  * components/mapContextMenu.js + startAddMarkerFlow/getVisibleCollabLayers
  * above) rather than a second contextmenu listener here.
  */
-export async function registerCollabLayers(vm, apiUrl, actorId, getToken) {
-    await refreshCollabLayerList(vm, apiUrl, actorId, getToken);
+export async function registerCollabLayers(vm, apiUrl, actorId, getToken, getMemberId) {
+    await refreshCollabLayerList(vm, apiUrl, actorId, getToken, getMemberId);
 }
 
 /** Create a new named layer, register its polling layer immediately, and refresh the drawer. */
-export async function createCollabLayer(vm, apiUrl, name, actorId, getToken) {
-    const layer = await createLayer(apiUrl, name, actorId, await getToken());
+export async function createCollabLayer(vm, apiUrl, name, actorId, getToken, permissions, getMemberId) {
+    const layer = await createLayer(apiUrl, name, actorId, await getToken(), permissions);
     if (!layer) return null;
     const list = vm.mapVM.collabLayers();
     vm.mapVM.collabLayers([...list, layer]);
     const key = layerKeyFor(layer.id);
-    registerLayerPolling(vm, apiUrl, layer, actorId, getToken);
+    registerLayerPolling(vm, apiUrl, layer, actorId, getToken, getMemberId);
     // Auto-show layers the user just created -- matches the 'ov.<drawerKey>'
     // flag both the layers drawer (main.js) and the Config modal's View
     // switch (Config.js collabLayerRows) read to decide initial visibility.
@@ -152,9 +177,29 @@ export async function createCollabLayer(vm, apiUrl, name, actorId, getToken) {
     return layer;
 }
 
+/**
+ * Delete a collaborative layer: fires the remote (soft-)delete, then tears
+ * down its polling registration/map presence and drops it from the list
+ * the config modal binds to. No-op (returns false) if the delete itself
+ * failed, e.g. a 403 from a since-changed allowDeleteByOthers=false --
+ * Config.js's row stays in place in that case rather than disappearing
+ * client-side while still existing server-side.
+ */
+export async function deleteCollabLayer(vm, apiUrl, layerId, actorId, getToken) {
+    const ok = await deleteLayer(apiUrl, layerId, actorId, await getToken());
+    if (!ok) return false;
+
+    const key = layerKeyFor(layerId);
+    vm.mapVM.unregisterPollingLayer(key);
+    localStorage.removeItem(`ov.online-${key}`);
+    vm.mapVM.collabLayers(vm.mapVM.collabLayers().filter((l) => l.id !== layerId));
+    vm.mapVM.layersDrawer?.refresh?.();
+    return true;
+}
+
 // ── Drawing ──────────────────────────────────────────────────────────
 
-function drawCollabMarkers(vm, layerGroup, data, apiUrl, layerId, key, actorId, getToken) {
+function drawCollabMarkers(vm, layerGroup, data, apiUrl, layer, key, actorId, getToken, getMemberId) {
     const markers = (data?.markers || []).filter((m) => !m.deleted);
     markers.forEach((marker) => {
         const icon = buildMarkerBadgeIcon({ icon: marker.icon, fill: marker.fill || DEFAULT_FILL });
@@ -169,7 +214,7 @@ function drawCollabMarkers(vm, layerGroup, data, apiUrl, layerId, key, actorId, 
         // re-fetch, and re-update(), ...) in an unbounded loop. Fetching is
         // instead deferred to the "popupopen" event so a marker's Ops Log
         // entry is only pulled once the user actually clicks it.
-        const { el, state } = buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken, leafletMarker);
+        const { el, state } = buildMarkerPopupEl(vm, apiUrl, layer, key, marker, actorId, getToken, leafletMarker, getMemberId);
         leafletMarker.bindPopup(el, { minWidth: 260, maxWidth: 320 });
         leafletMarker.on("popupopen", () => {
             busyLayerKeys.add(key);
@@ -188,7 +233,11 @@ function drawCollabMarkers(vm, layerGroup, data, apiUrl, layerId, key, actorId, 
 // The marker record only carries GPS/style + Ops Log entry ids -- title,
 // description and comment text are all resolved live from the Ops Log
 // (source of truth), fetched lazily on "popupopen" (see drawCollabMarkers).
-function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken, leafletMarker) {
+function buildMarkerPopupEl(vm, apiUrl, layer, key, marker, actorId, getToken, leafletMarker, getMemberId) {
+    const layerId = layer.id;
+    const canWrite = canWriteMarkers(layer, getMemberId);
+    const canComment = !layer.disableComments;
+
     const el = document.createElement("div");
     el.className = "collab-marker-popup";
 
@@ -197,11 +246,14 @@ function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken,
         <div class="collab-marker-desc"></div>
         <div class="collab-marker-meta"></div>
         <div class="collab-marker-comments"></div>
+        ${canComment ? `
         <div class="collab-marker-comment-form">
             <textarea class="collab-comment-input" placeholder="Add a comment…" rows="2" maxlength="${TEXT_CHAR_LIMIT}"></textarea>
             <div class="collab-char-counter"></div>
             <button type="button" class="btn btn-sm btn-outline-primary collab-add-comment-btn">Comment</button>
         </div>
+        ` : `<div class="collab-marker-comments-disabled"><i class="fas fa-comment-slash"></i> Comments are disabled on this layer</div>`}
+        ${canWrite ? `
         <div class="collab-marker-actions">
             <button type="button" class="btn btn-sm btn-outline-secondary collab-edit-marker-btn">Edit</button>
             <button type="button" class="btn btn-sm btn-outline-danger collab-delete-marker-btn">Delete</button>
@@ -211,65 +263,71 @@ function buildMarkerPopupEl(vm, apiUrl, layerId, key, marker, actorId, getToken,
             <button type="button" class="btn btn-sm btn-danger collab-confirm-delete-btn">Confirm Delete</button>
             <button type="button" class="btn btn-sm btn-secondary collab-cancel-delete-btn">Cancel</button>
         </div>
+        ` : ""}
     `;
-
-    const editBtn = el.querySelector(".collab-edit-marker-btn");
-    const deleteBtn = el.querySelector(".collab-delete-marker-btn");
-    const confirmBox = el.querySelector(".collab-marker-confirm");
-    const actionsBox = el.querySelector(".collab-marker-actions");
-    const confirmDeleteBtn = el.querySelector(".collab-confirm-delete-btn");
-    const cancelDeleteBtn = el.querySelector(".collab-cancel-delete-btn");
-    const commentInput = el.querySelector(".collab-comment-input");
-    const addCommentBtn = el.querySelector(".collab-add-comment-btn");
-    wireCharCounter(commentInput, TEXT_CHAR_LIMIT);
-
-    editBtn.addEventListener("click", () => {
-        vm.mapVM.map.closePopup();
-        openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, L.latLng(marker.lat, marker.lng), getToken, state.mainEntry);
-    });
-
-    deleteBtn.addEventListener("click", () => {
-        actionsBox.classList.add("d-none");
-        confirmBox.classList.remove("d-none");
-    });
-    cancelDeleteBtn.addEventListener("click", () => {
-        confirmBox.classList.add("d-none");
-        actionsBox.classList.remove("d-none");
-    });
-    confirmDeleteBtn.addEventListener("click", async () => {
-        // Whatever title/description the marker currently resolves to (or
-        // blank, if the Ops Log lookup above hasn't landed yet) becomes the
-        // deletion audit entry's content -- there's nothing left to stamp
-        // an opsLogId onto afterwards, so it only lives in the Ops Log.
-        const title = stripSubjectPrefix(state.mainEntry?.Subject);
-        const description = stripAuditFooter(state.mainEntry?.Text);
-        vm.mapVM.map.closePopup(); // clears busyLayerKeys (via "popupclose") before the refresh below
-        await logMarkerAudit(vm, "deleted", layerId, marker, title, description);
-        await deleteMarker(apiUrl, layerId, marker.id, actorId, await getToken());
-        vm.mapVM.refreshPollingLayer(key);
-    });
-
-    addCommentBtn.addEventListener("click", async () => {
-        const text = commentInput.value.trim();
-        if (!text) return;
-        addCommentBtn.disabled = true;
-        try {
-            const opsLogId = await logMarkerComment(vm, layerId, marker, text);
-            if (opsLogId == null) return;
-            await addMarkerComment(apiUrl, layerId, marker.id, opsLogId, actorId, await getToken());
-            marker.commentOpsLogIds = Array.isArray(marker.commentOpsLogIds) ? [...marker.commentOpsLogIds, opsLogId] : [opsLogId];
-            commentInput.value = "";
-            await renderComments(vm, el.querySelector(".collab-marker-comments"), marker, leafletMarker);
-        } finally {
-            addCommentBtn.disabled = false;
-        }
-    });
 
     // Populated on "popupopen" (see drawCollabMarkers) via loadMarkerContent,
     // which fetches the marker's title/description/comments from the Ops
     // Log. `state.mainEntry` is stashed there so the Edit/Delete handlers
-    // above can read whatever title and description are currently showing.
+    // below can read whatever title and description are currently showing.
     const state = { mainEntry: null };
+
+    if (canComment) {
+        const commentInput = el.querySelector(".collab-comment-input");
+        const addCommentBtn = el.querySelector(".collab-add-comment-btn");
+        wireCharCounter(commentInput, TEXT_CHAR_LIMIT);
+
+        addCommentBtn.addEventListener("click", async () => {
+            const text = commentInput.value.trim();
+            if (!text) return;
+            addCommentBtn.disabled = true;
+            try {
+                const opsLogId = await logMarkerComment(vm, layerId, marker, text);
+                if (opsLogId == null) return;
+                await addMarkerComment(apiUrl, layerId, marker.id, opsLogId, actorId, await getToken());
+                marker.commentOpsLogIds = Array.isArray(marker.commentOpsLogIds) ? [...marker.commentOpsLogIds, opsLogId] : [opsLogId];
+                commentInput.value = "";
+                await renderComments(vm, el.querySelector(".collab-marker-comments"), marker, leafletMarker);
+            } finally {
+                addCommentBtn.disabled = false;
+            }
+        });
+    }
+
+    if (canWrite) {
+        const editBtn = el.querySelector(".collab-edit-marker-btn");
+        const deleteBtn = el.querySelector(".collab-delete-marker-btn");
+        const confirmBox = el.querySelector(".collab-marker-confirm");
+        const actionsBox = el.querySelector(".collab-marker-actions");
+        const confirmDeleteBtn = el.querySelector(".collab-confirm-delete-btn");
+        const cancelDeleteBtn = el.querySelector(".collab-cancel-delete-btn");
+
+        editBtn.addEventListener("click", () => {
+            vm.mapVM.map.closePopup();
+            openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, L.latLng(marker.lat, marker.lng), getToken, state.mainEntry);
+        });
+
+        deleteBtn.addEventListener("click", () => {
+            actionsBox.classList.add("d-none");
+            confirmBox.classList.remove("d-none");
+        });
+        cancelDeleteBtn.addEventListener("click", () => {
+            confirmBox.classList.add("d-none");
+            actionsBox.classList.remove("d-none");
+        });
+        confirmDeleteBtn.addEventListener("click", async () => {
+            // Whatever title/description the marker currently resolves to (or
+            // blank, if the Ops Log lookup above hasn't landed yet) becomes the
+            // deletion audit entry's content -- there's nothing left to stamp
+            // an opsLogId onto afterwards, so it only lives in the Ops Log.
+            const title = stripSubjectPrefix(state.mainEntry?.Subject);
+            const description = stripAuditFooter(state.mainEntry?.Text);
+            vm.mapVM.map.closePopup(); // clears busyLayerKeys (via "popupclose") before the refresh below
+            await logMarkerAudit(vm, "deleted", layerId, marker, title, description);
+            await deleteMarker(apiUrl, layerId, marker.id, actorId, await getToken());
+            vm.mapVM.refreshPollingLayer(key);
+        });
+    }
 
     return { el, state };
 }
@@ -716,22 +774,26 @@ function showLayerPickerMenu(vm, apiUrl, actorId, layers, containerPoint, latlng
     };
 }
 
-/** Whether the "Add marker" item in the map's right-click context menu should be shown. */
-export function getVisibleCollabLayers(vm) {
-    return visibleCollabLayers(vm);
+/**
+ * Visible collaborative layers the current user may add a marker to --
+ * excludes read-only layers they didn't create. Drives whether the "Add
+ * marker" item in the map's right-click context menu is shown at all.
+ */
+export function getVisibleCollabLayers(vm, getMemberId) {
+    return visibleCollabLayers(vm).filter((layer) => canWriteMarkers(layer, getMemberId));
 }
 
 /**
  * Entry point for the "Add marker to shared layer" item in the app's
  * existing right-click context menu (components/mapContextMenu.js). With
- * exactly one visible layer, opens the marker form immediately; with more
- * than one, shows a small picker so the user chooses which layer receives
- * the new marker.
+ * exactly one visible (writable) layer, opens the marker form immediately;
+ * with more than one, shows a small picker so the user chooses which layer
+ * receives the new marker.
  */
-export function startAddMarkerFlow(vm, apiUrl, actorId, latlng, getToken) {
+export function startAddMarkerFlow(vm, apiUrl, actorId, latlng, getToken, getMemberId) {
     closeContextMenu();
 
-    const visible = visibleCollabLayers(vm);
+    const visible = getVisibleCollabLayers(vm, getMemberId);
     if (visible.length === 0) return;
 
     if (visible.length === 1) {

--- a/src/pages/tasking/utils/collabLayerSync.js
+++ b/src/pages/tasking/utils/collabLayerSync.js
@@ -85,9 +85,11 @@ export async function listLayers(apiUrl, token) {
  * @param {string} name
  * @param {string} actorId
  * @param {string} token  Beacon access token (Authorization: Bearer).
+ * @param {{readOnly?: boolean, allowDeleteByOthers?: boolean, disableComments?: boolean}} [permissions]
+ *   Fixed for the layer's lifetime -- there's no later "edit layer settings" flow.
  * @returns {Promise<Object|null>} the created layer summary, or null on failure
  */
-export async function createLayer(apiUrl, name, actorId, token) {
+export async function createLayer(apiUrl, name, actorId, token, permissions = {}) {
     const trimmed = (name || '').trim();
     if (!apiUrl || !trimmed) return null;
 
@@ -95,7 +97,14 @@ export async function createLayer(apiUrl, name, actorId, token) {
         const res = await fetch(LAMBDA_BASE, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-            body: JSON.stringify({ apiUrl, name: trimmed, createdBy: String(actorId) }),
+            body: JSON.stringify({
+                apiUrl,
+                name: trimmed,
+                createdBy: String(actorId),
+                readOnly: !!permissions.readOnly,
+                allowDeleteByOthers: permissions.allowDeleteByOthers !== false,
+                disableComments: !!permissions.disableComments,
+            }),
         });
         if (!res.ok) {
             throw new Error(`Create layer failed with status ${res.status}`);
@@ -111,6 +120,39 @@ export async function createLayer(apiUrl, name, actorId, token) {
     } catch (err) {
         console.warn('[collabLayerSync] createLayer error:', err);
         return null;
+    }
+}
+
+/**
+ * Delete (soft-delete) a collaborative layer. Optimistically removes it
+ * from the local cached index, then fires the remote write.
+ * @param {string} apiUrl
+ * @param {string} layerId
+ * @param {string} actorId
+ * @param {string} token  Beacon access token (Authorization: Bearer).
+ * @returns {Promise<boolean>} true on success
+ */
+export async function deleteLayer(apiUrl, layerId, actorId, token) {
+    if (!apiUrl || !layerId) return false;
+
+    const index = loadCachedLayerIndex();
+    saveCachedLayerIndex(index.filter((l) => l.id !== layerId));
+
+    try {
+        const url = `${LAMBDA_BASE}/${encodeURIComponent(layerId)}` +
+            `?apiUrl=${encodeURIComponent(apiUrl)}&actorId=${encodeURIComponent(actorId)}`;
+        const res = await fetch(url, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } });
+        if (!res.ok) {
+            throw new Error(`deleteLayer failed with status ${res.status}`);
+        }
+        localStorage.removeItem(layerCacheKey(layerId));
+        return true;
+    } catch (err) {
+        console.warn('[collabLayerSync] deleteLayer error:', err);
+        // Restore the optimistically-removed entry so a transient network
+        // failure doesn't silently hide a layer that's still on the server.
+        saveCachedLayerIndex(index);
+        return false;
     }
 }
 

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -3,7 +3,7 @@ import ko from 'knockout';
 
 import * as bootstrap from 'bootstrap5'; // Modal, Tooltip, etc.
 import { Enum } from '../utils/enum.js';
-import { createCollabLayer, refreshCollabLayerList } from '../mapLayers/collabLayer.js';
+import { createCollabLayer, refreshCollabLayerList, deleteCollabLayer } from '../mapLayers/collabLayer.js';
 
 
 
@@ -197,10 +197,19 @@ export function ConfigVM(root, deps) {
     // ── Collaborative map layers ──
     self.collabLayers = root.mapVM?.collabLayers || ko.observableArray([]);
     self.newLayerName = ko.observable('');
+    // Fixed for a layer's whole lifetime once created -- there's no later
+    // "edit layer settings" flow, by design (see mapLayers/collabLayer.js).
+    // Each backed by a radio pair in tasking.html, all following the same
+    // "Anyone can ___" / "Only I can/I've disabled ___" shape for a
+    // consistent mental model across the three permissions.
+    self.newLayerReadOnly = ko.observable(false); // marker permissions: "Anyone can add markers" / "Only I can add markers"
+    self.newLayerAllowDeleteByOthers = ko.observable(true); // delete permissions: "Anyone can delete this layer" / "Only I can delete this layer"
+    self.newLayerDisableComments = ko.observable(false); // comment permissions: "Anyone can comment" / "Comments are disabled"
     self.creatingCollabLayer = ko.observable(false);
     self.collabLayerError = ko.observable('');
     self.collabLayerSearch = ko.observable(''); // filters the (possibly long) layer list below
     self.refreshingCollabLayers = ko.observable(false);
+    self.deletingCollabLayerId = ko.observable(null); // id of the row currently mid-delete, if any
 
     function relativeTime(iso) {
         if (!iso) return 'never';
@@ -243,6 +252,8 @@ export function ConfigVM(root, deps) {
         .map(layer => {
             const key = `collab-${layer.id}`;
             const drawerKey = `online-${key}`;
+            const memberId = deps.getMemberId?.();
+            const isCreator = !!memberId && memberId === layer.createdByMemberId;
             const row = {
                 layer,
                 key,
@@ -251,8 +262,21 @@ export function ConfigVM(root, deps) {
                 markerCount: layer.markerCount || 0,
                 lastUsedLabel: relativeTime(layer.lastUsedAt),
                 viewEnabled: ko.observable(localStorage.getItem(`ov.${drawerKey}`) === '1'),
+                readOnly: !!layer.readOnly,
+                disableComments: !!layer.disableComments,
+                // allowDeleteByOthers defaults true server-side, so an
+                // absent/undefined value (older layers) reads as deletable.
+                canDelete: layer.allowDeleteByOthers !== false || isCreator,
+                confirmingDelete: ko.observable(false),
             };
+            // Precomputed here (rather than a ternary in the data-bind
+            // attribute) because knockout-secure-binding's expression
+            // grammar doesn't support the conditional (?:) operator.
+            row.deleteTitle = row.canDelete ? 'Delete layer' : 'Only the layer creator can delete this layer';
             row.viewEnabled.subscribe((v) => self._applyCollabLayerView(row, v));
+            row.requestDeleteLayer = () => row.confirmingDelete(true);
+            row.cancelDeleteLayer = () => row.confirmingDelete(false);
+            row.confirmDeleteLayer = () => self.deleteCollabLayer(row);
             return row;
         }));
 
@@ -270,9 +294,17 @@ export function ConfigVM(root, deps) {
         self.collabLayerError('');
         self.creatingCollabLayer(true);
         try {
-            const layer = await createCollabLayer(root, deps.apiUrl, name, deps.userId, deps.getToken);
+            const permissions = {
+                readOnly: self.newLayerReadOnly(),
+                allowDeleteByOthers: self.newLayerAllowDeleteByOthers(),
+                disableComments: self.newLayerDisableComments(),
+            };
+            const layer = await createCollabLayer(root, deps.apiUrl, name, deps.actorId, deps.getToken, permissions, deps.getMemberId);
             if (!layer) throw new Error('Create failed');
             self.newLayerName('');
+            self.newLayerReadOnly(false);
+            self.newLayerAllowDeleteByOthers(true);
+            self.newLayerDisableComments(false);
         } catch (err) {
             console.error('Error creating collaborative layer:', err);
             self.collabLayerError('Failed to create layer. Try again later.');
@@ -290,7 +322,7 @@ export function ConfigVM(root, deps) {
         self.collabLayerError('');
         self.refreshingCollabLayers(true);
         try {
-            await refreshCollabLayerList(root, deps.apiUrl, deps.userId, deps.getToken);
+            await refreshCollabLayerList(root, deps.apiUrl, deps.actorId, deps.getToken, deps.getMemberId);
         } catch (err) {
             console.error('Error refreshing collaborative layers:', err);
             self.collabLayerError('Failed to refresh layer list. Try again later.');
@@ -299,7 +331,27 @@ export function ConfigVM(root, deps) {
         }
     };
 
-    // Named method (rather than an inline function in the data-bind attribute)
+    // Actual delete, fired from row.confirmDeleteLayer above once the user
+    // has clicked through the row's inline confirm step (same two-step
+    // pattern as a marker's own delete confirm in collabLayer.js).
+    self.deleteCollabLayer = async (row) => {
+        if (!deps.apiUrl || self.deletingCollabLayerId()) return;
+
+        self.collabLayerError('');
+        self.deletingCollabLayerId(row.layer.id);
+        try {
+            const ok = await deleteCollabLayer(root, deps.apiUrl, row.layer.id, deps.actorId, deps.getToken);
+            if (!ok) throw new Error('Delete failed');
+        } catch (err) {
+            console.error('Error deleting collaborative layer:', err);
+            self.collabLayerError('Failed to delete layer. Try again later.');
+            row.confirmingDelete(false);
+        } finally {
+            self.deletingCollabLayerId(null);
+        }
+    };
+
+    // Named methods (rather than inline functions in data-bind attributes)
     // because knockout-secure-binding's restricted grammar doesn't support
     // control-flow statements like `if` inside inline function literals.
     self.handleNewLayerNameKeydown = (data, event) => {

--- a/src/pages/tasking/viewmodels/Map.js
+++ b/src/pages/tasking/viewmodels/Map.js
@@ -560,6 +560,15 @@ export function MapVM(Lmap, root) {
   };
 
 
+  /** Tear down a polling overlay layer registered via registerPollingLayer -- stops its timer, removes it from the map, and drops it from the registry entirely (unlike toggling visibility, which just removes/re-adds the same layerGroup). */
+  self.unregisterPollingLayer = function (key) {
+    const entry = self.onlineLayers.get(key);
+    if (!entry) return;
+    if (entry.timerId) clearInterval(entry.timerId);
+    if (entry.layerGroup && self.map.hasLayer(entry.layerGroup)) self.map.removeLayer(entry.layerGroup);
+    self.onlineLayers.delete(key);
+  };
+
   self.refreshPollingLayer = function (key) {
     const entry = self.onlineLayers.get(key);
     if (!entry) return;

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2808,7 +2808,7 @@
                                                     isn't deleted.
                                                 </p>
 
-                                                <div class="input-group input-group-sm mb-3">
+                                                <div class="input-group input-group-sm mb-2">
                                                     <input type="text" class="form-control" placeholder="New layer name"
                                                         data-bind="value: config.newLayerName, valueUpdate: 'input',
                                                             event: { keydown: config.handleNewLayerNameKeydown }">
@@ -2817,6 +2817,54 @@
                                                             enable: config.newLayerName().trim().length > 0 && !config.creatingCollabLayer()">
                                                         <i class="fa fa-plus me-1"></i>New layer
                                                     </button>
+                                                </div>
+                                                <button type="button" class="btn btn-sm btn-link p-0 mb-2 collab-permissions-toggle"
+                                                    data-bs-toggle="collapse" data-bs-target="#collabNewLayerOptions"
+                                                    aria-expanded="false" aria-controls="collabNewLayerOptions">
+                                                    <i class="fa fa-chevron-right small me-1"></i>New layer permissions
+                                                </button>
+                                                <div class="collapse" id="collabNewLayerOptions">
+                                                    <div class="collab-new-layer-options mb-3">
+                                                    <div class="small text-muted mb-1 w-100">Marker permissions</div>
+                                                    <div class="form-check form-check-inline"
+                                                        title="Everyone can add, edit and delete markers (everyone can also comment, unless disabled below).">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerReadOnly" id="collabNewLayerReadOnlyOff"
+                                                            data-bind="checked: config.newLayerReadOnly, checkedValue: false">
+                                                        <label class="form-check-label small" for="collabNewLayerReadOnlyOff">Anyone can add markers</label>
+                                                    </div>
+                                                    <div class="form-check form-check-inline"
+                                                        title="Others can view this layer and comment on markers, but only you can add, edit or delete markers.">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerReadOnly" id="collabNewLayerReadOnlyOn"
+                                                            data-bind="checked: config.newLayerReadOnly, checkedValue: true">
+                                                        <label class="form-check-label small" for="collabNewLayerReadOnlyOn">Only I can add markers</label>
+                                                    </div>
+                                                    <div class="small text-muted mb-1 mt-1 w-100">Delete permissions</div>
+                                                    <div class="form-check form-check-inline"
+                                                        title="Any member of your organisation can delete this layer.">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerAllowDelete" id="collabNewLayerAllowDeleteOn"
+                                                            data-bind="checked: config.newLayerAllowDeleteByOthers, checkedValue: true">
+                                                        <label class="form-check-label small" for="collabNewLayerAllowDeleteOn">Anyone can delete this layer</label>
+                                                    </div>
+                                                    <div class="form-check form-check-inline"
+                                                        title="Only you will be able to delete this layer.">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerAllowDelete" id="collabNewLayerAllowDeleteOff"
+                                                            data-bind="checked: config.newLayerAllowDeleteByOthers, checkedValue: false">
+                                                        <label class="form-check-label small" for="collabNewLayerAllowDeleteOff">Only I can delete this layer</label>
+                                                    </div>
+                                                    <div class="small text-muted mb-1 mt-1 w-100">Comment permissions</div>
+                                                    <div class="form-check form-check-inline"
+                                                        title="Anyone who can see this layer can comment on its markers.">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerDisableComments" id="collabNewLayerDisableCommentsOff"
+                                                            data-bind="checked: config.newLayerDisableComments, checkedValue: false">
+                                                        <label class="form-check-label small" for="collabNewLayerDisableCommentsOff">Anyone can comment</label>
+                                                    </div>
+                                                    <div class="form-check form-check-inline"
+                                                        title="Blocks comments on this layer's markers for everyone, including you.">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerDisableComments" id="collabNewLayerDisableCommentsOn"
+                                                            data-bind="checked: config.newLayerDisableComments, checkedValue: true">
+                                                        <label class="form-check-label small" for="collabNewLayerDisableCommentsOn">Comments are disabled</label>
+                                                    </div>
+                                                    </div>
                                                 </div>
                                                 <div class="text-danger small mb-2"
                                                     data-bind="visible: config.collabLayerError, text: config.collabLayerError"></div>
@@ -2836,6 +2884,10 @@
                                                                 <div class="form-text">
                                                                     <span data-bind="text: row.markerCount"></span> markers ·
                                                                     used <span data-bind="text: row.lastUsedLabel"></span>
+                                                                    <i class="fas fa-lock ms-1" title="Only the creator can add markers"
+                                                                        data-bind="visible: row.readOnly"></i>
+                                                                    <i class="fas fa-comment-slash ms-1" title="Comments disabled"
+                                                                        data-bind="visible: row.disableComments"></i>
                                                                 </div>
                                                             </div>
                                                             <div class="form-check form-switch mb-0" title="View">
@@ -2843,6 +2895,19 @@
                                                                     data-bind="checked: row.viewEnabled">
                                                                 <label class="form-check-label small">View</label>
                                                             </div>
+                                                            <button type="button" class="btn btn-sm btn-outline-danger py-0 px-2"
+                                                                data-bind="click: row.requestDeleteLayer, disable: !row.canDelete,
+                                                                    visible: !row.confirmingDelete(),
+                                                                    attr: { title: row.deleteTitle }">
+                                                                <i class="fa fa-trash"></i>
+                                                            </button>
+                                                            <span class="collab-layer-delete-confirm" data-bind="visible: row.confirmingDelete">
+                                                                <button type="button" class="btn btn-sm btn-danger"
+                                                                    data-bind="click: row.confirmDeleteLayer,
+                                                                        disable: $root.config.deletingCollabLayerId() === row.layer.id">Delete</button>
+                                                                <button type="button" class="btn btn-sm btn-secondary"
+                                                                    data-bind="click: row.cancelDeleteLayer">Cancel</button>
+                                                            </span>
                                                         </li>
                                                     </ul>
                                                 </div>

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2602,6 +2602,36 @@ overflow: hidden;
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* Collapsed by default (see tasking.html) so the three permission groups
+   below don't eat vertical space in the accordion body unless opened. */
+.collab-permissions-toggle {
+  font-size: 12px;
+}
+.collab-permissions-toggle .fa-chevron-right {
+  transition: transform 0.15s ease;
+}
+.collab-permissions-toggle[aria-expanded="true"] .fa-chevron-right {
+  transform: rotate(90deg);
+}
+.collab-new-layer-options {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 12px;
+  row-gap: 2px;
+}
+.collab-new-layer-options .form-check {
+  margin-right: 0; /* column-gap above replaces Bootstrap's inline margin */
+}
+.collab-layer-delete-confirm {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.collab-layer-delete-confirm .btn {
+  font-size: 11px;
+  padding: 1px 6px;
+  line-height: 1.4;
+}
 
 /* ── Collaborative marker popup (view/edit) ── */
 .collab-marker-popup {
@@ -2665,6 +2695,11 @@ overflow: hidden;
   font-size: 10px;
   padding: 1px 6px;
   line-height: 1.4;
+}
+.collab-marker-comments-disabled {
+  color: #888;
+  font-size: 11px;
+  margin-bottom: 6px;
 }
 /* Aesthetic-only text limit indicator (description/comment textareas) --
    never affects layout beyond its own line, so it can't destabilize the


### PR DESCRIPTION
## Summary
- Layer creators can now restrict a collaborative layer at creation time: only they can add/edit/delete markers (`readOnly`), only they can delete the layer (`allowDeleteByOthers`), and/or comments are disabled for everyone (`disableComments`). Flags are fixed for the layer's lifetime — no edit-settings flow.
- Enforced server-side in `lambda/map-layers-v2` against the Beacon member id from the caller's *verified* JWT (`claims.sub`), stored as `createdByMemberId` on the layer at creation — not the client-supplied `actorId`, which stays purely for display/audit as before.
- New soft-delete `DELETE /lad_v2/map-layers/{id}` route + handler for removing a layer (never touches the S3 object, matching the existing "never truly delete" philosophy for markers/staleness).
- Tasking UI: a collapsed-by-default "New layer permissions" section (Anyone/Only-I radio pairs per permission), a per-row Delete-layer button, and marker popup/add-marker gating that gets out of the way once an action would be rejected server-side anyway.
- Fixes a pre-existing bug where layer creation was attributed to a different Beacon identity (`userId`) than every marker/comment action on that layer (`personId`), which would have silently broken creator checks.

## Deployment
Already deployed to the live `LH-MapLayersv2` Lambda and its API Gateway route (`DELETE /lad_v2/map-layers/{id}` on `do4g6603de`), ahead of this PR, since the frontend and backend for this feature ship independently. Verified with a 19-assertion simulated-S3 integration test covering the full permission matrix, plus live smoke checks against the real endpoint.

## Test plan
- [x] Lambda handlers: local integration test against a simulated S3 store covering read-only/delete/comment permission matrix (all pass)
- [x] `node --check` on all changed Lambda files
- [x] `eslint` clean on all changed frontend files
- [x] Live smoke test: new route returns 401 (unauthenticated) rather than 404, confirming correct routing; existing routes unaffected
- [ ] Manual UI pass in the browser (creating a restricted layer, verifying Edit/Delete/comment gating, deleting a layer) — not yet done by a human

🤖 Generated with [Claude Code](https://claude.com/claude-code)