### PR TITLE
Give collaborative layer markers their own map pane

### DIFF
--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -352,6 +352,10 @@ map.createPane('pane-top'); map.getPane('pane-top').style.zIndex = 600;
 map.createPane('pane-top-plus'); map.getPane('pane-top-plus').style.zIndex = 601;
 
 
+map.createPane('pane-collab'); map.getPane('pane-collab').style.zIndex = 650;
+map.createPane('pane-collab-plus'); map.getPane('pane-collab-plus').style.zIndex = 651;
+
+
 map.createPane('pane-tippy-top'); map.getPane('pane-tippy-top').style.zIndex = 700;
 map.createPane('pane-tippy-top-plus'); map.getPane('pane-tippy-top-plus').style.zIndex = 701;
 

--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -204,7 +204,7 @@ function drawCollabMarkers(vm, layerGroup, data, apiUrl, layer, key, actorId, ge
     markers.forEach((marker) => {
         const icon = buildMarkerBadgeIcon({ icon: marker.icon, fill: marker.fill || DEFAULT_FILL });
 
-        const leafletMarker = L.marker([marker.lat, marker.lng], { icon });
+        const leafletMarker = L.marker([marker.lat, marker.lng], { icon, pane: "pane-collab" });
 
         // Bind a concrete, already-built element rather than Leaflet's
         // "content factory function" form of bindPopup -- that form gets

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -80,8 +80,9 @@ export function ConfigVM(root, deps) {
 
     self.paneDefs = [
         { id: 'pane-tippy-top', name: 'Incident markers' },
+        { id: 'pane-collab', name: 'Collaborative layer markers' },
         { id: 'pane-top', name: 'Asset markers' },
-        { id: 'pane-middle', name: 'Map overlays icons & labels' },
+        { id: 'pane-middle', name: 'Map overlay markers & labels' },
         { id: 'pane-lowest', name: 'Map overlay polygons & drawings' }
     ];
 
@@ -95,9 +96,15 @@ export function ConfigVM(root, deps) {
             .filter(Boolean)
             .map(p => ({ id: p.id, name: p.name }));
 
-        // ensure all panes exist (append any missing)
-        self.paneDefs.forEach(p => {
-            if (!list.some(x => x.id === p.id)) list.push({ id: p.id, name: p.name });
+        // Ensure all panes exist. Panes missing from a saved order (e.g. one
+        // introduced after the config was last saved) are inserted at their
+        // default position relative to paneDefs, rather than always at the
+        // bottom, so a newly-added pane keeps its intended default stacking.
+        self.paneDefs.forEach((p, defIdx) => {
+            if (list.some(x => x.id === p.id)) return;
+            const nextKnownDef = self.paneDefs.slice(defIdx + 1).find(d => list.some(x => x.id === d.id));
+            const insertAt = nextKnownDef ? list.findIndex(x => x.id === nextKnownDef.id) : list.length;
+            list.splice(insertAt, 0, { id: p.id, name: p.name });
         });
 
         self.paneOrder(list);

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2711,7 +2711,7 @@
                                                     <div class="col-md-6">
                                                         <fieldset>
                                                             <legend class="form-label fw-semibold mb-2">
-                                                                <i class="fa fa-layer-group me-1"></i>Marker Clustering
+                                                                <i class="fa fa-layer-group me-1"></i>Incident Marker Clustering
                                                             </legend>
 
                                                             <div class="form-check form-switch mb-2">
@@ -2770,9 +2770,12 @@
                                                     <div class="col-md-6">
                                                         <fieldset>
                                                             <legend class="form-label fw-semibold mb-2">
-                                                                <i class="fa fa-sort me-1"></i>Map Icon Layer Order
+                                                                <i class="fa fa-sort me-1"></i>Marker Layer Order
                                                                 <small class="text-muted fw-normal">(top → bottom)</small>
                                                             </legend>
+                                                            <div class="form-text mb-3">
+                                                                Controls the draw order of marker layers on the map. Drag and drop to reorder.
+                                                            </div>
                                                             <div class="border rounded p-2">
                                                                 <ul class="list-group"
                                                                     data-bind="foreach: { data: config.paneOrder, as: 'p' }">


### PR DESCRIPTION
## Summary
- Collaborative layer markers previously rendered in Leaflet's default `markerPane` (fixed z-index 600) instead of one of the app's custom panes, so they weren't part of the "Marker Layer Order" drawer and could stack unpredictably relative to Incident/Asset markers.
- Adds a new `pane-collab` pane, defaulted between Incident markers (above) and Asset markers (below), and wires collab markers to use it.
- Fixes the "append missing pane" migration logic so a pane newly introduced to `paneDefs` (like this one) is inserted at its default relative position in existing users' saved layer-order configs, rather than always landing at the bottom.
- Minor UI polish in the Config modal (clarified "Incident Marker Clustering" / "Marker Layer Order" labels, added helper text).

## Test plan
- [ ] Load the tasking map, open Config → Marker Layer Order, confirm "Collaborative layer markers" appears between "Incident markers" and "Asset markers" by default.
- [ ] Verify a collaborative layer marker renders above asset markers and below incident markers on the map.
- [ ] Drag-reorder panes, confirm collab markers move with their assigned pane.
- [ ] For an account with a previously-saved pane order (missing `pane-collab`), confirm it gets inserted in the correct default slot rather than at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)