### PR TITLE
Fix map popups rendering behind markers on the tasking map

### DIFF
--- a/src/pages/tasking/components/mapContextMenu.js
+++ b/src/pages/tasking/components/mapContextMenu.js
@@ -162,7 +162,7 @@ export function installMapContextMenu({
                 icon: geocodeRedMarkerIcon,
                 pane: 'pane-top-plus',
             })
-                .bindPopup('Reverse geocode failed')
+                .bindPopup('Reverse geocode failed', { pane: 'pane-popup-top' })
                 .addTo(geocodeClickedPointLayer);
             return;
         }
@@ -173,7 +173,7 @@ export function installMapContextMenu({
             icon: geocodeRedMarkerIcon,
             pane: 'pane-top-plus',
         })
-            .bindPopup(`Clicked location<br>${lastLatLng.lat.toFixed(6)}, ${lastLatLng.lng.toFixed(6)}`)
+            .bindPopup(`Clicked location<br>${lastLatLng.lat.toFixed(6)}, ${lastLatLng.lng.toFixed(6)}`, { pane: 'pane-popup-top' })
             .addTo(geocodeClickedPointLayer);
 
 
@@ -252,7 +252,7 @@ export function installMapContextMenu({
             if (shortLine) m.bindTooltip(shortLine, { direction: 'top', sticky: true });
 
             // full details on click
-            m.bindPopup(popupHtml);
+            m.bindPopup(popupHtml, { pane: 'pane-popup-top' });
 
             m.on('popupopen', () => {
                 const popup = m.getPopup();

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -359,6 +359,13 @@ map.createPane('pane-collab-plus'); map.getPane('pane-collab-plus').style.zIndex
 map.createPane('pane-tippy-top'); map.getPane('pane-tippy-top').style.zIndex = 700;
 map.createPane('pane-tippy-top-plus'); map.getPane('pane-tippy-top-plus').style.zIndex = 701;
 
+// Fixed above every reorderable marker pane (Config's paneOrder only ever
+// assigns 300-700, see Map.js applyPaneOrder) so popups -- which would
+// otherwise sit in Leaflet's default popupPane (also z-index 700, but
+// painted before these custom panes and so behind them on tie) -- always
+// render above every marker, including the topmost "Incident markers" pane.
+map.createPane('pane-popup-top'); map.getPane('pane-popup-top').style.zIndex = 750;
+
 
 function buildBasemapLayer(key) {
     // --- NSW VECTOR BASEMAP (Topographic style) ---

--- a/src/pages/tasking/mapLayers/bom.js
+++ b/src/pages/tasking/mapLayers/bom.js
@@ -85,7 +85,7 @@ export function registerBOMLandWarningsLayer(vm) {
           ${p.phase ? `<strong>Phase:</strong> ${p.phase}<br>` : ""}
           ${p.start_time_local ? `<strong>From:</strong> ${new Date(p.start_time_local).toLocaleString()}<br>` : ""}
           ${p.end_time_local ? `<strong>Until:</strong> ${new Date(p.end_time_local).toLocaleString()}` : ""}`;
-      });
+      }, { pane: "pane-popup-top" });
       layerGroup.addLayer(floodWarning);
 
       /* --- 1  Flood Watch -------------------------------------- */
@@ -107,7 +107,7 @@ export function registerBOMLandWarningsLayer(vm) {
           ${p.phase ? `<strong>Phase:</strong> ${p.phase}<br>` : ""}
           ${p.start_time_local ? `<strong>From:</strong> ${new Date(p.start_time_local).toLocaleString()}<br>` : ""}
           ${p.end_time_local ? `<strong>Until:</strong> ${new Date(p.end_time_local).toLocaleString()}` : ""}`;
-      });
+      }, { pane: "pane-popup-top" });
       layerGroup.addLayer(floodWatch);
 
       /* --- 2  Severe Weather Warning --------------------------- */
@@ -132,7 +132,7 @@ export function registerBOMLandWarningsLayer(vm) {
           ${p.warning ? `${p.warning}<br>` : ""}
           ${p.validfrom_utc ? `<strong>From:</strong> ${new Date(p.validfrom_utc).toLocaleString()}<br>` : ""}
           ${p.validto_utc ? `<strong>Until:</strong> ${new Date(p.validto_utc).toLocaleString()}` : ""}`;
-      });
+      }, { pane: "pane-popup-top" });
       layerGroup.addLayer(severeWeather);
 
       /* --- 3  Thunderstorm Warning ----------------------------- */
@@ -157,7 +157,7 @@ export function registerBOMLandWarningsLayer(vm) {
           ${p.phase ? `<strong>Phase:</strong> ${p.phase}<br>` : ""}
           ${p.start_time_local ? `<strong>From:</strong> ${new Date(p.start_time_local).toLocaleString()}<br>` : ""}
           ${p.end_time_local ? `<strong>Until:</strong> ${new Date(p.end_time_local).toLocaleString()}` : ""}`;
-      });
+      }, { pane: "pane-popup-top" });
       layerGroup.addLayer(thunderstorm);
 
       /* --- 4  Fire Weather Warnings ---------------------------- */
@@ -179,7 +179,7 @@ export function registerBOMLandWarningsLayer(vm) {
           ${p.day ? `<strong>Day:</strong> ${p.day}<br>` : ""}
           ${p.start_time_local ? `<strong>From:</strong> ${new Date(p.start_time_local).toLocaleString()}<br>` : ""}
           ${p.end_time_local ? `<strong>Until:</strong> ${new Date(p.end_time_local).toLocaleString()}` : ""}`;
-      });
+      }, { pane: "pane-popup-top" });
       layerGroup.addLayer(fireWeather);
     },
   });

--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -392,7 +392,7 @@ function drawCollabMarkers(vm, layerGroup, data, apiUrl, layer, key, actorId, ge
         // instead deferred to the "popupopen" event so a marker's Ops Log
         // entry is only pulled once the user actually clicks it.
         const { el, state } = buildMarkerPopupEl(vm, apiUrl, layer, key, marker, actorId, getToken, leafletMarker, getMemberId);
-        leafletMarker.bindPopup(el, { minWidth: 260, maxWidth: 320 });
+        leafletMarker.bindPopup(el, { minWidth: 260, maxWidth: 320, pane: "pane-popup-top" });
         leafletMarker.on("popupopen", () => {
             busyLayerKeys.add(key);
             loadMarkerContent(vm, marker, el, leafletMarker, state);
@@ -805,7 +805,7 @@ function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getTo
         });
     });
 
-    const popup = L.popup({ minWidth: 220, maxWidth: 260, closeOnClick: false, autoPanPadding: [16, 16] })
+    const popup = L.popup({ minWidth: 220, maxWidth: 260, closeOnClick: false, autoPanPadding: [16, 16], pane: "pane-popup-top" })
         .setLatLng(latlng)
         .setContent(el)
         .openOn(vm.mapVM.map);
@@ -983,7 +983,7 @@ export function getWritableCollabLayers(vm, getMemberId) {
 }
 
 /**
- * Entry point for the "Add marker to shared layer" item in the app's
+ * Entry point for the "Add marker to collaborative layer" item in the app's
  * existing right-click context menu (components/mapContextMenu.js). With
  * exactly one writable subscribed layer, opens the marker form immediately;
  * with more than one, shows a small picker so the user chooses which layer

--- a/src/pages/tasking/mapLayers/dams.js
+++ b/src/pages/tasking/mapLayers/dams.js
@@ -80,7 +80,7 @@ export function registerNSWDeclaredDamsLayer(vm) {
             : "",
           damId !== "" ? `<br><strong>Dam ID:</strong> ${damId}` : "",
         ].join("");
-      });
+      }, { pane: "pane-popup-top" });
 
       layerGroup.addLayer(featureLayer);
     },

--- a/src/pages/tasking/mapLayers/geoservices.js
+++ b/src/pages/tasking/mapLayers/geoservices.js
@@ -298,7 +298,7 @@ export function registerSESUnitLocationsLayer(vm) {
               iconAnchor: [8, 16], // Anchor point of the icon
               popupAnchor: [0, -16] // Point from which the popup opens relative to the iconAnchor
             })
-          }).bindPopup(`<strong>Loading ${name}...</strong>`);
+          }).bindPopup(`<strong>Loading ${name}...</strong>`, { pane: "pane-popup-top" });
 
           marker.on('popupopen', async () => {
             try {

--- a/src/pages/tasking/mapLayers/hazardwatch.js
+++ b/src/pages/tasking/mapLayers/hazardwatch.js
@@ -175,7 +175,7 @@ export function registerHazardWatchWarningsLayer(vm, apiHost) {
                     const p = feature?.properties || {};
                     const html = popupHtml(p);
 
-                    layer.bindPopup(html, { maxWidth: 460 });
+                    layer.bindPopup(html, { maxWidth: 460, pane: "pane-popup-top" });
 
                     let center;
                     try {
@@ -197,7 +197,7 @@ export function registerHazardWatchWarningsLayer(vm, apiHost) {
                         interactive: true,
                     });
 
-                    marker.bindPopup(html, { maxWidth: 460 });
+                    marker.bindPopup(html, { maxWidth: 460, pane: "pane-popup-top" });
 
                     layerGroup.addLayer(marker);
 

--- a/src/pages/tasking/mapLayers/transport.js
+++ b/src/pages/tasking/mapLayers/transport.js
@@ -42,7 +42,7 @@ export function registerTransportCamerasLayer(vm, map, getToken, apiHost, params
             iconAnchor: [16, 16],
             popupAnchor: [0, -16],
           }),
-        }).bindPopup(details);
+        }).bindPopup(details, { pane: "pane-popup-top" });
 
         layerGroup.addLayer(marker);
       });
@@ -140,7 +140,7 @@ export function registerTransportIncidentsLayer(vm, map, getToken, apiHost, para
             iconAnchor: [16, 16],
             popupAnchor: [0, -16],
           }),
-        }).bindPopup(details);
+        }).bindPopup(details, { pane: "pane-popup-top" });
 
         layerGroup.addLayer(marker);
       });

--- a/src/pages/tasking/mapLayers/waternsw.js
+++ b/src/pages/tasking/mapLayers/waternsw.js
@@ -53,7 +53,7 @@ export function registerWaterNSWBoundariesLayer(vm) {
       featureLayer.bindPopup((layer) => {
         const p = layer.feature.properties;
         return `<strong>${p.NAME || "Unknown"}</strong><br>${p.Class || ""}`;
-      });
+      }, { pane: "pane-popup-top" });
 
       layerGroup.addLayer(featureLayer);
     },
@@ -101,7 +101,7 @@ export function registerEPAContaminationSitesLayer(vm) {
             ? `<br><strong>Management:</strong> ${p.ManagementClass}`
             : "",
         ].join("");
-      });
+      }, { pane: "pane-popup-top" });
 
       layerGroup.addLayer(featureLayer);
     },

--- a/src/pages/tasking/markers/assetMarker.js
+++ b/src/pages/tasking/markers/assetMarker.js
@@ -86,6 +86,7 @@ export function attachAssetMarker(ko, map, viewModel, asset) {
       maxHeight: 360,
       autoPan: true,
       autoPanPadding: [16, 16],
+      pane: 'pane-popup-top',
     }).setContent(contentEl);
 
 
@@ -167,6 +168,7 @@ export function attachUnmatchedAssetMarker(ko, map, viewModel, asset) {
       maxHeight: 360,
       autoPan: true,
       autoPanPadding: [16, 16],
+      pane: 'pane-popup-top',
     }).setContent(contentEl);
 
     m.bindPopup(popup);

--- a/src/pages/tasking/markers/jobMarker.js
+++ b/src/pages/tasking/markers/jobMarker.js
@@ -34,7 +34,8 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
         maxWidth: 760,
         minHeight: 300,
         autoPan: true,
-        autoPanPadding: [16, 16]
+        autoPanPadding: [16, 16],
+        pane: 'pane-popup-top'
     }).setContent(contentEl);
 
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -4406,7 +4406,7 @@
     <div id="mapContextMenu" class="dropdown-menu shadow"
         style="position:fixed; display:none; z-index:5000; min-width: 220px;">
         <button type="button" class="dropdown-item disabled" id="ctxAddCollabMarker" disabled>
-            <i class="fa fa-map-marker-alt me-2"></i>Add marker to shared layer
+            <i class="fa fa-map-marker-alt me-2"></i>Add marker to collaborative layer
         </button>
         <button type="button" class="dropdown-item" id="ctxSearchHere">
             <i class="fa fa-search me-2"></i>Address Search

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2672,6 +2672,8 @@ overflow: hidden;
 .collab-marker-popup {
   font-size: 12px;
   min-width: 200px;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 .collab-marker-title {
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Every Leaflet popup on the tasking map (collab layer markers, incidents, assets, dams, WaterNSW, hazard watch, BOM weather, transport cameras/roadworks, SES unit locations, and context-menu search/geocode results) omitted a `pane` option, so they all fell back to Leaflet's built-in `popupPane`.
- That default pane is created before this app's custom marker panes, so on a z-index tie it loses and renders **behind** markers on the topmost custom pane (e.g. incident markers) — most visible when opening the "add collaborative marker" popup or any incident popup.
- Added a dedicated `pane-popup-top` pane (z-index 750, fixed above every reorderable marker pane) and pointed all affected popups at it.
- Also includes a couple of small pre-existing uncommitted tweaks: the context-menu label ("Add marker to shared layer" → "Add marker to collaborative layer") and a word-break fix for the collab marker popup CSS.

## Test plan
- [ ] Open the tasking map, right-click to add a collaborative layer marker, and confirm the form popup renders on top of nearby markers.
- [ ] Click an incident marker and confirm its popup is no longer obscured by other markers.
- [ ] Spot-check a BOM/WaterNSW/dam/hazard-watch/transport popup renders above nearby markers.