### PR TITLE
Add HQ/event attachment, moderator-managed permissions, and a subscriptions model for collaborative map layers

### DIFF
--- a/lambda/map-layers-v2/handlers/addMarkerComment.js
+++ b/lambda/map-layers-v2/handlers/addMarkerComment.js
@@ -2,6 +2,7 @@
 
 const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
 const { json, badRequest, notFound, forbidden } = require('../lib/response');
+const { commentMode, isAuthorized } = require('../lib/permissions');
 
 // POST /map-layers/{id}/features/{markerId}/comments
 // body: { apiUrl, actorId, opsLogId }
@@ -10,7 +11,7 @@ const { json, badRequest, notFound, forbidden } = require('../lib/response');
 // marker's comment thread. Like upsertFeature's opsLogId, this Lambda only
 // stores the pointer -- the comment's text/author lives entirely in that
 // Ops Log entry and is resolved via BeaconClient.operationslog.get().
-module.exports = async function addMarkerComment(event) {
+module.exports = async function addMarkerComment(event, claims) {
   const layerId = event.pathParameters?.id;
   const markerId = event.pathParameters?.markerId;
   let body;
@@ -23,6 +24,7 @@ module.exports = async function addMarkerComment(event) {
   const apiUrl = body.apiUrl;
   const actorId = String(body.actorId || '').slice(0, 100);
   const opsLogId = Number(body.opsLogId);
+  const memberId = String(claims?.sub || '');
 
   if (!apiUrl || !layerId || !markerId) {
     return badRequest('apiUrl, layer id and marker id are required');
@@ -35,8 +37,8 @@ module.exports = async function addMarkerComment(event) {
   const marker = layer.markers.find((m) => m.id === markerId);
   if (!marker) return notFound('Marker not found');
 
-  if (layer.disableComments) {
-    return forbidden('Comments are disabled on this layer');
+  if (!isAuthorized(commentMode(layer), layer, memberId)) {
+    return forbidden('You do not have permission to comment on this layer');
   }
 
   marker.commentOpsLogIds = Array.isArray(marker.commentOpsLogIds) ? marker.commentOpsLogIds : [];

--- a/lambda/map-layers-v2/handlers/createLayer.js
+++ b/lambda/map-layers-v2/handlers/createLayer.js
@@ -3,25 +3,89 @@
 const crypto = require('crypto');
 const { updateIndex, putLayerObject } = require('../lib/s3Store');
 const { json, badRequest } = require('../lib/response');
+const { normalizeMode } = require('../lib/permissions');
 
-// POST /map-layers   body: { apiUrl, name, createdBy, readOnly?, allowDeleteByOthers?, disableComments? }
+const MAX_MODERATORS = 100;
+
+/** Sanitize the client-supplied moderator list: [{id, name}], deduped by id. */
+function sanitizeModerators(input) {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const m of input) {
+    const id = String(m?.id || '').trim().slice(0, 100);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, name: String(m?.name || id).trim().slice(0, 200) });
+    if (out.length >= MAX_MODERATORS) break;
+  }
+  return out;
+}
+
+/**
+ * Sanitize the optional event attachment: { id, name } -> stored as
+ * eventId/eventName, or both null if no event (or an incomplete one) was
+ * given. eventId/eventName are pure display/bookkeeping (like createdBy) --
+ * nothing in this feature authorizes against them.
+ */
+function sanitizeEvent(input) {
+  const id = String(input?.id || '').trim().slice(0, 50);
+  if (!id) return { eventId: null, eventName: null, eventIdentifier: null };
+  const name = String(input?.name || id).trim().slice(0, 200);
+  const identifier = String(input?.identifier || '').trim().slice(0, 50) || null;
+  return { eventId: id, eventName: name, eventIdentifier: identifier };
+}
+
+/**
+ * Sanitize the required HQ attachment: { id, name } -> { hqId, hqName }, or
+ * both null if missing/incomplete (caller must then reject the request --
+ * unlike sanitizeEvent, there's no valid "no HQ" case for a layer).
+ */
+function sanitizeHq(input) {
+  const id = String(input?.id || '').trim().slice(0, 50);
+  if (!id) return { hqId: null, hqName: null };
+  const name = String(input?.name || id).trim().slice(0, 200);
+  return { hqId: id, hqName: name };
+}
+
+// POST /map-layers
+// body: { apiUrl, name, createdBy, hq, markerMode?, deleteMode?, commentMode?, moderators?, event? }
 //
-// The three permission flags are fixed at creation time -- there's no
-// "edit layer settings" flow, so every handler that reads them back off the
-// stored layer/summary can treat them as immutable for that layer's
-// lifetime.
-//   - readOnly (default false): only the creator may create/edit/delete
-//     markers; everyone else may still comment (unless disableComments).
-//     Enforced in upsertFeature.js / deleteFeature.js.
-//   - allowDeleteByOthers (default true): whether anyone, vs. only the
-//     creator, may delete the layer itself. Enforced in deleteLayer.js.
-//   - disableComments (default false): blocks comments for everyone,
-//     including the creator. Enforced in addMarkerComment.js.
+// The permission modes and moderator list are fixed at creation time --
+// there's no "edit layer settings" flow for the modes themselves, so every
+// handler that reads them back off the stored layer/summary can treat them
+// as immutable for that layer's lifetime. The moderator list itself *is*
+// editable later by the creator (see updateLayerModerators.js) since who
+// should moderate a layer can change over an incident's lifetime even when
+// the permission structure doesn't.
+//
+// Each of markerMode/deleteMode/commentMode is one of 'anyone' | 'creator'
+// | 'moderators' (default 'anyone' if omitted/invalid):
+//   - markerMode: who may create/edit/delete markers. Enforced in
+//     upsertFeature.js / deleteFeature.js.
+//   - deleteMode: who may delete the layer itself. Enforced in
+//     deleteLayer.js.
+//   - commentMode: who may comment on markers. Enforced in
+//     addMarkerComment.js.
+// 'moderators' always additionally allows the creator (see
+// lib/permissions.js isAuthorized).
+//
+// `hq` (required): { id, name } of the Beacon HQ (entity) this layer
+// belongs to -- every layer must have one, stored as hqId/hqName. Also
+// fixed at creation, no later "reassign HQ" flow. Drives the layer list's
+// default HQ filter (Config.js) -- layers created before this field existed
+// simply have no hqId and so only ever show up under "All HQs".
+//
+// `event` (optional): { id, name } of a Beacon event this layer relates to,
+// stored as eventId/eventName -- purely for display in the layer list
+// (Config.js), same "fixed at creation" rule as the permission modes above,
+// no later "attach/detach event" flow.
 //
 // "The creator" for all of the above means `createdByMemberId` --
 // `claims.sub`, the Beacon member id off the caller's own verified token --
 // not the client-supplied `createdBy` (actorId/personId), which is only
-// bookkeeping/display metadata a caller could set to anything. See
+// bookkeeping/display metadata a caller could set to anything. Moderator
+// ids are the same Beacon member id space (see lib/permissions.js). See
 // index.js, which passes the verified claims into every handler.
 module.exports = async function createLayer(event, claims) {
   let body;
@@ -35,21 +99,25 @@ module.exports = async function createLayer(event, claims) {
   const name = String(body.name || '').trim().slice(0, 200);
   const createdBy = String(body.createdBy || '').slice(0, 100);
   const createdByMemberId = String(claims?.sub || '');
-  const readOnly = body.readOnly === true;
-  const allowDeleteByOthers = body.allowDeleteByOthers !== false;
-  const disableComments = body.disableComments === true;
+  const markerMode = normalizeMode(body.markerMode) || 'anyone';
+  const deleteMode = normalizeMode(body.deleteMode) || 'anyone';
+  const commentMode = normalizeMode(body.commentMode) || 'anyone';
+  const moderators = sanitizeModerators(body.moderators);
+  const { eventId, eventName, eventIdentifier } = sanitizeEvent(body.event);
+  const { hqId, hqName } = sanitizeHq(body.hq);
 
   if (!apiUrl || !name) return badRequest('apiUrl and name are required');
+  if (!hqId) return badRequest('hq is required');
 
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
   const summary = {
     id, name, createdBy, createdByMemberId, createdAt: now, lastUsedAt: now, markerCount: 0,
-    readOnly, allowDeleteByOthers, disableComments,
+    markerMode, deleteMode, commentMode, moderators, eventId, eventName, eventIdentifier, hqId, hqName,
   };
   const layer = {
     id, apiUrl, name, createdBy, createdByMemberId, createdAt: now, lastUsedAt: now, markers: [],
-    readOnly, allowDeleteByOthers, disableComments,
+    markerMode, deleteMode, commentMode, moderators, eventId, eventName, eventIdentifier, hqId, hqName,
   };
 
   await putLayerObject(apiUrl, id, layer);

--- a/lambda/map-layers-v2/handlers/deleteFeature.js
+++ b/lambda/map-layers-v2/handlers/deleteFeature.js
@@ -2,6 +2,7 @@
 
 const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
 const { json, badRequest, notFound, forbidden } = require('../lib/response');
+const { markerMode, isAuthorized } = require('../lib/permissions');
 
 // DELETE /map-layers/{id}/features/{markerId}?apiUrl=...&actorId=...
 // Soft-deletes the marker (sets deleted: true) rather than removing it, so
@@ -26,11 +27,10 @@ module.exports = async function deleteFeature(event, claims) {
   const marker = layer.markers.find((m) => m.id === markerId);
   if (!marker) return notFound('Marker not found');
 
-  // Same rule as upsertFeature.js: a read-only layer restricts marker
-  // writes (including delete) to the layer's creator, authorized against
-  // the verified token's memberId.
-  if (layer.readOnly && memberId !== layer.createdByMemberId) {
-    return forbidden('Only the layer creator can delete markers on this read-only layer');
+  // Same rule as upsertFeature.js: markerMode gates marker deletes too,
+  // authorized against the verified token's memberId.
+  if (!isAuthorized(markerMode(layer), layer, memberId)) {
+    return forbidden('You do not have permission to delete markers on this layer');
   }
 
   const now = new Date().toISOString();

--- a/lambda/map-layers-v2/handlers/deleteLayer.js
+++ b/lambda/map-layers-v2/handlers/deleteLayer.js
@@ -2,6 +2,7 @@
 
 const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
 const { json, badRequest, notFound, forbidden } = require('../lib/response');
+const { deleteMode, isAuthorized } = require('../lib/permissions');
 
 // DELETE /map-layers/{id}?apiUrl=...&actorId=...
 //
@@ -24,8 +25,8 @@ module.exports = async function deleteLayer(event, claims) {
   const layer = await getLayerObject(apiUrl, layerId);
   if (!layer) return notFound('Layer not found');
 
-  if (layer.allowDeleteByOthers === false && memberId !== layer.createdByMemberId) {
-    return forbidden('Only the layer creator can delete this layer');
+  if (!isAuthorized(deleteMode(layer), layer, memberId)) {
+    return forbidden('You do not have permission to delete this layer');
   }
 
   const now = new Date().toISOString();

--- a/lambda/map-layers-v2/handlers/listLayers.js
+++ b/lambda/map-layers-v2/handlers/listLayers.js
@@ -5,18 +5,25 @@ const { json, badRequest } = require('../lib/response');
 
 const STALE_MS = 120 * 24 * 60 * 60 * 1000; // 120 days
 
-// GET /map-layers?apiUrl=...
+// GET /map-layers?apiUrl=...&hqId=...
 // Lists layers for an org, excluding any unused for 120+ days. The
 // underlying data is never deleted by this filter -- only omitted from
-// the listing.
+// the listing. `hqId`, if given, additionally restricts the list to layers
+// attached to that HQ (see createLayer.js) -- omitted entirely for "All
+// HQs" (Config.js's collabLayerHqFilterPicker cleared). Layers created
+// before the HQ requirement existed have no hqId and so never match a
+// specific hqId filter, only the unfiltered "All HQs" request.
 module.exports = async function listLayers(event) {
   const apiUrl = event.queryStringParameters?.apiUrl;
+  const hqId = event.queryStringParameters?.hqId || null;
   if (!apiUrl) return badRequest('apiUrl is required');
 
   const { data } = await getJson(indexKey(apiUrl));
   const layers = (data?.layers || []).filter((l) => {
     const lastUsed = new Date(l.lastUsedAt).getTime();
-    return Number.isFinite(lastUsed) && Date.now() - lastUsed <= STALE_MS;
+    if (!Number.isFinite(lastUsed) || Date.now() - lastUsed > STALE_MS) return false;
+    if (hqId && l.hqId !== hqId) return false;
+    return true;
   });
 
   return json(200, { layers });

--- a/lambda/map-layers-v2/handlers/updateLayerModerators.js
+++ b/lambda/map-layers-v2/handlers/updateLayerModerators.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound, forbidden } = require('../lib/response');
+const { isAuthorized } = require('../lib/permissions');
+
+const MAX_MODERATORS = 100;
+
+/** Sanitize the client-supplied moderator list: [{id, name}], deduped by id. */
+function sanitizeModerators(input) {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const m of input) {
+    const id = String(m?.id || '').trim().slice(0, 100);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, name: String(m?.name || id).trim().slice(0, 200) });
+    if (out.length >= MAX_MODERATORS) break;
+  }
+  return out;
+}
+
+// PUT /map-layers/{id}/moderators   body: { apiUrl, moderators: [{id, name}] }
+//
+// Unlike markerMode/deleteMode/commentMode (fixed at creation, see
+// createLayer.js), the moderator list itself can be updated later -- who
+// should moderate a layer changes over an incident's lifetime even when the
+// permission structure doesn't. The creator or any *current* moderator may
+// change it (isAuthorized('moderators', ...) -- same rule as the
+// marker/delete/comment 'moderators' mode: creator plus anyone already on
+// the list), so a stranger still can't silently add themselves. Replaces
+// the full list rather than diffing (simpler, and the client always sends
+// its complete current list -- see collabLayerSync.js's
+// updateLayerModerators). A moderator removing themselves (or every other
+// moderator) is allowed -- same trust level as the creator over this list.
+module.exports = async function updateLayerModerators(event, claims) {
+  const layerId = event.pathParameters?.id;
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return badRequest('Invalid JSON body');
+  }
+
+  const apiUrl = body.apiUrl;
+  const memberId = String(claims?.sub || '');
+
+  if (!apiUrl || !layerId) return badRequest('apiUrl and layer id are required');
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  if (!isAuthorized('moderators', layer, memberId)) {
+    return forbidden('Only the layer creator or a moderator can manage moderators');
+  }
+
+  const moderators = sanitizeModerators(body.moderators);
+  const now = new Date().toISOString();
+  layer.moderators = moderators;
+  layer.lastUsedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+
+  await updateIndex(apiUrl, (index) => {
+    const entry = index.layers.find((l) => l.id === layerId);
+    if (entry) {
+      entry.moderators = moderators;
+      entry.lastUsedAt = now;
+    }
+  });
+
+  return json(200, { moderators });
+};

--- a/lambda/map-layers-v2/handlers/upsertFeature.js
+++ b/lambda/map-layers-v2/handlers/upsertFeature.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto');
 const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
 const { json, badRequest, notFound, forbidden } = require('../lib/response');
+const { markerMode, isAuthorized } = require('../lib/permissions');
 
 // Must stay in sync with the icon keys in
 // src/pages/tasking/components/collab_marker_icons.js (MARKER_ICON_GROUPS).
@@ -51,12 +52,11 @@ module.exports = async function upsertFeature(event, claims) {
   const layer = await getLayerObject(apiUrl, layerId);
   if (!layer) return notFound('Layer not found');
 
-  // On a read-only layer, only the layer's creator may create/edit markers
-  // -- everyone else is limited to commenting (see addMarkerComment.js).
   // Authorized against the verified token's memberId, not the
-  // client-supplied actorId.
-  if (layer.readOnly && memberId !== layer.createdByMemberId) {
-    return forbidden('Only the layer creator can add or edit markers on this read-only layer');
+  // client-supplied actorId. See lib/permissions.js for the markerMode /
+  // isAuthorized rules (anyone / creator-only / creator+moderators).
+  if (!isAuthorized(markerMode(layer), layer, memberId)) {
+    return forbidden('You do not have permission to add or edit markers on this layer');
   }
 
   const now = new Date().toISOString();

--- a/lambda/map-layers-v2/index.js
+++ b/lambda/map-layers-v2/index.js
@@ -9,6 +9,7 @@ const upsertFeature = require('./handlers/upsertFeature');
 const deleteFeature = require('./handlers/deleteFeature');
 const addMarkerComment = require('./handlers/addMarkerComment');
 const deleteLayer = require('./handlers/deleteLayer');
+const updateLayerModerators = require('./handlers/updateLayerModerators');
 
 // Single Lambda fronting all /lad_v2/map-layers routes via API Gateway HTTP
 // API (payload format 2.0) Lambda proxy integration. Routed by
@@ -22,6 +23,7 @@ const ROUTES = {
   'POST /lad_v2/map-layers': createLayer,
   'GET /lad_v2/map-layers/{id}': getLayer,
   'DELETE /lad_v2/map-layers/{id}': deleteLayer,
+  'PUT /lad_v2/map-layers/{id}/moderators': updateLayerModerators,
   'PUT /lad_v2/map-layers/{id}/features': upsertFeature,
   'DELETE /lad_v2/map-layers/{id}/features/{markerId}': deleteFeature,
   'POST /lad_v2/map-layers/{id}/features/{markerId}/comments': addMarkerComment,

--- a/lambda/map-layers-v2/lib/permissions.js
+++ b/lambda/map-layers-v2/lib/permissions.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// Each of the three collaborative-layer permission axes (who can write
+// markers, who can delete the layer, who can comment) is a 3-way mode:
+// 'anyone' | 'creator' | 'moderators'. 'moderators' always additionally
+// allows the creator -- a "moderators can" setting shouldn't lock the
+// creator themselves out.
+//
+// Layers created before this feature only have the old boolean flags
+// (readOnly / allowDeleteByOthers / disableComments) and no `moderators`
+// list -- the *Mode() readers below fall back to deriving the equivalent
+// mode from those booleans so old layers keep behaving exactly as they did.
+// disableComments=true had no direct 3-way equivalent (it blocked everyone,
+// including the creator); 'creator' is the closest available mode and is
+// what new layers get if a user picks "Only I can comment".
+const VALID_MODES = new Set(['anyone', 'creator', 'moderators']);
+
+function normalizeMode(value) {
+  return VALID_MODES.has(value) ? value : null;
+}
+
+function markerMode(layer) {
+  return layer.markerMode || (layer.readOnly ? 'creator' : 'anyone');
+}
+
+function deleteMode(layer) {
+  return layer.deleteMode || (layer.allowDeleteByOthers === false ? 'creator' : 'anyone');
+}
+
+function commentMode(layer) {
+  return layer.commentMode || (layer.disableComments ? 'creator' : 'anyone');
+}
+
+/** Is `memberId` allowed to perform an action gated by `mode` on `layer`? */
+function isAuthorized(mode, layer, memberId) {
+  if (mode === 'anyone') return true;
+  if (!memberId) return false;
+  if (memberId === layer.createdByMemberId) return true;
+  if (mode === 'moderators') {
+    return Array.isArray(layer.moderators) && layer.moderators.some((m) => m?.id === memberId);
+  }
+  return false;
+}
+
+module.exports = { VALID_MODES, normalizeMode, markerMode, deleteMode, commentMode, isAuthorized };

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -1425,9 +1425,16 @@ function VM() {
             });
         },
         fetchAllSectors: (hqs) => self.fetchAllSectors(hqs),
+        searchMembers: (q) => self.searchMembers(q),
+        searchEvents: (q) => self.searchEvents(q),
         getToken: () => getToken(),
         apiUrl: sourceUrl,
         userId: params.userId,
+        // The Beacon entity id of the HQ this Lighthouse instance was
+        // launched for (?hq=<id> in the URL) -- every collaborative layer
+        // must be attached to an HQ (Config.js), and the layer list defaults
+        // to showing just this HQ's layers, both seeded from this id.
+        defaultHqId: params.hq || null,
         // Collaborative-layer actions (create/delete layer) are attributed
         // (for display/audit only) using the same identity as every
         // marker/comment op on that layer (markerActorId, i.e.
@@ -2241,6 +2248,35 @@ function VM() {
             BeaconClient.contacts.searchAll(query, apiHost, params.userId, t, function (data) {
                 resolve(data.Results || []);
             })
+        });
+    }
+
+    // Searches Beacon members by name or member number (Username) -- used
+    // by the collaborative-layer moderator picker (Config.js). Returns raw
+    // Users/Search result rows; Config.js maps each row's Username to the
+    // same member-id space as getMemberId()/createdByMemberId above.
+    self.searchMembers = async function (query) {
+        const t = await getToken();   // blocks here until token is ready
+        return new Promise((resolve) => {
+            BeaconClient.users.search(query, apiHost, params.userId, t, function (data) {
+                resolve(data?.Results || []);
+            }, function () {
+                resolve([]);
+            });
+        });
+    }
+
+    // Searches Beacon events by name or identifier -- used by the
+    // collaborative-layer "attach to event" picker (Config.js). Returns raw
+    // Events/Search result rows.
+    self.searchEvents = async function (query) {
+        const t = await getToken();   // blocks here until token is ready
+        return new Promise((resolve) => {
+            BeaconClient.events.search(query, apiHost, params.userId, t, function (data) {
+                resolve(data?.Results || []);
+            }, function () {
+                resolve([]);
+            });
         });
     }
 

--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -4,10 +4,15 @@ import {
     listLayers,
     createLayer,
     deleteLayer,
+    updateLayerModerators,
     fetchLayerMarkers,
     upsertMarker,
     deleteMarker,
     addMarkerComment,
+    getSubscribedLayerIds,
+    subscribeLayer,
+    unsubscribeLayer,
+    migrateLegacyVisibleLayersToSubscriptions,
 } from "../utils/collabLayerSync.js";
 
 const REFRESH_MS = 10000; // polling only fires while the layer is visible (registerPollingLayer's hasLayer gate)
@@ -88,26 +93,62 @@ function visibleCollabLayers(vm) {
 
 // ── Permissions ──────────────────────────────────────────────────────
 //
-// A layer's readOnly / allowDeleteByOthers / disableComments flags are set
-// once at creation time (see Config.js's createCollabLayer form) and never
-// change afterward, so there's no staleness concern reading them straight
-// off whatever layer object is already in hand. The Lambda enforces all
-// three independently and authoritatively (see lambda/map-layers-v2) --
-// this client-side gating only decides what to show/hide so a user isn't
-// invited to attempt something that will just come back as a 403.
+// A layer's markerMode / deleteMode / commentMode are set once at creation
+// time (see Config.js's createCollabLayer form) and never change afterward,
+// so there's no staleness concern reading them straight off whatever layer
+// object is already in hand. `moderators` (who counts as a moderator under
+// the 'moderators' mode) *can* change later -- the creator can add/remove
+// moderators after creation (see Config.js's per-row "Manage moderators")
+// -- but it's still read straight off the layer object already in hand,
+// same as the modes; a stale moderator list here just means the UI is
+// briefly out of date until the next poll, not a security gap (the Lambda
+// enforces authoritatively, see lambda/map-layers-v2). This client-side
+// gating only decides what to show/hide so a user isn't invited to attempt
+// something that will just come back as a 403.
+//
+// Each mode is one of 'anyone' | 'creator' | 'moderators'. Layers created
+// before this feature only carry the old readOnly / allowDeleteByOthers /
+// disableComments booleans -- the effective*Mode() helpers below derive the
+// equivalent mode from those so old layers keep behaving as they did.
 //
 // `getMemberId` is a sync () => string|null, the current user's Beacon
 // member id decoded from their own access token (main.js) -- the same
 // identity the Lambda authorizes against via the token's verified `sub`
 // claim, which is why it's what's compared to a layer's
-// `createdByMemberId` rather than the actorId/personId used for
-// createdBy/updatedBy bookkeeping elsewhere in this feature.
+// `createdByMemberId`/`moderators` rather than the actorId/personId used
+// for createdBy/updatedBy bookkeeping elsewhere in this feature.
+
+function effectiveMarkerMode(layer) {
+    return layer.markerMode || (layer.readOnly ? 'creator' : 'anyone');
+}
+
+function effectiveCommentMode(layer) {
+    return layer.commentMode || (layer.disableComments ? 'creator' : 'anyone');
+}
+
+/** Is `memberId` the creator or a listed moderator of `layer`? */
+function isCreatorOrModerator(layer, memberId) {
+    if (!memberId) return false;
+    if (memberId === layer.createdByMemberId) return true;
+    return Array.isArray(layer.moderators) && layer.moderators.some((m) => m?.id === memberId);
+}
+
+function isAuthorizedForMode(mode, layer, getMemberId) {
+    if (mode === 'anyone') return true;
+    const memberId = getMemberId?.();
+    if (mode === 'creator') return !!memberId && memberId === layer.createdByMemberId;
+    if (mode === 'moderators') return isCreatorOrModerator(layer, memberId);
+    return false;
+}
 
 /** Whether the current user may create/edit/delete markers on `layer`. */
 function canWriteMarkers(layer, getMemberId) {
-    if (!layer?.readOnly) return true;
-    const memberId = getMemberId?.();
-    return !!memberId && memberId === layer.createdByMemberId;
+    return isAuthorizedForMode(effectiveMarkerMode(layer), layer, getMemberId);
+}
+
+/** Whether the current user may comment on `layer`'s markers. */
+function canCommentOnLayer(layer, getMemberId) {
+    return isAuthorizedForMode(effectiveCommentMode(layer), layer, getMemberId);
 }
 
 /**
@@ -131,12 +172,19 @@ function registerLayerPolling(vm, apiUrl, layer, actorId, getToken, getMemberId)
 }
 
 /**
- * Fetch the list of collaborative layers for the org, store it on the
- * MapVM for the config modal to bind to, and register/refresh polling
- * layers for any layer not already registered.
+ * Fetch every layer for the org (unfiltered -- subscriptions can span any
+ * HQ, so there's no single hqId to scope this fetch to) and narrow it down
+ * client-side to the ones the user is subscribed to. This -- not any HQ
+ * filter -- is what populates vm.mapVM.collabLayers()/Config.js's "My
+ * layers" list, so a subscribed layer stays listed (and unsubscribe-able)
+ * regardless of whatever HQ the separate "Find a layer" search is scoped
+ * to. Registers/refreshes polling for any subscribed layer not already
+ * registered.
  */
-export async function refreshCollabLayerList(vm, apiUrl, actorId, getToken, getMemberId) {
-    const layers = await listLayers(apiUrl, await getToken());
+export async function refreshSubscribedLayers(vm, apiUrl, actorId, getToken, getMemberId) {
+    const subscribedIds = getSubscribedLayerIds();
+    const all = await listLayers(apiUrl, await getToken());
+    const layers = all.filter((layer) => subscribedIds.has(String(layer.id)));
     vm.mapVM.collabLayers(layers);
     // Only register layers we haven't seen yet -- re-registering an already
     // visible layer would hand it a brand new (empty) layerGroup that never
@@ -150,6 +198,17 @@ export async function refreshCollabLayerList(vm, apiUrl, actorId, getToken, getM
 }
 
 /**
+ * Fetch layers for a single HQ -- backs Config.js's "Find a layer" search
+ * (browsing to discover/subscribe to a layer), never touches
+ * vm.mapVM.collabLayers or registers anything. Thin pass-through kept here
+ * (rather than Config.js importing collabLayerSync.js's listLayers
+ * directly) so every org-layer fetch funnels through one module.
+ */
+export async function searchLayersForHq(apiUrl, getToken, hqId) {
+    return listLayers(apiUrl, await getToken(), hqId);
+}
+
+/**
  * Called once at startup (main.js), alongside the other register*Layer
  * calls. The right-click "Add marker" trigger itself is wired up
  * separately, into the app's existing map context menu (see
@@ -157,20 +216,27 @@ export async function refreshCollabLayerList(vm, apiUrl, actorId, getToken, getM
  * above) rather than a second contextmenu listener here.
  */
 export async function registerCollabLayers(vm, apiUrl, actorId, getToken, getMemberId) {
-    await refreshCollabLayerList(vm, apiUrl, actorId, getToken, getMemberId);
+    migrateLegacyVisibleLayersToSubscriptions();
+    await refreshSubscribedLayers(vm, apiUrl, actorId, getToken, getMemberId);
 }
 
-/** Create a new named layer, register its polling layer immediately, and refresh the drawer. */
+/**
+ * Create a new named layer, subscribe its creator to it, register its
+ * polling layer immediately, and refresh the drawer.
+ */
 export async function createCollabLayer(vm, apiUrl, name, actorId, getToken, permissions, getMemberId) {
     const layer = await createLayer(apiUrl, name, actorId, await getToken(), permissions);
     if (!layer) return null;
+    subscribeLayer(layer.id);
     const list = vm.mapVM.collabLayers();
     vm.mapVM.collabLayers([...list, layer]);
     const key = layerKeyFor(layer.id);
     registerLayerPolling(vm, apiUrl, layer, actorId, getToken, getMemberId);
     // Auto-show layers the user just created -- matches the 'ov.<drawerKey>'
-    // flag both the layers drawer (main.js) and the Config modal's View
-    // switch (Config.js collabLayerRows) read to decide initial visibility.
+    // flag the layers drawer (main.js) reads to decide initial visibility.
+    // The one deliberate exception to "Config subscribes, LayersDrawer
+    // shows/hides": whoever just made a layer almost certainly wants to
+    // see it immediately, without a second trip to the Layers control.
     localStorage.setItem(`ov.online-${key}`, '1');
     vm.mapVM.layersDrawer?.refresh?.();
     vm.mapVM.refreshPollingLayer(key);
@@ -179,10 +245,10 @@ export async function createCollabLayer(vm, apiUrl, name, actorId, getToken, per
 
 /**
  * Delete a collaborative layer: fires the remote (soft-)delete, then tears
- * down its polling registration/map presence and drops it from the list
- * the config modal binds to. No-op (returns false) if the delete itself
- * failed, e.g. a 403 from a since-changed allowDeleteByOthers=false --
- * Config.js's row stays in place in that case rather than disappearing
+ * down its polling registration/map presence, drops the subscription, and
+ * drops it from the list the config modal binds to. No-op (returns false)
+ * if the delete itself failed, e.g. a 403 from a since-changed deleteMode
+ * -- Config.js's row stays in place in that case rather than disappearing
  * client-side while still existing server-side.
  */
 export async function deleteCollabLayer(vm, apiUrl, layerId, actorId, getToken) {
@@ -192,9 +258,60 @@ export async function deleteCollabLayer(vm, apiUrl, layerId, actorId, getToken) 
     const key = layerKeyFor(layerId);
     vm.mapVM.unregisterPollingLayer(key);
     localStorage.removeItem(`ov.online-${key}`);
+    unsubscribeLayer(layerId);
     vm.mapVM.collabLayers(vm.mapVM.collabLayers().filter((l) => l.id !== layerId));
     vm.mapVM.layersDrawer?.refresh?.();
     return true;
+}
+
+/**
+ * Subscribe to an already-existing layer (found via Config.js's "Find a
+ * layer" search) -- adds it to "My layers", registers it for
+ * polling/LayersDrawer, but leaves it hidden until explicitly shown via
+ * the Layers control (see createCollabLayer's comment for the one
+ * exception to that rule).
+ */
+export function subscribeToLayer(vm, apiUrl, layer, actorId, getToken, getMemberId) {
+    subscribeLayer(layer.id);
+    const list = vm.mapVM.collabLayers();
+    if (!list.some((l) => l.id === layer.id)) {
+        vm.mapVM.collabLayers([...list, layer]);
+    }
+    if (!vm.mapVM.onlineLayers.has(layerKeyFor(layer.id))) {
+        registerLayerPolling(vm, apiUrl, layer, actorId, getToken, getMemberId);
+    }
+    vm.mapVM.layersDrawer?.refresh?.();
+}
+
+/**
+ * Unsubscribe from a layer: drops it from "My layers" and tears down its
+ * polling/map presence entirely (unlike hiding it, which leaves it
+ * registered -- see registerPollingLayer's doc comment). Local-only, no
+ * remote call -- subscriptions aren't org data (see collabLayerSync.js).
+ */
+export function unsubscribeFromLayer(vm, layerId) {
+    const key = layerKeyFor(layerId);
+    vm.mapVM.unregisterPollingLayer(key);
+    localStorage.removeItem(`ov.online-${key}`);
+    unsubscribeLayer(layerId);
+    vm.mapVM.collabLayers(vm.mapVM.collabLayers().filter((l) => l.id !== layerId));
+    vm.mapVM.layersDrawer?.refresh?.();
+}
+
+/**
+ * Replace a layer's moderator list (creator-only, enforced server-side --
+ * see lambda updateLayerModerators.js). Updates the in-memory layer object
+ * (shared by reference with vm.mapVM.collabLayers()'s entry, same as every
+ * other layer field) on success so Config.js's row immediately reflects the
+ * new list without waiting for the next poll/refresh.
+ */
+export async function updateCollabLayerModerators(vm, apiUrl, layerId, moderators, getToken) {
+    const saved = await updateLayerModerators(apiUrl, layerId, moderators, await getToken());
+    if (saved == null) return null;
+
+    const layer = vm.mapVM.collabLayers().find((l) => l.id === layerId);
+    if (layer) layer.moderators = saved;
+    return saved;
 }
 
 // ── Drawing ──────────────────────────────────────────────────────────
@@ -236,7 +353,11 @@ function drawCollabMarkers(vm, layerGroup, data, apiUrl, layer, key, actorId, ge
 function buildMarkerPopupEl(vm, apiUrl, layer, key, marker, actorId, getToken, leafletMarker, getMemberId) {
     const layerId = layer.id;
     const canWrite = canWriteMarkers(layer, getMemberId);
-    const canComment = !layer.disableComments;
+    const canComment = canCommentOnLayer(layer, getMemberId);
+    const commentMode = effectiveCommentMode(layer);
+    const commentsRestrictedMessage = commentMode === 'moderators'
+        ? "Only the layer creator and moderators can comment on this layer"
+        : "Only the layer creator can comment on this layer";
 
     const el = document.createElement("div");
     el.className = "collab-marker-popup";
@@ -252,7 +373,7 @@ function buildMarkerPopupEl(vm, apiUrl, layer, key, marker, actorId, getToken, l
             <div class="collab-char-counter"></div>
             <button type="button" class="btn btn-sm btn-outline-primary collab-add-comment-btn">Comment</button>
         </div>
-        ` : `<div class="collab-marker-comments-disabled"><i class="fas fa-comment-slash"></i> Comments are disabled on this layer</div>`}
+        ` : `<div class="collab-marker-comments-disabled"><i class="fas fa-comment-slash"></i> ${escHtml(commentsRestrictedMessage)}</div>`}
         ${canWrite ? `
         <div class="collab-marker-actions">
             <button type="button" class="btn btn-sm btn-outline-secondary collab-edit-marker-btn">Edit</button>
@@ -433,7 +554,15 @@ function stripSubjectPrefix(subject) {
     return sepIdx === -1 ? "" : subject.slice(sepIdx + 3);
 }
 
-function createOpsLogAuditEntry(vm, subject, text) {
+/**
+ * `eventId`, when the marker's layer has one attached (see Config.js's
+ * "attach to event" picker), is threaded through as the Ops Log entry's own
+ * EventId -- ties every marker/comment logged against that layer back to
+ * the same Beacon event, same as logging it by hand from that event's own
+ * Ops Log tab would. Omitted entirely (not sent as a blank field) for
+ * layers with no event attached, same as before this existed.
+ */
+function createOpsLogAuditEntry(vm, subject, text, eventId) {
     if (typeof vm.createOpsLogEntry !== "function") return Promise.resolve(null);
 
     const payload = {
@@ -445,6 +574,7 @@ function createOpsLogAuditEntry(vm, subject, text) {
         TagIds: [MARKER_AUDIT_TAG_ID],
         TimeLogged: new Date().toISOString(),
     };
+    if (eventId) payload.EventId = eventId;
 
     return new Promise((resolve) => {
         vm.createOpsLogEntry(payload, (result) => resolve(result?.Id ?? null));
@@ -464,10 +594,11 @@ function createOpsLogAuditEntry(vm, subject, text) {
  * so this never needs to truncate.
  */
 function logMarkerAudit(vm, action, layerId, marker, title, description) {
-    const layerName = vm.mapVM.collabLayers().find((l) => l.id === layerId)?.name || layerId;
+    const layer = vm.mapVM.collabLayers().find((l) => l.id === layerId);
+    const layerName = layer?.name || layerId;
     const subject = title ? `${markerSubjectLead(action)} - ${title}` : markerSubjectLead(action);
     const text = `${description || ""}${buildMarkerAuditFooter(action, layerName, marker)}`;
-    return createOpsLogAuditEntry(vm, subject, text);
+    return createOpsLogAuditEntry(vm, subject, text, layer?.eventId);
 }
 
 /**
@@ -476,9 +607,10 @@ function logMarkerAudit(vm, action, layerId, marker, title, description) {
  * marker's commentOpsLogIds.
  */
 function logMarkerComment(vm, layerId, marker, commentText) {
-    const layerName = vm.mapVM.collabLayers().find((l) => l.id === layerId)?.name || layerId;
+    const layer = vm.mapVM.collabLayers().find((l) => l.id === layerId);
+    const layerName = layer?.name || layerId;
     const text = `${commentText}${buildMarkerAuditFooter("commented on", layerName, marker)}`;
-    return createOpsLogAuditEntry(vm, `${SUBJECT_PREFIX} comment`, text);
+    return createOpsLogAuditEntry(vm, `${SUBJECT_PREFIX} comment`, text, layer?.eventId);
 }
 
 /** Fetch a single Ops Log entry by id, resolving null if unavailable/failed. */

--- a/src/pages/tasking/utils/collabLayerSync.js
+++ b/src/pages/tasking/utils/collabLayerSync.js
@@ -51,6 +51,68 @@ function saveCachedLayer(layerId, layer) {
     localStorage.setItem(layerCacheKey(layerId), JSON.stringify(layer));
 }
 
+// ── Subscriptions ────────────────────────────────────────────────────
+//
+// Which collaborative layers a user tracks (shown in Config's "My layers"
+// list, and registered for polling/LayersDrawer) is a client-side
+// preference, not org data -- never sent to the Lambda. Kept independent
+// of HQ so a subscribed layer stays manageable (visible in the list,
+// unsubscribe-able) no matter which HQ the separate "Find a layer" search
+// is currently scoped to -- that's the whole point: unsubscribing from a
+// layer shouldn't require first knowing/re-selecting the HQ it came from.
+const LS_SUBSCRIPTIONS_KEY = 'lh_collabLayer_subscriptions';
+
+/** @returns {Set<string>} */
+export function getSubscribedLayerIds() {
+    try {
+        return new Set(JSON.parse(localStorage.getItem(LS_SUBSCRIPTIONS_KEY)) || []);
+    } catch {
+        return new Set();
+    }
+}
+
+function saveSubscribedLayerIds(ids) {
+    localStorage.setItem(LS_SUBSCRIPTIONS_KEY, JSON.stringify([...ids]));
+}
+
+export function isSubscribed(layerId) {
+    return getSubscribedLayerIds().has(String(layerId));
+}
+
+export function subscribeLayer(layerId) {
+    const ids = getSubscribedLayerIds();
+    ids.add(String(layerId));
+    saveSubscribedLayerIds(ids);
+}
+
+export function unsubscribeLayer(layerId) {
+    const ids = getSubscribedLayerIds();
+    ids.delete(String(layerId));
+    saveSubscribedLayerIds(ids);
+}
+
+/**
+ * One-time migration from the pre-subscriptions model, where every layer
+ * ever fetched got auto-registered and shown/hidden state was tracked
+ * purely by per-layer `ov.online-collab-<id>` flags (see collabLayer.js /
+ * Config.js). Guarded by LS_SUBSCRIPTIONS_KEY already existing (real
+ * subscriptions, even an empty set, always leaves that key set) so this
+ * only ever runs once per browser -- otherwise a layer someone explicitly
+ * unsubscribed from would keep reappearing as long as its old `ov.*` flag
+ * was still '1'.
+ */
+export function migrateLegacyVisibleLayersToSubscriptions() {
+    if (localStorage.getItem(LS_SUBSCRIPTIONS_KEY) !== null) return;
+
+    const ids = new Set();
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        const match = key && key.match(/^ov\.online-collab-(.+)$/);
+        if (match && localStorage.getItem(key) === '1') ids.add(match[1]);
+    }
+    saveSubscribedLayerIds(ids);
+}
+
 // ── List / create layers ────────────────────────────────────────────
 
 /**
@@ -58,24 +120,37 @@ function saveCachedLayer(layerId, layer) {
  * excluded server-side, not deleted).
  * @param {string} apiUrl
  * @param {string} token  Beacon access token (Authorization: Bearer).
+ * @param {string} [hqId]  If given, restricts the list to layers attached
+ *   to this HQ server-side (see lambda listLayers.js) -- omit for "All HQs".
  * @returns {Promise<Array<Object>>}
  */
-export async function listLayers(apiUrl, token) {
-    if (!apiUrl) return loadCachedLayerIndex();
+export async function listLayers(apiUrl, token, hqId) {
+    // Only the unfiltered "All HQs" list is a complete enough picture of
+    // the org's layers to serve as the offline cache -- an HQ-scoped
+    // response would otherwise silently shrink it for every other HQ. So
+    // an HQ-scoped call reads/writes nothing but a client-side filter over
+    // that same full cache, both as its "no apiUrl yet" fallback below and
+    // on a failed fetch.
+    const cached = () => {
+        const all = loadCachedLayerIndex();
+        return hqId ? all.filter((l) => l.hqId === hqId) : all;
+    };
+
+    if (!apiUrl) return cached();
 
     try {
-        const url = `${LAMBDA_BASE}?apiUrl=${encodeURIComponent(apiUrl)}`;
+        const url = `${LAMBDA_BASE}?apiUrl=${encodeURIComponent(apiUrl)}${hqId ? `&hqId=${encodeURIComponent(hqId)}` : ''}`;
         const res = await fetch(url, { method: 'GET', headers: { Accept: 'application/json', Authorization: `Bearer ${token}` } });
         if (!res.ok) {
             console.warn('[collabLayerSync] list failed:', res.status);
-            return loadCachedLayerIndex();
+            return cached();
         }
         const { layers } = await res.json();
-        saveCachedLayerIndex(layers || []);
+        if (!hqId) saveCachedLayerIndex(layers || []);
         return layers || [];
     } catch (err) {
         console.warn('[collabLayerSync] list error:', err);
-        return loadCachedLayerIndex();
+        return cached();
     }
 }
 
@@ -85,13 +160,20 @@ export async function listLayers(apiUrl, token) {
  * @param {string} name
  * @param {string} actorId
  * @param {string} token  Beacon access token (Authorization: Bearer).
- * @param {{readOnly?: boolean, allowDeleteByOthers?: boolean, disableComments?: boolean}} [permissions]
- *   Fixed for the layer's lifetime -- there's no later "edit layer settings" flow.
+ * @param {{markerMode?: string, deleteMode?: string, commentMode?: string, moderators?: Array<{id: string, name: string}>, event?: {id: string, name: string}|null, hq: {id: string, name: string}}} permissions
+ *   Each mode is one of 'anyone' | 'creator' | 'moderators' (default 'anyone').
+ *   Modes are fixed for the layer's lifetime -- there's no later "edit layer
+ *   settings" flow for them -- but `moderators` itself can be changed later
+ *   by the creator via updateLayerModerators() below. `event`, if given, is
+ *   the optional Beacon event this layer is attached to -- also fixed at
+ *   creation, purely for display (see Config.js's layer list). `hq` is
+ *   required -- every layer must belong to an HQ (also fixed at creation);
+ *   the Lambda rejects the request if it's missing.
  * @returns {Promise<Object|null>} the created layer summary, or null on failure
  */
 export async function createLayer(apiUrl, name, actorId, token, permissions = {}) {
     const trimmed = (name || '').trim();
-    if (!apiUrl || !trimmed) return null;
+    if (!apiUrl || !trimmed || !permissions.hq?.id) return null;
 
     try {
         const res = await fetch(LAMBDA_BASE, {
@@ -101,9 +183,12 @@ export async function createLayer(apiUrl, name, actorId, token, permissions = {}
                 apiUrl,
                 name: trimmed,
                 createdBy: String(actorId),
-                readOnly: !!permissions.readOnly,
-                allowDeleteByOthers: permissions.allowDeleteByOthers !== false,
-                disableComments: !!permissions.disableComments,
+                markerMode: permissions.markerMode || 'anyone',
+                deleteMode: permissions.deleteMode || 'anyone',
+                commentMode: permissions.commentMode || 'anyone',
+                moderators: Array.isArray(permissions.moderators) ? permissions.moderators : [],
+                event: permissions.event || null,
+                hq: permissions.hq,
             }),
         });
         if (!res.ok) {
@@ -153,6 +238,51 @@ export async function deleteLayer(apiUrl, layerId, actorId, token) {
         // failure doesn't silently hide a layer that's still on the server.
         saveCachedLayerIndex(index);
         return false;
+    }
+}
+
+/**
+ * Replace a layer's moderator list. Only the layer's creator is authorized
+ * server-side (see lambda updateLayerModerators.js) -- calling this as
+ * anyone else fails with a 403 and the local cache is left untouched.
+ * @param {string} apiUrl
+ * @param {string} layerId
+ * @param {Array<{id: string, name: string}>} moderators
+ * @param {string} token  Beacon access token (Authorization: Bearer).
+ * @returns {Promise<Array<{id: string, name: string}>|null>} the saved moderator list, or null on failure
+ */
+export async function updateLayerModerators(apiUrl, layerId, moderators, token) {
+    if (!apiUrl || !layerId) return null;
+
+    try {
+        const res = await fetch(`${LAMBDA_BASE}/${encodeURIComponent(layerId)}/moderators`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+            body: JSON.stringify({ apiUrl, moderators: moderators || [] }),
+        });
+        if (!res.ok) {
+            throw new Error(`updateLayerModerators failed with status ${res.status}`);
+        }
+        const { moderators: saved } = await res.json();
+
+        // Reconcile the cached index entry (if present) so a page reload
+        // before the next refreshCollabLayerList() still shows the update.
+        const index = loadCachedLayerIndex();
+        const entry = index.find((l) => l.id === layerId);
+        if (entry) {
+            entry.moderators = saved;
+            saveCachedLayerIndex(index);
+        }
+        const cachedLayer = loadCachedLayer(layerId);
+        if (cachedLayer) {
+            cachedLayer.moderators = saved;
+            saveCachedLayer(layerId, cachedLayer);
+        }
+
+        return saved;
+    } catch (err) {
+        console.warn('[collabLayerSync] updateLayerModerators error:', err);
+        return null;
     }
 }
 

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -3,11 +3,302 @@ import ko from 'knockout';
 
 import * as bootstrap from 'bootstrap5'; // Modal, Tooltip, etc.
 import { Enum } from '../utils/enum.js';
-import { createCollabLayer, refreshCollabLayerList, deleteCollabLayer } from '../mapLayers/collabLayer.js';
+import {
+    createCollabLayer, deleteCollabLayer, updateCollabLayerModerators,
+    refreshSubscribedLayers, searchLayersForHq, subscribeToLayer, unsubscribeFromLayer,
+} from '../mapLayers/collabLayer.js';
 
 
 
 const FUNCTION_URL = "https://lambda.lighthouse-extension.com/lad_v2/share";
+
+/**
+ * Reusable search-and-pick-multiple-members widget backing a layer's
+ * moderator list -- used both for the "new layer" form and, later, for
+ * editing an existing layer's moderators per row (only the layer creator
+ * can, mirroring the server-side check in updateLayerModerators.js).
+ * Mirrors the recipient search/picker pattern in SMSTeamModalVM.js.
+ *
+ * Each picked entry is `{ id, name }`, `id` being the Beacon member id
+ * (Username) -- the same identity space as getMemberId()/createdByMemberId
+ * (see mapLayers/collabLayer.js's permissions section for why), resolved
+ * via `searchMembers` (Config.js's deps.searchMembers ->
+ * BeaconClient.users.search) rather than the PersonId space
+ * resolvePersonName()/getSimplePerson() use elsewhere on this page.
+ */
+function makeModeratorPicker(searchMembers, initial = []) {
+    const picker = {};
+    picker.moderators = ko.observableArray(initial.map(m => ({ ...m })));
+    picker.searchQuery = ko.observable('');
+    picker.searchResults = ko.observableArray([]);
+    picker.dropdownOpen = ko.observable(false);
+    picker.loading = ko.observable(false);
+    picker.hasFocus = ko.observable(false);
+
+    let searchTimer = null;
+
+    picker.clearSearch = () => {
+        picker.searchQuery('');
+        picker.searchResults([]);
+        picker.dropdownOpen(false);
+    };
+    picker.closeDropdown = () => {
+        // Delay lets a click on a dropdown item fire before it's hidden.
+        setTimeout(() => picker.dropdownOpen(false), 150);
+    };
+    picker.onSearchKeydown = (_vm, e) => {
+        if (e.key === 'Escape') { picker.clearSearch(); return true; }
+        if (e.key === 'Enter') {
+            const first = picker.searchResults()[0];
+            if (first) picker.addFromSearch(first);
+            return false;
+        }
+        return true;
+    };
+    picker.runSearch = async () => {
+        const q = (picker.searchQuery() || '').trim();
+        if (q.length < 2) {
+            picker.searchResults([]);
+            picker.dropdownOpen(false);
+            return;
+        }
+        // Opens immediately (loading state) rather than waiting for the
+        // response and gating on hasFocus() at that point -- matches the
+        // proven locationSearch pattern elsewhere in this file (self.query's
+        // subscribe), which found that fragile: a focus/blur timing quirk
+        // could leave a real, non-empty result list stuck hidden (reported
+        // as "the HQ picker doesn't drop down when there's only 1 result",
+        // same bug in every picker built from this same shape).
+        picker.searchResults([]);
+        picker.dropdownOpen(true);
+        picker.loading(true);
+        try {
+            const rows = await searchMembers(q);
+            // Username is required -- it's the member-id space moderator
+            // checks are authorized against (see collabLayer.js's
+            // permissions section), so a result without one can't actually
+            // be added as a moderator. Disabled accounts are still shown
+            // (just filtering them silently made real results disappear
+            // when a Disabled flag was set on training/test accounts).
+            const cleaned = (rows || [])
+                .filter(r => r.Username)
+                .map(r => ({
+                    id: String(r.Username),
+                    name: [r.Firstname, r.Lastname].filter(Boolean).join(' ') || String(r.Username),
+                    detail: String(r.Username),
+                }));
+            picker.searchResults(cleaned);
+        } catch (err) {
+            console.error('Member search failed:', err);
+            picker.searchResults([]);
+        } finally {
+            picker.loading(false);
+        }
+    };
+    picker.searchQuery.subscribe(() => {
+        if (searchTimer) clearTimeout(searchTimer);
+        searchTimer = setTimeout(picker.runSearch, 250);
+    });
+    picker.addFromSearch = (result) => {
+        if (!result) return;
+        if (!picker.moderators().some(m => m.id === result.id)) {
+            picker.moderators.push({ id: result.id, name: result.name });
+        }
+        picker.clearSearch();
+    };
+    picker.removeModerator = (moderator) => {
+        picker.moderators.remove(m => m.id === moderator.id);
+    };
+    /** Discards any in-progress edits, restoring the picker to `next`. */
+    picker.reset = (next = []) => {
+        picker.moderators(next.map(m => ({ ...m })));
+        picker.clearSearch();
+    };
+    return picker;
+}
+
+/**
+ * Single-select counterpart to makeModeratorPicker, backing a layer's
+ * optional "attach to event" field (see createCollabLayer's `event`
+ * param). Same search/debounce shape, but holds at most one picked
+ * `{id, name, identifier}` rather than a list.
+ */
+function makeEventPicker(searchEvents) {
+    const picker = {};
+    picker.selected = ko.observable(null);
+    picker.searchQuery = ko.observable('');
+    picker.searchResults = ko.observableArray([]);
+    picker.dropdownOpen = ko.observable(false);
+    picker.loading = ko.observable(false);
+    picker.hasFocus = ko.observable(false);
+    // Precomputed (rather than a ternary in the data-bind attribute)
+    // because knockout-secure-binding's expression grammar doesn't support
+    // the conditional (?:) operator. Shows the identifier alongside the
+    // name (e.g. "6/1718 — Flood response") rather than name alone, since
+    // the name is often generic (see the create-layer form's chip and
+    // -- once the identifier is round-tripped through the layer object,
+    // see createLayer.js's eventIdentifier -- the layer list's own badge).
+    picker.selectedLabel = ko.pureComputed(() => {
+        const s = picker.selected();
+        if (!s) return '';
+        return s.identifier ? `${s.identifier} — ${s.name}` : s.name;
+    });
+
+    let searchTimer = null;
+
+    picker.clearSearch = () => {
+        picker.searchQuery('');
+        picker.searchResults([]);
+        picker.dropdownOpen(false);
+    };
+    picker.closeDropdown = () => {
+        setTimeout(() => picker.dropdownOpen(false), 150);
+    };
+    picker.onSearchKeydown = (_vm, e) => {
+        if (e.key === 'Escape') { picker.clearSearch(); return true; }
+        if (e.key === 'Enter') {
+            const first = picker.searchResults()[0];
+            if (first) picker.selectFromSearch(first);
+            return false;
+        }
+        return true;
+    };
+    picker.runSearch = async () => {
+        const q = (picker.searchQuery() || '').trim();
+        if (q.length < 2) {
+            picker.searchResults([]);
+            picker.dropdownOpen(false);
+            return;
+        }
+        // Opens immediately (loading state) rather than waiting for the
+        // response and gating on hasFocus() at that point -- see
+        // makeModeratorPicker above for why (same bug, same fix, shared
+        // across every picker built from this shape).
+        picker.searchResults([]);
+        picker.dropdownOpen(true);
+        picker.loading(true);
+        try {
+            const rows = await searchEvents(q);
+            const cleaned = (rows || [])
+                .filter(r => r.Id != null)
+                .map(r => ({
+                    id: String(r.Id),
+                    name: r.Name || `Event ${r.Id}`,
+                    identifier: r.Identifier || '',
+                }));
+            picker.searchResults(cleaned);
+        } catch (err) {
+            console.error('Event search failed:', err);
+            picker.searchResults([]);
+        } finally {
+            picker.loading(false);
+        }
+    };
+    picker.searchQuery.subscribe(() => {
+        if (searchTimer) clearTimeout(searchTimer);
+        searchTimer = setTimeout(picker.runSearch, 250);
+    });
+    picker.selectFromSearch = (result) => {
+        if (!result) return;
+        picker.selected(result);
+        picker.clearSearch();
+    };
+    picker.clearSelection = () => picker.selected(null);
+    /** Discards any in-progress edits, restoring the picker to `next`. */
+    picker.reset = (next = null) => {
+        picker.selected(next ? { ...next } : null);
+        picker.clearSearch();
+    };
+    return picker;
+}
+
+/**
+ * Single-select entity picker scoped to Headquarters-type entities, backing
+ * both a layer's required HQ attachment and the layer list's HQ filter
+ * (Config.js). Same search/debounce shape as makeEventPicker, but searches
+ * Beacon entities (deps.entitiesSearch, i.e. BeaconClient.entities.search)
+ * rather than events.
+ *
+ * Filtered to results carrying a HeadquartersStatusTypeId -- confirmed
+ * against a live Entities/Search response as the actual "this entity is an
+ * HQ" signal (a real HQ came back with EntityTypeId: 2, e.g. a Zone HQ
+ * under State Headquarters' EntityTypeId: 1 -- EntityTypeId varies by
+ * level in the org hierarchy and is *not* a reliable "is this an HQ" check
+ * on its own, unlike HeadquartersStatusTypeId which only ever appears on
+ * HQ-type entities).
+ */
+function makeHqPicker(searchEntities, initial = null) {
+    const picker = {};
+    picker.selected = ko.observable(initial ? { ...initial } : null);
+    picker.searchQuery = ko.observable('');
+    picker.searchResults = ko.observableArray([]);
+    picker.dropdownOpen = ko.observable(false);
+    picker.loading = ko.observable(false);
+    picker.hasFocus = ko.observable(false);
+
+    let searchTimer = null;
+
+    picker.clearSearch = () => {
+        picker.searchQuery('');
+        picker.searchResults([]);
+        picker.dropdownOpen(false);
+    };
+    picker.closeDropdown = () => {
+        setTimeout(() => picker.dropdownOpen(false), 150);
+    };
+    picker.onSearchKeydown = (_vm, e) => {
+        if (e.key === 'Escape') { picker.clearSearch(); return true; }
+        if (e.key === 'Enter') {
+            const first = picker.searchResults()[0];
+            if (first) picker.selectFromSearch(first);
+            return false;
+        }
+        return true;
+    };
+    picker.runSearch = async () => {
+        const q = (picker.searchQuery() || '').trim();
+        if (q.length < 2) {
+            picker.searchResults([]);
+            picker.dropdownOpen(false);
+            return;
+        }
+        // Opens immediately (loading state) rather than waiting for the
+        // response and gating on hasFocus() at that point -- see
+        // makeModeratorPicker above for why (same bug, same fix, shared
+        // across every picker built from this shape).
+        picker.searchResults([]);
+        picker.dropdownOpen(true);
+        picker.loading(true);
+        try {
+            const rows = await searchEntities(q);
+            const cleaned = (rows || [])
+                .filter(r => r.Id != null && r.HeadquartersStatusTypeId != null)
+                .map(r => ({ id: String(r.Id), name: r.Name || `HQ ${r.Id}` }));
+            picker.searchResults(cleaned);
+        } catch (err) {
+            console.error('HQ search failed:', err);
+            picker.searchResults([]);
+        } finally {
+            picker.loading(false);
+        }
+    };
+    picker.searchQuery.subscribe(() => {
+        if (searchTimer) clearTimeout(searchTimer);
+        searchTimer = setTimeout(picker.runSearch, 250);
+    });
+    picker.selectFromSearch = (result) => {
+        if (!result) return;
+        picker.selected(result);
+        picker.clearSearch();
+    };
+    picker.clearSelection = () => picker.selected(null);
+    /** Discards any in-progress edits, restoring the picker to `next`. */
+    picker.reset = (next = null) => {
+        picker.selected(next ? { ...next } : null);
+        picker.clearSearch();
+    };
+    return picker;
+}
 
 
 
@@ -202,21 +493,113 @@ export function ConfigVM(root, deps) {
         };
     }
     // ── Collaborative map layers ──
+    //
+    // Two independent concerns, deliberately kept apart rather than merged
+    // into one HQ-scoped list-with-a-view-toggle (the earlier design here,
+    // which made a layer impossible to find/unsubscribe from once its HQ
+    // fell outside whatever filter happened to be selected):
+    //   - "My layers" (self.collabLayers/collabLayerRows below) -- every
+    //     layer this user is *subscribed* to (see collabLayerSync.js's
+    //     localStorage-backed subscription helpers; subscribing is a
+    //     client preference, not org data). Always lists every
+    //     subscription regardless of HQ, so managing/unsubscribing from
+    //     one never requires knowing which HQ it came from. You get here
+    //     either by creating a layer (auto-subscribes you) or by
+    //     subscribing to one found via "Find a layer" below.
+    //   - "Find a layer" (self.discoverHqPicker/discoverRows below) --
+    //     search one HQ at a time to discover layers to subscribe to. Pure
+    //     browse/discovery; never touches My layers except via an explicit
+    //     Subscribe click.
+    // Whether a subscribed layer is actually drawn on the map is the map's
+    // own Layers control's job entirely (LayersDrawer, main.js) -- this
+    // panel has no View/show-hide toggle of its own anymore. The one
+    // exception: creating a layer auto-shows it (see collabLayer.js's
+    // createCollabLayer) since whoever just made one almost certainly
+    // wants to see it immediately.
     self.collabLayers = root.mapVM?.collabLayers || ko.observableArray([]);
+    // The whole "create a layer" flow (name, HQ, advanced options) is
+    // collapsed behind a single "+ New layer" toggle by default -- it's a
+    // lot of controls (mandatory HQ, optional event, 3 permission modes,
+    // moderators) to have permanently on-screen above what's usually the
+    // more-often-used layer list below.
+    self.showCreateLayerForm = ko.observable(false);
+    self.toggleCreateLayerForm = () => self.showCreateLayerForm(!self.showCreateLayerForm());
     self.newLayerName = ko.observable('');
-    // Fixed for a layer's whole lifetime once created -- there's no later
-    // "edit layer settings" flow, by design (see mapLayers/collabLayer.js).
-    // Each backed by a radio pair in tasking.html, all following the same
-    // "Anyone can ___" / "Only I can/I've disabled ___" shape for a
-    // consistent mental model across the three permissions.
-    self.newLayerReadOnly = ko.observable(false); // marker permissions: "Anyone can add markers" / "Only I can add markers"
-    self.newLayerAllowDeleteByOthers = ko.observable(true); // delete permissions: "Anyone can delete this layer" / "Only I can delete this layer"
-    self.newLayerDisableComments = ko.observable(false); // comment permissions: "Anyone can comment" / "Comments are disabled"
+    // Every layer must belong to an HQ -- defaults to whatever HQ this
+    // Lighthouse instance was launched for (?hq=<entity id>, resolved below
+    // into self.defaultHq), but can be changed via search before creating.
+    // Required (unlike the event picker below), enforced both here
+    // (createCollabLayer) and server-side (createLayer.js).
+    self.newLayerHqPicker = makeHqPicker(deps.entitiesSearch);
+    // Optional Beacon event this layer relates to -- purely display
+    // metadata (like createdBy), fixed at creation same as the permission
+    // modes below, no later "attach/detach event" flow.
+    self.newLayerEventPicker = makeEventPicker(deps.searchEvents);
+    // Each mode is fixed for a layer's whole lifetime once created -- there's
+    // no later "edit permissions" flow, by design (see
+    // mapLayers/collabLayer.js). Each backed by a 3-way radio group in
+    // tasking.html: 'anyone' | 'creator' | 'moderators', all following the
+    // same "Anyone can ___" / "Only I can ___" / "Moderators can ___" shape
+    // for a consistent mental model across the three permissions. The
+    // moderator *list* itself is the one thing that's editable later (by
+    // the creator) -- see newLayerModeratorPicker below and each row's own
+    // moderatorPicker in collabLayerRows.
+    self.newLayerMarkerMode = ko.observable('anyone'); // who can add/edit/delete markers
+    self.newLayerDeleteMode = ko.observable('anyone'); // who can delete the layer itself
+    self.newLayerCommentMode = ko.observable('anyone'); // who can comment on markers
+    self.newLayerModeratorPicker = makeModeratorPicker(deps.searchMembers);
+    // Shown only once at least one permission above is set to 'moderators'
+    // -- the moderator list is meaningless (and hidden) otherwise.
+    self.showNewLayerModeratorPicker = ko.pureComputed(() =>
+        self.newLayerMarkerMode() === 'moderators' ||
+        self.newLayerDeleteMode() === 'moderators' ||
+        self.newLayerCommentMode() === 'moderators');
     self.creatingCollabLayer = ko.observable(false);
     self.collabLayerError = ko.observable('');
-    self.collabLayerSearch = ko.observable(''); // filters the (possibly long) layer list below
+    self.collabLayerSearch = ko.observable(''); // filters "My layers" by name -- mainly useful once you've subscribed to a lot of them
     self.refreshingCollabLayers = ko.observable(false);
     self.deletingCollabLayerId = ko.observable(null); // id of the row currently mid-delete, if any
+
+    // ── Find a layer (discover/subscribe) ──
+    // Collapsed behind its own toggle by default, same reasoning as
+    // showCreateLayerForm above.
+    self.showDiscoverForm = ko.observable(false);
+    self.toggleDiscoverForm = () => {
+        self.showDiscoverForm(!self.showDiscoverForm());
+        // Fetch on first open (rather than requiring a search/HQ pick
+        // first) so opening this immediately shows something -- no HQ
+        // picked means "all HQs", not "nothing", see runDiscoverSearch.
+        if (self.showDiscoverForm() && self.discoverResults().length === 0 && !self.discoverLoading()) {
+            self.runDiscoverSearch();
+        }
+    };
+    // Browses one HQ's layers at a time to find something to subscribe to
+    // -- deliberately not the same picker as newLayerHqPicker above (that
+    // one's "what HQ does my new layer belong to", this one's "what HQ am
+    // I browsing"), even though both default to the same launch HQ.
+    self.discoverHqPicker = makeHqPicker(deps.entitiesSearch);
+    self.discoverSearch = ko.observable(''); // filters the picked HQ's results by name
+    self.discoverLoading = ko.observable(false);
+    self.discoverResults = ko.observableArray([]); // raw layer objects for the picked HQ
+    self.discoverError = ko.observable('');
+
+    // Resolves ?hq=<entity id> (deps.defaultHqId) once at startup and seeds
+    // both HQ pickers below with it -- the "new layer" picker so creating a
+    // layer defaults to this HQ, the "Find a layer" picker so discovery
+    // defaults to browsing this HQ's layers. Kept separately (self.defaultHq)
+    // so createCollabLayer can reset newLayerHqPicker back to it after each
+    // creation instead of clearing it to nothing (users creating several
+    // layers in a row are almost always doing it for the same HQ).
+    self.defaultHq = ko.observable(null);
+    if (deps.defaultHqId) {
+        Promise.resolve(deps.entity(deps.defaultHqId)).then(entity => {
+            if (!entity?.Id) return;
+            const hq = { id: String(entity.Id), name: entity.Name || String(entity.Id) };
+            self.defaultHq(hq);
+            self.newLayerHqPicker.reset(hq);
+            self.discoverHqPicker.reset(hq);
+        }).catch(err => console.warn('Failed to resolve default HQ:', err));
+    }
 
     function relativeTime(iso) {
         if (!iso) return 'never';
@@ -230,26 +613,23 @@ export function ConfigVM(root, deps) {
         return `${Math.round(hrs / 24)}d ago`;
     }
 
-    // Applies the actual show/hide side-effect when a row's View switch
-    // changes. `row.key` is the unprefixed registry key used by
-    // mapVM.onlineLayers; `row.drawerKey` is the 'online-'-prefixed key the
-    // layers drawer uses for its `ov.<key>` localStorage visibility flag
-    // (see getOverlayDefsForControl in Map.js) — both must be kept in sync.
-    // Any user can add/edit/delete markers on a visible layer directly on
-    // the map (right-click to add, popup buttons to edit/delete) — there's
-    // no separate "edit mode" toggle here, just View.
-    self._applyCollabLayerView = (row, enabled) => {
-        const layerObj = root.mapVM.onlineLayers.get(row.key)?.layerGroup;
-        if (!layerObj) return;
-        if (enabled) {
-            root.mapVM.map.addLayer(layerObj);
-            localStorage.setItem(`ov.${row.drawerKey}`, '1');
-        } else {
-            root.mapVM.map.removeLayer(layerObj);
-            localStorage.setItem(`ov.${row.drawerKey}`, '0');
-        }
-        root.mapVM.layersDrawer?.refresh?.();
-    };
+    // Layers created before the moderators feature only carry the old
+    // readOnly / allowDeleteByOthers / disableComments booleans and no mode
+    // fields -- derive the equivalent mode so old layers display and behave
+    // the same as before (mirrors lambda/map-layers-v2/lib/permissions.js
+    // and collabLayer.js's effective*Mode() helpers, which every
+    // permission-enforcing Lambda handler and the map popup gating also
+    // fall back to).
+    function effectiveMarkerMode(layer) {
+        return layer.markerMode || (layer.readOnly ? 'creator' : 'anyone');
+    }
+    function effectiveDeleteMode(layer) {
+        return layer.deleteMode || (layer.allowDeleteByOthers === false ? 'creator' : 'anyone');
+    }
+    function effectiveCommentMode(layer) {
+        return layer.commentMode || (layer.disableComments ? 'creator' : 'anyone');
+    }
+    const MODE_LABELS = { anyone: 'Anyone', creator: 'Only the creator', moderators: 'The creator and moderators' };
 
     // Sorted alphabetically so a long list stays scannable; filtered by
     // collabLayerSearch below for the same reason.
@@ -257,33 +637,85 @@ export function ConfigVM(root, deps) {
         .slice()
         .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
         .map(layer => {
-            const key = `collab-${layer.id}`;
-            const drawerKey = `online-${key}`;
             const memberId = deps.getMemberId?.();
             const isCreator = !!memberId && memberId === layer.createdByMemberId;
+            const moderators = Array.isArray(layer.moderators) ? layer.moderators : [];
+            const isModerator = !!memberId && moderators.some(m => m?.id === memberId);
+            const markerMode = effectiveMarkerMode(layer);
+            const deleteMode = effectiveDeleteMode(layer);
+            const commentMode = effectiveCommentMode(layer);
+            const canDeleteByMode = deleteMode === 'anyone' || isCreator || (deleteMode === 'moderators' && isModerator);
+            // Creator or any current moderator can manage the moderator
+            // list (see lambda updateLayerModerators.js's isAuthorized
+            // check) -- a moderator can add/remove others, including
+            // themselves.
+            const canManageModerators = isCreator || isModerator;
             const row = {
                 layer,
-                key,
-                drawerKey,
                 name: layer.name,
                 markerCount: layer.markerCount || 0,
                 lastUsedLabel: relativeTime(layer.lastUsedAt),
-                viewEnabled: ko.observable(localStorage.getItem(`ov.${drawerKey}`) === '1'),
-                readOnly: !!layer.readOnly,
-                disableComments: !!layer.disableComments,
-                // allowDeleteByOthers defaults true server-side, so an
-                // absent/undefined value (older layers) reads as deletable.
-                canDelete: layer.allowDeleteByOthers !== false || isCreator,
+                markerMode,
+                commentMode,
+                markerRestricted: markerMode !== 'anyone',
+                commentRestricted: commentMode !== 'anyone',
+                markerModeTitle: `${MODE_LABELS[markerMode]} can add, edit or delete markers`,
+                commentModeTitle: `${MODE_LABELS[commentMode]} can comment`,
+                moderators,
+                moderatorCount: moderators.length,
+                // Precomputed (rather than a ternary in the data-bind
+                // attribute) because knockout-secure-binding's expression
+                // grammar doesn't support the conditional (?:) operator.
+                moderatorCountLabel: `${moderators.length} moderator${moderators.length === 1 ? '' : 's'}`,
+                moderatorNamesLabel: moderators.map(m => m.name).join(', '),
+                eventName: layer.eventName || null,
+                // Precomputed (rather than a ternary in the data-bind
+                // attribute) because knockout-secure-binding's expression
+                // grammar doesn't support the conditional (?:) operator.
+                eventLabel: layer.eventName
+                    ? (layer.eventIdentifier ? `${layer.eventIdentifier} — ${layer.eventName}` : layer.eventName)
+                    : null,
+                hqId: layer.hqId || null,
+                hqName: layer.hqName || null,
+                isCreator,
+                canDelete: canDeleteByMode,
                 confirmingDelete: ko.observable(false),
+                // layer.createdBy is a raw Beacon person id -- resolved
+                // asynchronously (and cached) to a display name via
+                // root.resolvePersonName, same as marker/comment authorship
+                // elsewhere on this page.
+                authorName: ko.observable(''),
+                // Creator or any current moderator can manage moderators
+                // (enforced server-side too, see updateLayerModerators.js)
+                // -- everyone else doesn't get the "Manage moderators"
+                // control at all.
+                canManageModerators,
+                editingModerators: ko.observable(false),
+                savingModerators: ko.observable(false),
+                moderatorsError: ko.observable(''),
+                moderatorPicker: canManageModerators ? makeModeratorPicker(deps.searchMembers, moderators) : null,
             };
+            if (layer.createdBy && root.resolvePersonName) {
+                root.resolvePersonName(layer.createdBy).then(name => row.authorName(name));
+            }
             // Precomputed here (rather than a ternary in the data-bind
             // attribute) because knockout-secure-binding's expression
             // grammar doesn't support the conditional (?:) operator.
-            row.deleteTitle = row.canDelete ? 'Delete layer' : 'Only the layer creator can delete this layer';
-            row.viewEnabled.subscribe((v) => self._applyCollabLayerView(row, v));
+            row.deleteTitle = row.canDelete ? 'Delete layer' : `${MODE_LABELS[deleteMode]} can delete this layer`;
+            row.unsubscribe = () => self.unsubscribeLayer(row);
             row.requestDeleteLayer = () => row.confirmingDelete(true);
             row.cancelDeleteLayer = () => row.confirmingDelete(false);
             row.confirmDeleteLayer = () => self.deleteCollabLayer(row);
+            row.toggleEditModerators = () => {
+                row.moderatorsError('');
+                row.moderatorPicker?.reset(row.moderators);
+                row.editingModerators(!row.editingModerators());
+            };
+            row.cancelEditModerators = () => {
+                row.moderatorPicker?.reset(row.moderators);
+                row.editingModerators(false);
+            };
+            row.saveModerators = () => self.saveRowModerators(row);
             return row;
         }));
 
@@ -294,24 +726,153 @@ export function ConfigVM(root, deps) {
         return rows.filter(row => row.name.toLowerCase().includes(q));
     });
 
+    // Precomputed (rather than a ternary in the data-bind attribute)
+    // because knockout-secure-binding's expression grammar doesn't support
+    // the conditional (?:) operator.
+    self.noLayersMessage = ko.pureComputed(() =>
+        self.collabLayers().length === 0
+            ? "You haven't subscribed to any layers yet — create one above, or find one to subscribe to below."
+            : '');
+
+    // Single computed driving both the visible condition and the message
+    // text -- avoids two separate bindings on the same element (a compound
+    // `visible` expression plus a `text:` interpolation) rendering
+    // inconsistently with each other for a frame.
+    self.noSearchMatchMessage = ko.pureComputed(() => {
+        const q = self.collabLayerSearch().trim();
+        if (!q || self.collabLayers().length === 0 || self.filteredCollabLayerRows().length > 0) return '';
+        return `No layers match "${q}".`;
+    });
+
+    // ── Find a layer (discover/subscribe) ──
+    // No HQ picked means "search all HQs" -- not "search nothing" -- so
+    // this always fetches something, scoped server-side when an HQ is
+    // picked (see lambda listLayers.js's hqId param) or unfiltered when not.
+    self.runDiscoverSearch = async () => {
+        if (!deps.apiUrl) {
+            self.discoverResults([]);
+            return;
+        }
+        self.discoverError('');
+        self.discoverLoading(true);
+        try {
+            const hqId = self.discoverHqPicker.selected()?.id;
+            self.discoverResults(await searchLayersForHq(deps.apiUrl, deps.getToken, hqId));
+        } catch (err) {
+            console.error('Error searching layers:', err);
+            self.discoverError('Failed to search layers. Try again later.');
+            self.discoverResults([]);
+        } finally {
+            self.discoverLoading(false);
+        }
+    };
+    self.discoverHqPicker.selected.subscribe(() => self.runDiscoverSearch());
+
+    self.discoverRows = ko.pureComputed(() => {
+        const subscribedIds = new Set(self.collabLayers().map(l => l.id));
+        const q = self.discoverSearch().trim().toLowerCase();
+        return self.discoverResults()
+            .filter(layer => !q || (layer.name || '').toLowerCase().includes(q))
+            .slice()
+            .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+            .map(layer => {
+                const drow = {
+                    layer,
+                    name: layer.name,
+                    markerCount: layer.markerCount || 0,
+                    lastUsedLabel: relativeTime(layer.lastUsedAt),
+                    // hqName is shown per-row since browsing can span every
+                    // HQ at once (no HQ picked -- see runDiscoverSearch above).
+                    hqName: layer.hqName || null,
+                    eventName: layer.eventName || null,
+                    // Precomputed (rather than a ternary in the data-bind
+                    // attribute) because knockout-secure-binding's
+                    // expression grammar doesn't support the conditional
+                    // (?:) operator.
+                    eventLabel: layer.eventName
+                        ? (layer.eventIdentifier ? `${layer.eventIdentifier} — ${layer.eventName}` : layer.eventName)
+                        : null,
+                    alreadySubscribed: subscribedIds.has(layer.id),
+                    subscribing: ko.observable(false),
+                    // layer.createdBy is a raw Beacon person id -- resolved
+                    // asynchronously (and cached) to a display name via
+                    // root.resolvePersonName, same as collabLayerRows above.
+                    authorName: ko.observable(''),
+                };
+                if (layer.createdBy && root.resolvePersonName) {
+                    root.resolvePersonName(layer.createdBy).then(name => drow.authorName(name));
+                }
+                return drow;
+            });
+    });
+
+    // Precomputed (rather than a ternary in the data-bind attribute)
+    // because knockout-secure-binding's expression grammar doesn't support
+    // the conditional (?:) operator.
+    self.discoverEmptyMessage = ko.pureComputed(() => {
+        if (self.discoverLoading() || self.discoverRows().length > 0) return '';
+        const hq = self.discoverHqPicker.selected();
+        return hq ? `No layers found for ${hq.name}.` : 'No layers found.';
+    });
+
+    self.subscribeToDiscoverRow = (discoverRow) => {
+        if (discoverRow.alreadySubscribed || discoverRow.subscribing()) return;
+        discoverRow.subscribing(true);
+        try {
+            subscribeToLayer(root, deps.apiUrl, discoverRow.layer, deps.actorId, deps.getToken, deps.getMemberId);
+        } finally {
+            discoverRow.subscribing(false);
+        }
+    };
+
+    self.unsubscribeLayer = (row) => {
+        unsubscribeFromLayer(root, row.layer.id);
+    };
+
+    // Shared by a successful create and an explicit Cancel -- puts the form
+    // back to its just-opened state. HQ resets to the resolved default (not
+    // empty), since creating several layers in a row, or reopening the form
+    // later, is almost always for the same HQ; everything else resets to
+    // its "no customisation" default.
+    function resetNewLayerForm() {
+        self.newLayerName('');
+        self.newLayerMarkerMode('anyone');
+        self.newLayerDeleteMode('anyone');
+        self.newLayerCommentMode('anyone');
+        self.newLayerModeratorPicker.reset([]);
+        self.newLayerEventPicker.reset(null);
+        self.newLayerHqPicker.reset(self.defaultHq());
+    }
+
+    self.cancelCreateLayer = () => {
+        self.collabLayerError('');
+        resetNewLayerForm();
+        self.showCreateLayerForm(false);
+    };
+
     self.createCollabLayer = async () => {
         const name = self.newLayerName().trim();
+        const hq = self.newLayerHqPicker.selected();
         if (!name || !deps.apiUrl) return;
+        if (!hq) {
+            self.collabLayerError('An HQ is required -- search for one above.');
+            return;
+        }
 
         self.collabLayerError('');
         self.creatingCollabLayer(true);
         try {
             const permissions = {
-                readOnly: self.newLayerReadOnly(),
-                allowDeleteByOthers: self.newLayerAllowDeleteByOthers(),
-                disableComments: self.newLayerDisableComments(),
+                markerMode: self.newLayerMarkerMode(),
+                deleteMode: self.newLayerDeleteMode(),
+                commentMode: self.newLayerCommentMode(),
+                moderators: self.newLayerModeratorPicker.moderators(),
+                event: self.newLayerEventPicker.selected(),
+                hq,
             };
             const layer = await createCollabLayer(root, deps.apiUrl, name, deps.actorId, deps.getToken, permissions, deps.getMemberId);
             if (!layer) throw new Error('Create failed');
-            self.newLayerName('');
-            self.newLayerReadOnly(false);
-            self.newLayerAllowDeleteByOthers(true);
-            self.newLayerDisableComments(false);
+            resetNewLayerForm();
         } catch (err) {
             console.error('Error creating collaborative layer:', err);
             self.collabLayerError('Failed to create layer. Try again later.');
@@ -320,16 +881,17 @@ export function ConfigVM(root, deps) {
         }
     };
 
-    // Re-pulls the org's layer list from the server -- picks up layers
-    // created by other users since this page loaded (createCollabLayer
-    // above only accounts for layers *this* session created).
+    // Re-pulls "My layers" from the server -- picks up any changes to
+    // layers this user is subscribed to since this page loaded
+    // (createCollabLayer above only accounts for layers *this* session
+    // created/subscribed to).
     self.refreshCollabLayers = async () => {
         if (!deps.apiUrl || self.refreshingCollabLayers()) return;
 
         self.collabLayerError('');
         self.refreshingCollabLayers(true);
         try {
-            await refreshCollabLayerList(root, deps.apiUrl, deps.actorId, deps.getToken, deps.getMemberId);
+            await refreshSubscribedLayers(root, deps.apiUrl, deps.actorId, deps.getToken, deps.getMemberId);
         } catch (err) {
             console.error('Error refreshing collaborative layers:', err);
             self.collabLayerError('Failed to refresh layer list. Try again later.');
@@ -355,6 +917,35 @@ export function ConfigVM(root, deps) {
             row.confirmingDelete(false);
         } finally {
             self.deletingCollabLayerId(null);
+        }
+    };
+
+    // Saves a row's in-progress moderator picker as the layer's new
+    // moderator list, fired from row.saveModerators above. Only rows the
+    // creator or a current moderator can manage ever get a moderatorPicker
+    // (see collabLayerRows' canManageModerators), so there's no separate
+    // authorization check needed here -- the Lambda enforces it
+    // authoritatively either way.
+    self.saveRowModerators = async (row) => {
+        if (!deps.apiUrl || !row.moderatorPicker || row.savingModerators()) return;
+
+        row.moderatorsError('');
+        row.savingModerators(true);
+        try {
+            const moderators = row.moderatorPicker.moderators();
+            const saved = await updateCollabLayerModerators(root, deps.apiUrl, row.layer.id, moderators, deps.getToken);
+            if (saved == null) throw new Error('Update failed');
+            // updateCollabLayerModerators mutates row.layer.moderators in
+            // place (it's the same object reference held in
+            // self.collabLayers()) -- force collabLayerRows to recompute so
+            // this row (and its canDelete/moderator badges) reflect the new
+            // list immediately, same as a poll-driven refresh would.
+            self.collabLayers.valueHasMutated();
+        } catch (err) {
+            console.error('Error updating layer moderators:', err);
+            row.moderatorsError('Failed to save moderators. Try again later.');
+        } finally {
+            row.savingModerators(false);
         }
     };
 

--- a/src/shared/BeaconClient.js
+++ b/src/shared/BeaconClient.js
@@ -22,11 +22,13 @@ import * as suppliers from './BeaconClient/suppliers.js';
 import * as images from './BeaconClient/images.js';
 import * as icems from './BeaconClient/icems.js';
 import * as people from './BeaconClient/people.js';
+import * as users from './BeaconClient/users.js';
+import * as events from './BeaconClient/events.js';
 
-export { job, asset, nitc, operationslog, resources, team, unit, entities, tasking, notifications, geoservices, tags, sectors, frao, contacts, messages, suppliers, images, icems, people };
+export { job, asset, nitc, operationslog, resources, team, unit, entities, tasking, notifications, geoservices, tags, sectors, frao, contacts, messages, suppliers, images, icems, people, users, events };
 
 // re-export functions
-export default { job, asset, nitc, operationslog, resources, team, unit, entities, tasking, notifications, geoservices, tags, sectors, frao, contacts, messages, suppliers, images, icems, people, toFormUrlEncoded };
+export default { job, asset, nitc, operationslog, resources, team, unit, entities, tasking, notifications, geoservices, tags, sectors, frao, contacts, messages, suppliers, images, icems, people, users, events, toFormUrlEncoded };
 export function toFormUrlEncoded(obj) {
     const params = [];
     for (const key in obj) {

--- a/src/shared/BeaconClient/events.js
+++ b/src/shared/BeaconClient/events.js
@@ -1,0 +1,32 @@
+import $ from 'jquery';
+
+// A single free-text `query` is sent against both EventName and Identifier
+// simultaneously (same "OR across fields" shape as Users/Search) so callers
+// don't need to guess whether the user typed an event name or its
+// identifier (e.g. "6/1718"). ViewModelType=2 mirrors Beacon's own event
+// picker requests.
+export function search(query, host, userId = 'notPassed', token, callback, errorCallback) {
+  $.ajax({
+    type: 'GET',
+    url: host + '/Api/v1/Events/Search?EventName=' + encodeURIComponent(query) +
+      '&Identifier=' + encodeURIComponent(query) +
+      '&ViewModelType=2&PageSize=10&SortField=identifier&SortOrder=asc' +
+      '&LighthouseFunction=SearchEvents&userId=' + userId,
+    beforeSend: function (n) {
+      n.setRequestHeader('Authorization', 'Bearer ' + token);
+    },
+    cache: false,
+    dataType: 'json',
+    complete: function (response, textStatus) {
+      if (textStatus == 'success') {
+        if (typeof callback === 'function') {
+          callback(response.responseJSON);
+        }
+      } else {
+        if (typeof errorCallback === 'function') {
+          errorCallback(response);
+        }
+      }
+    }
+  });
+}

--- a/src/shared/BeaconClient/users.js
+++ b/src/shared/BeaconClient/users.js
@@ -1,0 +1,53 @@
+import $ from 'jquery';
+
+/**
+ * Builds the FirstName/LastName/Username/Email query params for a single
+ * free-text search box. A query containing a space is unambiguously a
+ * "firstname lastname" search (nobody's Username or Email has a space in
+ * it), so it's split -- everything before the last word as FirstName,
+ * the last word as LastName -- rather than sent as one blob to every field,
+ * which would rarely match anything. A single word (a name, member number,
+ * or partial email) is still sent against all four fields simultaneously
+ * (mirroring how Beacon's own admin UI searches this endpoint) so callers
+ * don't need to guess which kind of value the user typed.
+ */
+function buildSearchParams(query) {
+  const trimmed = String(query || '').trim();
+  const words = trimmed.split(/\s+/).filter(Boolean);
+
+  if (words.length > 1) {
+    const lastName = words[words.length - 1];
+    const firstName = words.slice(0, -1).join(' ');
+    return 'FirstName=' + encodeURIComponent(firstName) + '&LastName=' + encodeURIComponent(lastName);
+  }
+
+  return 'FirstName=' + encodeURIComponent(trimmed) +
+    '&LastName=' + encodeURIComponent(trimmed) +
+    '&Username=' + encodeURIComponent(trimmed) +
+    '&Email=' + encodeURIComponent(trimmed);
+}
+
+export function search(query, host, userId = 'notPassed', token, callback, errorCallback) {
+  $.ajax({
+    type: 'GET',
+    url: host + '/Api/v1/Users/Search?' + buildSearchParams(query) +
+      '&External=false&IsDeleted=false&PageIndex=1&PageSize=10' +
+      '&LighthouseFunction=SearchUsers&userId=' + userId,
+    beforeSend: function (n) {
+      n.setRequestHeader('Authorization', 'Bearer ' + token);
+    },
+    cache: false,
+    dataType: 'json',
+    complete: function (response, textStatus) {
+      if (textStatus == 'success') {
+        if (typeof callback === 'function') {
+          callback(response.responseJSON);
+        }
+      } else {
+        if (typeof errorCallback === 'function') {
+          errorCallback(response);
+        }
+      }
+    }
+  });
+}

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2805,103 +2805,379 @@
                                                 </div>
                                                 <p class="small text-muted mb-3">
                                                     Shared marker layers that everyone in your organisation can see and
-                                                    edit together. Enable View to show a layer on the map — once
-                                                    visible, right-click anywhere on the map to drop a marker on it.
-                                                    Layers unused for 120 days stop appearing here, but their data
-                                                    isn't deleted.
+                                                    edit together. Create one, or find one below and subscribe to add
+                                                    it to your list. Use the <i class="fas fa-layer-group"></i> Layers
+                                                    button on the map to actually show/hide a layer you've subscribed
+                                                    to — once visible, right-click anywhere on the map to drop a
+                                                    marker on it. Layers unused for 120 days stop appearing in search,
+                                                    but their data isn't deleted.
                                                 </p>
 
+                                                <!-- ko if: !config.showCreateLayerForm() -->
+                                                <button type="button" class="btn btn-sm btn-outline-primary mb-3"
+                                                    data-bind="click: config.toggleCreateLayerForm">
+                                                    <i class="fa fa-plus me-1"></i>New layer
+                                                </button>
+                                                <!-- /ko -->
+                                                <!-- ko if: config.showCreateLayerForm -->
+                                                <div class="collab-create-layer-panel border rounded p-2 mb-3">
                                                 <div class="input-group input-group-sm mb-2">
                                                     <input type="text" class="form-control" placeholder="New layer name"
                                                         data-bind="value: config.newLayerName, valueUpdate: 'input',
                                                             event: { keydown: config.handleNewLayerNameKeydown }">
-                                                    <button class="btn btn-outline-primary" type="button"
-                                                        data-bind="click: config.createCollabLayer,
-                                                            enable: config.newLayerName().trim().length > 0 && !config.creatingCollabLayer()">
-                                                        <i class="fa fa-plus me-1"></i>New layer
-                                                    </button>
+                                                </div>
+                                                <!-- Every layer must belong to an HQ, so this stays visible (not
+                                                     tucked into the collapsed options below) -- defaults to the HQ
+                                                     this page was launched for (?hq=), see Config.js's defaultHq. -->
+                                                <div class="collab-moderator-picker mb-2" data-bind="with: config.newLayerHqPicker">
+                                                    <div class="small text-muted mb-1">HQ (required)</div>
+                                                    <!-- ko if: !selected() -->
+                                                    <div class="input-group input-group-sm position-relative">
+                                                        <input type="text" class="form-control" placeholder="Search by name…" autocomplete="off" data-bind="
+                                                            value: searchQuery,
+                                                            valueUpdate: 'afterkeydown',
+                                                            hasFocus: hasFocus,
+                                                            event: { blur: closeDropdown, keydown: onSearchKeydown }">
+                                                        <ul class="dropdown-menu w-100 show collab-moderator-dropdown" data-bind="visible: dropdownOpen">
+                                                            <!-- ko if: loading -->
+                                                            <li>
+                                                                <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2" style="pointer-events:none;">
+                                                                    <i class="fa fa-spinner fa-spin me-2"></i>Searching…
+                                                                </div>
+                                                            </li>
+                                                            <!-- /ko -->
+                                                            <!-- ko ifnot: loading -->
+                                                            <!-- ko foreach: searchResults -->
+                                                            <li>
+                                                                <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
+                                                                    data-bind="click: $parent.selectFromSearch">
+                                                                    <span class="text-truncate" data-bind="text: name"></span>
+                                                                </div>
+                                                            </li>
+                                                            <!-- /ko -->
+                                                            <!-- ko if: searchResults().length === 0 -->
+                                                            <li>
+                                                                <div class="dropdown-item text-muted text-center py-2" style="pointer-events:none;">No results found.</div>
+                                                            </li>
+                                                            <!-- /ko -->
+                                                            <!-- /ko -->
+                                                        </ul>
+                                                    </div>
+                                                    <!-- /ko -->
+                                                    <!-- ko if: selected -->
+                                                    <span class="badge bg-primary-subtle text-primary-emphasis collab-moderator-chip">
+                                                        <i class="fas fa-building"></i>
+                                                        <span data-bind="text: selected() && selected().name"></span>
+                                                        <button type="button" class="btn-close" title="Change HQ"
+                                                            data-bind="click: clearSelection"></button>
+                                                    </span>
+                                                    <!-- /ko -->
                                                 </div>
                                                 <button type="button" class="btn btn-sm btn-link p-0 mb-2 collab-permissions-toggle"
                                                     data-bs-toggle="collapse" data-bs-target="#collabNewLayerOptions"
                                                     aria-expanded="false" aria-controls="collabNewLayerOptions">
-                                                    <i class="fa fa-chevron-right small me-1"></i>New layer permissions
+                                                    <i class="fa fa-chevron-right small me-1"></i>Advanced options
                                                 </button>
                                                 <div class="collapse" id="collabNewLayerOptions">
                                                     <div class="collab-new-layer-options mb-3">
+                                                    <div class="collab-moderator-picker mb-3 w-100" data-bind="with: config.newLayerEventPicker">
+                                                        <div class="small text-muted mb-1">Attach to event (optional)</div>
+                                                        <!-- ko if: !selected() -->
+                                                        <div class="input-group input-group-sm position-relative">
+                                                            <input type="text" class="form-control" placeholder="Search by name or identifier…" autocomplete="off" data-bind="
+                                                                value: searchQuery,
+                                                                valueUpdate: 'afterkeydown',
+                                                                hasFocus: hasFocus,
+                                                                event: { blur: closeDropdown, keydown: onSearchKeydown }">
+                                                            <ul class="dropdown-menu w-100 show collab-moderator-dropdown" data-bind="visible: dropdownOpen">
+                                                                <!-- ko if: loading -->
+                                                                <li>
+                                                                    <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2" style="pointer-events:none;">
+                                                                        <i class="fa fa-spinner fa-spin me-2"></i>Searching…
+                                                                    </div>
+                                                                </li>
+                                                                <!-- /ko -->
+                                                                <!-- ko ifnot: loading -->
+                                                                <!-- ko foreach: searchResults -->
+                                                                <li>
+                                                                    <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
+                                                                        data-bind="click: $parent.selectFromSearch">
+                                                                        <span class="text-truncate" data-bind="text: name"></span>
+                                                                        <span class="text-muted small ms-2 text-truncate" data-bind="text: identifier"></span>
+                                                                    </div>
+                                                                </li>
+                                                                <!-- /ko -->
+                                                                <!-- ko if: searchResults().length === 0 -->
+                                                                <li>
+                                                                    <div class="dropdown-item text-muted text-center py-2" style="pointer-events:none;">No results found.</div>
+                                                                </li>
+                                                                <!-- /ko -->
+                                                                <!-- /ko -->
+                                                            </ul>
+                                                        </div>
+                                                        <!-- /ko -->
+                                                        <!-- ko if: selected -->
+                                                        <span class="badge bg-info-subtle text-info-emphasis collab-moderator-chip">
+                                                            <i class="fas fa-calendar-day"></i>
+                                                            <span data-bind="text: selectedLabel"></span>
+                                                            <button type="button" class="btn-close" title="Remove event"
+                                                                data-bind="click: clearSelection"></button>
+                                                        </span>
+                                                        <!-- /ko -->
+                                                    </div>
                                                     <div class="small text-muted mb-1 w-100">Marker permissions</div>
                                                     <div class="form-check form-check-inline"
-                                                        title="Everyone can add, edit and delete markers (everyone can also comment, unless disabled below).">
-                                                        <input class="form-check-input" type="radio" name="collabNewLayerReadOnly" id="collabNewLayerReadOnlyOff"
-                                                            data-bind="checked: config.newLayerReadOnly, checkedValue: false">
-                                                        <label class="form-check-label small" for="collabNewLayerReadOnlyOff">Anyone can add markers</label>
+                                                        title="Everyone can add, edit and delete markers (everyone can also comment, unless restricted below).">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerMarkerMode" id="collabNewLayerMarkerModeAnyone"
+                                                            data-bind="checked: config.newLayerMarkerMode, checkedValue: 'anyone'">
+                                                        <label class="form-check-label small" for="collabNewLayerMarkerModeAnyone">Anyone can add markers</label>
                                                     </div>
                                                     <div class="form-check form-check-inline"
                                                         title="Others can view this layer and comment on markers, but only you can add, edit or delete markers.">
-                                                        <input class="form-check-input" type="radio" name="collabNewLayerReadOnly" id="collabNewLayerReadOnlyOn"
-                                                            data-bind="checked: config.newLayerReadOnly, checkedValue: true">
-                                                        <label class="form-check-label small" for="collabNewLayerReadOnlyOn">Only I can add markers</label>
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerMarkerMode" id="collabNewLayerMarkerModeCreator"
+                                                            data-bind="checked: config.newLayerMarkerMode, checkedValue: 'creator'">
+                                                        <label class="form-check-label small" for="collabNewLayerMarkerModeCreator">Only I can add markers</label>
+                                                    </div>
+                                                    <div class="form-check form-check-inline"
+                                                        title="Only you and the moderators you choose below can add, edit or delete markers.">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerMarkerMode" id="collabNewLayerMarkerModeModerators"
+                                                            data-bind="checked: config.newLayerMarkerMode, checkedValue: 'moderators'">
+                                                        <label class="form-check-label small" for="collabNewLayerMarkerModeModerators">Moderators can add markers</label>
                                                     </div>
                                                     <div class="small text-muted mb-1 mt-1 w-100">Delete permissions</div>
                                                     <div class="form-check form-check-inline"
                                                         title="Any member of your organisation can delete this layer.">
-                                                        <input class="form-check-input" type="radio" name="collabNewLayerAllowDelete" id="collabNewLayerAllowDeleteOn"
-                                                            data-bind="checked: config.newLayerAllowDeleteByOthers, checkedValue: true">
-                                                        <label class="form-check-label small" for="collabNewLayerAllowDeleteOn">Anyone can delete this layer</label>
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerDeleteMode" id="collabNewLayerDeleteModeAnyone"
+                                                            data-bind="checked: config.newLayerDeleteMode, checkedValue: 'anyone'">
+                                                        <label class="form-check-label small" for="collabNewLayerDeleteModeAnyone">Anyone can delete this layer</label>
                                                     </div>
                                                     <div class="form-check form-check-inline"
                                                         title="Only you will be able to delete this layer.">
-                                                        <input class="form-check-input" type="radio" name="collabNewLayerAllowDelete" id="collabNewLayerAllowDeleteOff"
-                                                            data-bind="checked: config.newLayerAllowDeleteByOthers, checkedValue: false">
-                                                        <label class="form-check-label small" for="collabNewLayerAllowDeleteOff">Only I can delete this layer</label>
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerDeleteMode" id="collabNewLayerDeleteModeCreator"
+                                                            data-bind="checked: config.newLayerDeleteMode, checkedValue: 'creator'">
+                                                        <label class="form-check-label small" for="collabNewLayerDeleteModeCreator">Only I can delete this layer</label>
+                                                    </div>
+                                                    <div class="form-check form-check-inline"
+                                                        title="Only you and the moderators you choose below can delete this layer.">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerDeleteMode" id="collabNewLayerDeleteModeModerators"
+                                                            data-bind="checked: config.newLayerDeleteMode, checkedValue: 'moderators'">
+                                                        <label class="form-check-label small" for="collabNewLayerDeleteModeModerators">Moderators can delete this layer</label>
                                                     </div>
                                                     <div class="small text-muted mb-1 mt-1 w-100">Comment permissions</div>
                                                     <div class="form-check form-check-inline"
                                                         title="Anyone who can see this layer can comment on its markers.">
-                                                        <input class="form-check-input" type="radio" name="collabNewLayerDisableComments" id="collabNewLayerDisableCommentsOff"
-                                                            data-bind="checked: config.newLayerDisableComments, checkedValue: false">
-                                                        <label class="form-check-label small" for="collabNewLayerDisableCommentsOff">Anyone can comment</label>
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerCommentMode" id="collabNewLayerCommentModeAnyone"
+                                                            data-bind="checked: config.newLayerCommentMode, checkedValue: 'anyone'">
+                                                        <label class="form-check-label small" for="collabNewLayerCommentModeAnyone">Anyone can comment</label>
                                                     </div>
                                                     <div class="form-check form-check-inline"
-                                                        title="Blocks comments on this layer's markers for everyone, including you.">
-                                                        <input class="form-check-input" type="radio" name="collabNewLayerDisableComments" id="collabNewLayerDisableCommentsOn"
-                                                            data-bind="checked: config.newLayerDisableComments, checkedValue: true">
-                                                        <label class="form-check-label small" for="collabNewLayerDisableCommentsOn">Comments are disabled</label>
+                                                        title="Only you will be able to comment on this layer's markers.">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerCommentMode" id="collabNewLayerCommentModeCreator"
+                                                            data-bind="checked: config.newLayerCommentMode, checkedValue: 'creator'">
+                                                        <label class="form-check-label small" for="collabNewLayerCommentModeCreator">Only I can comment</label>
+                                                    </div>
+                                                    <div class="form-check form-check-inline"
+                                                        title="Only you and the moderators you choose below can comment on this layer's markers.">
+                                                        <input class="form-check-input" type="radio" name="collabNewLayerCommentMode" id="collabNewLayerCommentModeModerators"
+                                                            data-bind="checked: config.newLayerCommentMode, checkedValue: 'moderators'">
+                                                        <label class="form-check-label small" for="collabNewLayerCommentModeModerators">Moderators can comment</label>
+                                                    </div>
+
+                                                    <div class="collab-moderator-picker mt-2 w-100"
+                                                        data-bind="visible: config.showNewLayerModeratorPicker, with: config.newLayerModeratorPicker">
+                                                        <div class="small text-muted mb-1">Moderators</div>
+                                                        <div class="input-group input-group-sm position-relative">
+                                                            <input type="text" class="form-control" placeholder="Search by name or member number…" autocomplete="off" data-bind="
+                                                                value: searchQuery,
+                                                                valueUpdate: 'afterkeydown',
+                                                                hasFocus: hasFocus,
+                                                                event: { blur: closeDropdown, keydown: onSearchKeydown }">
+                                                            <button class="btn btn-outline-secondary" type="button" title="Clear"
+                                                                data-bind="click: clearSearch, enable: searchQuery">&times;</button>
+                                                            <ul class="dropdown-menu w-100 show collab-moderator-dropdown" data-bind="visible: dropdownOpen">
+                                                                <!-- ko if: loading -->
+                                                                <li>
+                                                                    <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2" style="pointer-events:none;">
+                                                                        <i class="fa fa-spinner fa-spin me-2"></i>Searching…
+                                                                    </div>
+                                                                </li>
+                                                                <!-- /ko -->
+                                                                <!-- ko ifnot: loading -->
+                                                                <!-- ko foreach: searchResults -->
+                                                                <li>
+                                                                    <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
+                                                                        data-bind="click: $parent.addFromSearch">
+                                                                        <span class="text-truncate" data-bind="text: name"></span>
+                                                                        <span class="text-muted small ms-2 text-truncate" data-bind="text: detail"></span>
+                                                                    </div>
+                                                                </li>
+                                                                <!-- /ko -->
+                                                                <!-- ko if: searchResults().length === 0 -->
+                                                                <li>
+                                                                    <div class="dropdown-item text-muted text-center py-2" style="pointer-events:none;">No results found.</div>
+                                                                </li>
+                                                                <!-- /ko -->
+                                                                <!-- /ko -->
+                                                            </ul>
+                                                        </div>
+                                                        <div class="collab-moderator-chips mt-1" data-bind="visible: moderators().length > 0, foreach: moderators">
+                                                            <span class="badge bg-secondary collab-moderator-chip">
+                                                                <span data-bind="text: name"></span>
+                                                                <button type="button" class="btn-close btn-close-white" title="Remove"
+                                                                    data-bind="click: $parent.removeModerator"></button>
+                                                            </span>
+                                                        </div>
                                                     </div>
                                                     </div>
                                                 </div>
                                                 <div class="text-danger small mb-2"
                                                     data-bind="visible: config.collabLayerError, text: config.collabLayerError"></div>
+                                                <div class="d-flex gap-2">
+                                                    <button type="button" class="btn btn-sm btn-primary"
+                                                        data-bind="click: config.createCollabLayer,
+                                                            enable: config.newLayerName().trim().length > 0 && !!config.newLayerHqPicker.selected() && !config.creatingCollabLayer()">
+                                                        <i class="fa fa-plus me-1"></i>Create layer
+                                                    </button>
+                                                    <button type="button" class="btn btn-sm btn-outline-secondary"
+                                                        data-bind="click: config.cancelCreateLayer">
+                                                        Cancel
+                                                    </button>
+                                                </div>
+                                                </div>
+                                                <!-- /ko -->
+
+                                                <!-- ko if: !config.showDiscoverForm() -->
+                                                <button type="button" class="btn btn-sm btn-outline-secondary mb-3"
+                                                    data-bind="click: config.toggleDiscoverForm">
+                                                    <i class="fa fa-search me-1"></i>Find a layer
+                                                </button>
+                                                <!-- /ko -->
+                                                <!-- ko if: config.showDiscoverForm -->
+                                                <div class="collab-create-layer-panel border rounded p-2 mb-3">
+                                                <div class="collab-moderator-picker mb-2" data-bind="with: config.discoverHqPicker">
+                                                    <div class="small text-muted mb-1">Search HQ (optional — leave blank to search every HQ)</div>
+                                                    <!-- ko if: !selected() -->
+                                                    <div class="input-group input-group-sm position-relative">
+                                                        <input type="text" class="form-control" placeholder="Search by name…" autocomplete="off" data-bind="
+                                                            value: searchQuery,
+                                                            valueUpdate: 'afterkeydown',
+                                                            hasFocus: hasFocus,
+                                                            event: { blur: closeDropdown, keydown: onSearchKeydown }">
+                                                        <ul class="dropdown-menu w-100 show collab-moderator-dropdown" data-bind="visible: dropdownOpen">
+                                                            <!-- ko if: loading -->
+                                                            <li>
+                                                                <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2" style="pointer-events:none;">
+                                                                    <i class="fa fa-spinner fa-spin me-2"></i>Searching…
+                                                                </div>
+                                                            </li>
+                                                            <!-- /ko -->
+                                                            <!-- ko ifnot: loading -->
+                                                            <!-- ko foreach: searchResults -->
+                                                            <li>
+                                                                <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
+                                                                    data-bind="click: $parent.selectFromSearch">
+                                                                    <span class="text-truncate" data-bind="text: name"></span>
+                                                                </div>
+                                                            </li>
+                                                            <!-- /ko -->
+                                                            <!-- ko if: searchResults().length === 0 -->
+                                                            <li>
+                                                                <div class="dropdown-item text-muted text-center py-2" style="pointer-events:none;">No results found.</div>
+                                                            </li>
+                                                            <!-- /ko -->
+                                                            <!-- /ko -->
+                                                        </ul>
+                                                    </div>
+                                                    <!-- /ko -->
+                                                    <!-- ko if: selected -->
+                                                    <span class="badge bg-primary-subtle text-primary-emphasis collab-moderator-chip">
+                                                        <i class="fas fa-building"></i>
+                                                        <span data-bind="text: selected() && selected().name"></span>
+                                                        <button type="button" class="btn-close" title="Change HQ"
+                                                            data-bind="click: clearSelection"></button>
+                                                    </span>
+                                                    <!-- /ko -->
+                                                </div>
+                                                <div class="input-group input-group-sm mb-2">
+                                                    <span class="input-group-text"><i class="fa fa-search"></i></span>
+                                                    <input type="text" class="form-control" placeholder="Filter results by name"
+                                                        data-bind="value: config.discoverSearch, valueUpdate: 'input'">
+                                                </div>
+                                                <ul class="list-group" data-bind="foreach: { data: config.discoverRows, as: 'drow' }">
+                                                    <li class="list-group-item py-2 d-flex align-items-center gap-2">
+                                                        <div class="flex-grow-1 collab-layer-row-info">
+                                                            <div class="collab-layer-row-name" data-bind="text: drow.name, attr: { title: drow.name }"></div>
+                                                            <div class="small text-muted" data-bind="visible: drow.hqName">
+                                                                <i class="fas fa-building"></i> <span data-bind="text: drow.hqName"></span>
+                                                            </div>
+                                                            <div class="form-text">
+                                                                <span data-bind="visible: drow.authorName">by <span data-bind="text: drow.authorName"></span> ·</span>
+                                                                <span data-bind="text: drow.markerCount"></span> markers ·
+                                                                used <span data-bind="text: drow.lastUsedLabel"></span>
+                                                                <span class="badge bg-info-subtle text-info-emphasis ms-1"
+                                                                    data-bind="visible: drow.eventName, attr: { title: drow.eventLabel }">
+                                                                    <i class="fas fa-calendar-day"></i> <span data-bind="text: drow.eventLabel"></span>
+                                                                </span>
+                                                            </div>
+                                                        </div>
+                                                        <button type="button" class="btn btn-sm btn-outline-primary py-0 px-2"
+                                                            data-bind="visible: !drow.alreadySubscribed, click: $root.config.subscribeToDiscoverRow, disable: drow.subscribing">
+                                                            <i class="fa fa-plus me-1"></i>Subscribe
+                                                        </button>
+                                                        <span class="badge bg-success-subtle text-success-emphasis" data-bind="visible: drow.alreadySubscribed">
+                                                            <i class="fa fa-check me-1"></i>Subscribed
+                                                        </span>
+                                                    </li>
+                                                </ul>
+                                                <div class="text-danger small mt-2" data-bind="visible: config.discoverError, text: config.discoverError"></div>
+                                                <div class="form-text mt-2" data-bind="visible: config.discoverEmptyMessage, text: config.discoverEmptyMessage"></div>
+                                                </div>
+                                                <!-- /ko -->
 
                                                 <div class="input-group input-group-sm mb-2"
-                                                    data-bind="visible: config.collabLayerRows().length > 5">
+                                                    data-bind="visible: config.collabLayers().length > 5">
                                                     <span class="input-group-text"><i class="fa fa-search"></i></span>
-                                                    <input type="text" class="form-control" placeholder="Filter layers by name"
+                                                    <input type="text" class="form-control" placeholder="Filter my layers by name"
                                                         data-bind="value: config.collabLayerSearch, valueUpdate: 'input'">
                                                 </div>
 
                                                 <div class="collab-layer-list-scroll">
                                                     <ul class="list-group" data-bind="foreach: { data: config.filteredCollabLayerRows, as: 'row' }">
-                                                        <li class="list-group-item d-flex align-items-center gap-2 py-2">
+                                                        <li class="list-group-item py-2">
+                                                        <div class="d-flex align-items-center gap-2">
                                                             <div class="flex-grow-1 collab-layer-row-info">
                                                                 <div class="collab-layer-row-name" data-bind="text: row.name, attr: { title: row.name }"></div>
+                                                                <div class="small text-muted" data-bind="visible: row.hqName">
+                                                                    <i class="fas fa-building"></i> <span data-bind="text: row.hqName"></span>
+                                                                </div>
                                                                 <div class="form-text">
+                                                                    <span data-bind="visible: row.authorName">by <span data-bind="text: row.authorName"></span> ·</span>
                                                                     <span data-bind="text: row.markerCount"></span> markers ·
                                                                     used <span data-bind="text: row.lastUsedLabel"></span>
-                                                                    <i class="fas fa-lock ms-1" title="Only the creator can add markers"
-                                                                        data-bind="visible: row.readOnly"></i>
-                                                                    <i class="fas fa-comment-slash ms-1" title="Comments disabled"
-                                                                        data-bind="visible: row.disableComments"></i>
+                                                                    <i class="fas fa-lock ms-1" data-bind="visible: row.markerRestricted, attr: { title: row.markerModeTitle }"></i>
+                                                                    <i class="fas fa-comment-slash ms-1" data-bind="visible: row.commentRestricted, attr: { title: row.commentModeTitle }"></i>
+                                                                    <span class="badge bg-secondary-subtle text-secondary-emphasis ms-1"
+                                                                        data-bind="visible: row.moderatorCount > 0, text: row.moderatorCountLabel, attr: { title: row.moderatorNamesLabel }"></span>
+                                                                    <span class="badge bg-info-subtle text-info-emphasis ms-1"
+                                                                        data-bind="visible: row.eventName, attr: { title: row.eventLabel }">
+                                                                        <i class="fas fa-calendar-day"></i> <span data-bind="text: row.eventLabel"></span>
+                                                                    </span>
                                                                 </div>
                                                             </div>
-                                                            <div class="form-check form-switch mb-0" title="View">
-                                                                <input class="form-check-input" type="checkbox" role="switch"
-                                                                    data-bind="checked: row.viewEnabled">
-                                                                <label class="form-check-label small">View</label>
-                                                            </div>
-                                                            <button type="button" class="btn btn-sm btn-outline-danger py-0 px-2"
-                                                                data-bind="click: row.requestDeleteLayer, disable: !row.canDelete,
-                                                                    visible: !row.confirmingDelete(),
-                                                                    attr: { title: row.deleteTitle }">
+                                                            <button type="button" class="btn btn-sm btn-outline-primary py-0 px-2" title="Unsubscribe -- removes it from your list, doesn't affect anyone else"
+                                                                data-bind="visible: !row.confirmingDelete(), click: row.unsubscribe">
+                                                                <i class="fa fa-bookmark me-1"></i>Unsubscribe
+                                                            </button>
+                                                            <!-- Deliberately small/muted (not bordered buttons like
+                                                                 Unsubscribe above) so these administrative/destructive
+                                                                 actions read as secondary and don't get confused with
+                                                                 the primary Unsubscribe action. -->
+                                                            <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage moderators"
+                                                                data-bind="visible: row.canManageModerators && !row.confirmingDelete(), click: row.toggleEditModerators">
+                                                                <i class="fa fa-user-shield"></i>
+                                                            </button>
+                                                            <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1"
+                                                                data-bind="visible: !row.confirmingDelete(), click: row.requestDeleteLayer, disable: !row.canDelete, attr: { title: row.deleteTitle }">
                                                                 <i class="fa fa-trash"></i>
                                                             </button>
                                                             <span class="collab-layer-delete-confirm" data-bind="visible: row.confirmingDelete">
@@ -2911,15 +3187,64 @@
                                                                 <button type="button" class="btn btn-sm btn-secondary"
                                                                     data-bind="click: row.cancelDeleteLayer">Cancel</button>
                                                             </span>
+                                                        </div>
+                                                        <div class="collab-moderator-picker collab-moderator-edit mt-2"
+                                                            data-bind="visible: row.editingModerators, with: row.moderatorPicker">
+                                                            <div class="input-group input-group-sm position-relative">
+                                                                <input type="text" class="form-control" placeholder="Search by name or member number…" autocomplete="off" data-bind="
+                                                                    value: searchQuery,
+                                                                    valueUpdate: 'afterkeydown',
+                                                                    hasFocus: hasFocus,
+                                                                    event: { blur: closeDropdown, keydown: onSearchKeydown }">
+                                                                <button class="btn btn-outline-secondary" type="button" title="Clear"
+                                                                    data-bind="click: clearSearch, enable: searchQuery">&times;</button>
+                                                                <ul class="dropdown-menu w-100 show collab-moderator-dropdown" data-bind="visible: dropdownOpen">
+                                                                    <!-- ko if: loading -->
+                                                                    <li>
+                                                                        <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2" style="pointer-events:none;">
+                                                                            <i class="fa fa-spinner fa-spin me-2"></i>Searching…
+                                                                        </div>
+                                                                    </li>
+                                                                    <!-- /ko -->
+                                                                    <!-- ko ifnot: loading -->
+                                                                    <!-- ko foreach: searchResults -->
+                                                                    <li>
+                                                                        <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
+                                                                            data-bind="click: $parent.addFromSearch">
+                                                                            <span class="text-truncate" data-bind="text: name"></span>
+                                                                            <span class="text-muted small ms-2 text-truncate" data-bind="text: detail"></span>
+                                                                        </div>
+                                                                    </li>
+                                                                    <!-- /ko -->
+                                                                    <!-- ko if: searchResults().length === 0 -->
+                                                                    <li>
+                                                                        <div class="dropdown-item text-muted text-center py-2" style="pointer-events:none;">No results found.</div>
+                                                                    </li>
+                                                                    <!-- /ko -->
+                                                                    <!-- /ko -->
+                                                                </ul>
+                                                            </div>
+                                                            <div class="collab-moderator-chips mt-1" data-bind="visible: moderators().length > 0, foreach: moderators">
+                                                                <span class="badge bg-secondary collab-moderator-chip">
+                                                                    <span data-bind="text: name"></span>
+                                                                    <button type="button" class="btn-close btn-close-white" title="Remove"
+                                                                        data-bind="click: $parent.removeModerator"></button>
+                                                                </span>
+                                                            </div>
+                                                            <div class="text-danger small mt-1" data-bind="visible: $parent.moderatorsError, text: $parent.moderatorsError"></div>
+                                                            <div class="mt-2 d-flex gap-1">
+                                                                <button type="button" class="btn btn-sm btn-primary"
+                                                                    data-bind="click: $parent.saveModerators, disable: $parent.savingModerators">Save</button>
+                                                                <button type="button" class="btn btn-sm btn-secondary"
+                                                                    data-bind="click: $parent.cancelEditModerators">Cancel</button>
+                                                            </div>
+                                                        </div>
                                                         </li>
                                                     </ul>
                                                 </div>
-                                                <div class="form-text mt-2" data-bind="visible: config.collabLayerRows().length === 0">
-                                                    No collaborative layers yet — create one above.
+                                                <div class="form-text mt-2" data-bind="visible: config.noLayersMessage, text: config.noLayersMessage">
                                                 </div>
-                                                <div class="form-text mt-2"
-                                                    data-bind="visible: config.collabLayerRows().length > 0 && config.filteredCollabLayerRows().length === 0">
-                                                    No layers match "<span data-bind="text: config.collabLayerSearch"></span>".
+                                                <div class="form-text mt-2" data-bind="visible: config.noSearchMatchMessage, text: config.noSearchMatchMessage">
                                                 </div>
 
                                             </div>

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2633,6 +2633,41 @@ overflow: hidden;
   line-height: 1.4;
 }
 
+/* ── Moderator picker (new-layer form + per-row "Manage moderators") ── */
+.collab-moderator-picker {
+  width: 100%;
+}
+.collab-moderator-edit {
+  border-top: 1px solid #eee;
+  padding-top: 8px;
+}
+.collab-moderator-dropdown {
+  max-height: 200px;
+  overflow: auto;
+  position: absolute;
+  top: 100%;
+  z-index: 5;
+}
+.collab-moderator-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.collab-moderator-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: normal;
+}
+.collab-moderator-chip .btn-close {
+  font-size: 9px;
+  padding: 0;
+  opacity: 0.8;
+}
+.collab-moderator-chip .btn-close:hover {
+  opacity: 1;
+}
+
 /* ── Collaborative marker popup (view/edit) ── */
 .collab-marker-popup {
   font-size: 12px;


### PR DESCRIPTION
## Summary
- Every collaborative layer must now belong to an HQ (required, defaults to `?hq=`) and can optionally be attached to a Beacon event; both searchable via new BeaconClient modules.
- Marker/delete/comment permissions are now a 3-way mode (anyone/creator/moderators) with a shared moderator list per layer, editable by the creator **or** any current moderator.
- Replaced the old HQ-filtered "list with a View toggle" with a subscriptions model: a "My layers" list that's always cross-HQ (so unsubscribing never depends on knowing which HQ a layer came from) plus a separate "Find a layer" search to discover and subscribe. Actually showing/hiding a layer on the map is now solely the map's own Layers control's job.
- `listLayers.js` gained server-side HQ filtering; permission checks were centralized into `lib/permissions.js` and reused across every handler.
- Marker/comment Ops Log entries now carry the layer's `EventId` when one is attached.

## Test plan
- [x] `npx eslint --ext .ts,.js --max-warnings=0 ./src` passes
- [x] `npx webpack --config webpack.dev.js` builds cleanly
- [x] HTML tag-balance verified across `static/pages/tasking.html`
- [x] Backend changes deployed to `LH-MapLayersv2` and smoke-tested (401/unauthorized on routing, confirming live code path) throughout development
- [ ] Manual click-through in a real Beacon session (create layer, attach HQ/event, subscribe/unsubscribe, manage moderators as creator and as a moderator, delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)