### PR TITLE
Fix flash of unbound placeholder content before config modal shows

### DIFF
--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -3683,6 +3683,10 @@ document.addEventListener('DOMContentLoaded', function () {
         const configModalEl = document.getElementById('configModal');
         bootstrap.Modal.getOrCreateInstance(configModalEl).show();
 
+        // reveal the page now that bindings are applied and the modal is open,
+        // so we don't flash unbound placeholder content beforehand
+        document.body.style.opacity = '1';
+
         installModalHotkeys({
             modalEl: configModalEl,
             onSave: () => myViewModel.config.saveAndCloseAndLoad(),
@@ -3774,11 +3778,6 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
 })
-
-// show page once DOM + CSS are ready (don't wait for map tiles)
-document.addEventListener('DOMContentLoaded', function () {
-    document.body.style.opacity = '1';
-});
 
 
 


### PR DESCRIPTION
The page reveal (body opacity 1) fired on the plain DOMContentLoaded event, racing ahead of the async require(["knockout", ...]) load and ko.applyBindings call. That let raw, unbound markup (and the config modal popping in afterward) flash briefly on page load. Now the reveal happens right after bindings are applied and the modal is already open.