### PR TITLE
Let layer owners/moderators change a collaborative layer's HQ or event after creation

### DIFF
--- a/lambda/map-layers-v2/handlers/createLayer.js
+++ b/lambda/map-layers-v2/handlers/createLayer.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const { updateIndex, putLayerObject } = require('../lib/s3Store');
 const { json, badRequest } = require('../lib/response');
 const { normalizeMode } = require('../lib/permissions');
+const { sanitizeEvent, sanitizeHq } = require('../lib/attachment');
 
 const MAX_MODERATORS = 100;
 
@@ -20,32 +21,6 @@ function sanitizeModerators(input) {
     if (out.length >= MAX_MODERATORS) break;
   }
   return out;
-}
-
-/**
- * Sanitize the optional event attachment: { id, name } -> stored as
- * eventId/eventName, or both null if no event (or an incomplete one) was
- * given. eventId/eventName are pure display/bookkeeping (like createdBy) --
- * nothing in this feature authorizes against them.
- */
-function sanitizeEvent(input) {
-  const id = String(input?.id || '').trim().slice(0, 50);
-  if (!id) return { eventId: null, eventName: null, eventIdentifier: null };
-  const name = String(input?.name || id).trim().slice(0, 200);
-  const identifier = String(input?.identifier || '').trim().slice(0, 50) || null;
-  return { eventId: id, eventName: name, eventIdentifier: identifier };
-}
-
-/**
- * Sanitize the required HQ attachment: { id, name } -> { hqId, hqName }, or
- * both null if missing/incomplete (caller must then reject the request --
- * unlike sanitizeEvent, there's no valid "no HQ" case for a layer).
- */
-function sanitizeHq(input) {
-  const id = String(input?.id || '').trim().slice(0, 50);
-  if (!id) return { hqId: null, hqName: null };
-  const name = String(input?.name || id).trim().slice(0, 200);
-  return { hqId: id, hqName: name };
 }
 
 // POST /map-layers
@@ -69,16 +44,16 @@ function sanitizeHq(input) {
 // lib/permissions.js isAuthorized).
 //
 // `hq` (required): { id, name } of the Beacon HQ (entity) this layer
-// belongs to -- every layer must have one, stored as hqId/hqName. Also
-// fixed at creation, no later "reassign HQ" flow. Drives the layer list's
-// default HQ filter (Config.js) -- layers created before this field existed
-// simply have no hqId and so only ever show up under "All HQs".
+// belongs to -- every layer must have one, stored as hqId/hqName. Like the
+// permission modes above, can be changed later by the creator or a current
+// moderator (see updateLayerAttachment.js). Drives the layer list's default
+// HQ filter (Config.js) -- layers created before this field existed simply
+// have no hqId and so only ever show up under "All HQs".
 //
-// `event` (optional): { id, name } of a Beacon event this layer relates to,
-// stored as eventId/eventName -- purely for display in the layer list
-// (Config.js), fixed at creation with no later "attach/detach event" flow
-// (unlike the permission modes above, which can be changed later -- see
-// updateLayerPermissions.js).
+// `event` (optional): { id, name, identifier } of a Beacon event this layer
+// relates to, stored as eventId/eventName/eventIdentifier -- purely for
+// display in the layer list (Config.js), also changeable later via
+// updateLayerAttachment.js.
 //
 // "The creator" for all of the above means `createdByMemberId` --
 // `claims.sub`, the Beacon member id off the caller's own verified token --

--- a/lambda/map-layers-v2/handlers/updateLayerAttachment.js
+++ b/lambda/map-layers-v2/handlers/updateLayerAttachment.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { getLayerObject, putLayerObject, updateIndex } = require('../lib/s3Store');
+const { json, badRequest, notFound, forbidden } = require('../lib/response');
+const { isAuthorized } = require('../lib/permissions');
+const { sanitizeEvent, sanitizeHq } = require('../lib/attachment');
+
+// PUT /map-layers/{id}/attachment   body: { apiUrl, hq: {id, name}, event: {id, name, identifier}|null }
+//
+// The HQ and event a layer's attached to turn out not to be fixed for its
+// whole lifetime after all (same story as the moderator list and the three
+// permission modes, see updateLayerModerators.js/updateLayerPermissions.js)
+// -- a layer created against the wrong HQ, or one that should follow an
+// incident from one Beacon event to the next, needs a way to be
+// reassigned. Same authorization rule as those two: creator or any
+// *current* moderator (isAuthorized('moderators', ...)).
+//
+// `hq` is required, exactly as at creation (createLayer.js) -- a layer can
+// never end up with no HQ. `event`, if omitted or null, clears any existing
+// event attachment; a given event replaces it outright (no partial-update
+// shape, same as createLayer.js).
+module.exports = async function updateLayerAttachment(event, claims) {
+  const layerId = event.pathParameters?.id;
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return badRequest('Invalid JSON body');
+  }
+
+  const apiUrl = body.apiUrl;
+  const memberId = String(claims?.sub || '');
+
+  if (!apiUrl || !layerId) return badRequest('apiUrl and layer id are required');
+
+  const layer = await getLayerObject(apiUrl, layerId);
+  if (!layer) return notFound('Layer not found');
+
+  if (!isAuthorized('moderators', layer, memberId)) {
+    return forbidden('Only the layer creator or a moderator can change the HQ or event');
+  }
+
+  const { hqId, hqName } = sanitizeHq(body.hq);
+  if (!hqId) return badRequest('hq is required');
+  const { eventId, eventName, eventIdentifier } = sanitizeEvent(body.event);
+
+  const now = new Date().toISOString();
+  layer.hqId = hqId;
+  layer.hqName = hqName;
+  layer.eventId = eventId;
+  layer.eventName = eventName;
+  layer.eventIdentifier = eventIdentifier;
+  layer.lastUsedAt = now;
+  await putLayerObject(apiUrl, layerId, layer);
+
+  await updateIndex(apiUrl, (index) => {
+    const entry = index.layers.find((l) => l.id === layerId);
+    if (entry) {
+      entry.hqId = hqId;
+      entry.hqName = hqName;
+      entry.eventId = eventId;
+      entry.eventName = eventName;
+      entry.eventIdentifier = eventIdentifier;
+      entry.lastUsedAt = now;
+    }
+  });
+
+  return json(200, { hqId, hqName, eventId, eventName, eventIdentifier });
+};

--- a/lambda/map-layers-v2/index.js
+++ b/lambda/map-layers-v2/index.js
@@ -11,6 +11,7 @@ const addMarkerComment = require('./handlers/addMarkerComment');
 const deleteLayer = require('./handlers/deleteLayer');
 const updateLayerModerators = require('./handlers/updateLayerModerators');
 const updateLayerPermissions = require('./handlers/updateLayerPermissions');
+const updateLayerAttachment = require('./handlers/updateLayerAttachment');
 
 // Single Lambda fronting all /lad_v2/map-layers routes via API Gateway HTTP
 // API (payload format 2.0) Lambda proxy integration. Routed by
@@ -26,6 +27,7 @@ const ROUTES = {
   'DELETE /lad_v2/map-layers/{id}': deleteLayer,
   'PUT /lad_v2/map-layers/{id}/moderators': updateLayerModerators,
   'PUT /lad_v2/map-layers/{id}/permissions': updateLayerPermissions,
+  'PUT /lad_v2/map-layers/{id}/attachment': updateLayerAttachment,
   'PUT /lad_v2/map-layers/{id}/features': upsertFeature,
   'DELETE /lad_v2/map-layers/{id}/features/{markerId}': deleteFeature,
   'POST /lad_v2/map-layers/{id}/features/{markerId}/comments': addMarkerComment,

--- a/lambda/map-layers-v2/lib/attachment.js
+++ b/lambda/map-layers-v2/lib/attachment.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// Shared by createLayer.js (fixed at creation) and updateLayerAttachment.js
+// (changed later, see that handler's doc comment for why a layer's HQ/event
+// turned out not to be fixed for its whole lifetime after all).
+
+/**
+ * Sanitize the optional event attachment: { id, name, identifier } ->
+ * { eventId, eventName, eventIdentifier }, all null if no event (or an
+ * incomplete one) was given. eventId/eventName/eventIdentifier are pure
+ * display/bookkeeping (like createdBy) -- nothing in this feature
+ * authorizes against them.
+ */
+function sanitizeEvent(input) {
+  const id = String(input?.id || '').trim().slice(0, 50);
+  if (!id) return { eventId: null, eventName: null, eventIdentifier: null };
+  const name = String(input?.name || id).trim().slice(0, 200);
+  const identifier = String(input?.identifier || '').trim().slice(0, 50) || null;
+  return { eventId: id, eventName: name, eventIdentifier: identifier };
+}
+
+/**
+ * Sanitize the required HQ attachment: { id, name } -> { hqId, hqName }, or
+ * both null if missing/incomplete (caller must then reject the request --
+ * there's no valid "no HQ" case for a layer).
+ */
+function sanitizeHq(input) {
+  const id = String(input?.id || '').trim().slice(0, 50);
+  if (!id) return { hqId: null, hqName: null };
+  const name = String(input?.name || id).trim().slice(0, 200);
+  return { hqId: id, hqName: name };
+}
+
+module.exports = { sanitizeEvent, sanitizeHq };

--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -6,6 +6,7 @@ import {
     deleteLayer,
     updateLayerModerators,
     updateLayerPermissions,
+    updateLayerAttachment,
     fetchLayerMarkers,
     upsertMarker,
     deleteMarker,
@@ -370,6 +371,29 @@ export async function updateCollabLayerPermissions(vm, apiUrl, layerId, permissi
         layer.markerMode = saved.markerMode;
         layer.deleteMode = saved.deleteMode;
         layer.commentMode = saved.commentMode;
+    }
+    return saved;
+}
+
+/**
+ * Update a layer's HQ and/or event attachment (creator-or-moderator only,
+ * enforced server-side -- see lambda updateLayerAttachment.js). Updates the
+ * in-memory layer object (shared by reference with vm.mapVM.collabLayers()'s
+ * entry, same as updateCollabLayerPermissions above) on success so
+ * Config.js's row immediately reflects the new HQ/event without waiting for
+ * the next poll/refresh.
+ */
+export async function updateCollabLayerAttachment(vm, apiUrl, layerId, attachment, getToken) {
+    const saved = await updateLayerAttachment(apiUrl, layerId, attachment, await getToken());
+    if (saved == null) return null;
+
+    const layer = vm.mapVM.collabLayers().find((l) => l.id === layerId);
+    if (layer) {
+        layer.hqId = saved.hqId;
+        layer.hqName = saved.hqName;
+        layer.eventId = saved.eventId;
+        layer.eventName = saved.eventName;
+        layer.eventIdentifier = saved.eventIdentifier;
     }
     return saved;
 }

--- a/src/pages/tasking/utils/collabLayerSync.js
+++ b/src/pages/tasking/utils/collabLayerSync.js
@@ -338,6 +338,54 @@ export async function updateLayerPermissions(apiUrl, layerId, permissions, token
     }
 }
 
+/**
+ * Update a layer's HQ and/or event attachment. Only the creator or a
+ * current moderator is authorized server-side (see lambda
+ * updateLayerAttachment.js) -- calling this as anyone else fails with a
+ * 403 and the local cache is left untouched. `hq` is required, same as at
+ * creation; `event` given as null (or omitted) clears any existing event
+ * attachment.
+ * @param {string} apiUrl
+ * @param {string} layerId
+ * @param {{hq: {id: string, name: string}, event?: {id: string, name: string, identifier?: string}|null}} attachment
+ * @param {string} token  Beacon access token (Authorization: Bearer).
+ * @returns {Promise<{hqId: string, hqName: string, eventId: string|null, eventName: string|null, eventIdentifier: string|null}|null>} the saved attachment, or null on failure
+ */
+export async function updateLayerAttachment(apiUrl, layerId, attachment, token) {
+    if (!apiUrl || !layerId || !attachment?.hq?.id) return null;
+
+    try {
+        const res = await fetch(`${LAMBDA_BASE}/${encodeURIComponent(layerId)}/attachment`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+            body: JSON.stringify({ apiUrl, hq: attachment.hq, event: attachment.event || null }),
+        });
+        if (!res.ok) {
+            throw new Error(`updateLayerAttachment failed with status ${res.status}`);
+        }
+        const saved = await res.json();
+
+        // Reconcile the cached index entry (if present) so a page reload
+        // before the next refreshCollabLayerList() still shows the update.
+        const index = loadCachedLayerIndex();
+        const entry = index.find((l) => l.id === layerId);
+        if (entry) {
+            Object.assign(entry, saved);
+            saveCachedLayerIndex(index);
+        }
+        const cachedLayer = loadCachedLayer(layerId);
+        if (cachedLayer) {
+            Object.assign(cachedLayer, saved);
+            saveCachedLayer(layerId, cachedLayer);
+        }
+
+        return saved;
+    } catch (err) {
+        console.warn('[collabLayerSync] updateLayerAttachment error:', err);
+        return null;
+    }
+}
+
 // ── Layer markers ────────────────────────────────────────────────────
 
 /**

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -5,6 +5,7 @@ import * as bootstrap from 'bootstrap5'; // Modal, Tooltip, etc.
 import { Enum } from '../utils/enum.js';
 import {
     createCollabLayer, deleteCollabLayer, updateCollabLayerModerators, updateCollabLayerPermissions,
+    updateCollabLayerAttachment,
     refreshSubscribedLayers, searchLayersForHq, subscribeToLayer, unsubscribeFromLayer,
 } from '../mapLayers/collabLayer.js';
 
@@ -119,13 +120,14 @@ function makeModeratorPicker(searchMembers, initial = []) {
 
 /**
  * Single-select counterpart to makeModeratorPicker, backing a layer's
- * optional "attach to event" field (see createCollabLayer's `event`
- * param). Same search/debounce shape, but holds at most one picked
- * `{id, name, identifier}` rather than a list.
+ * "attach to event" field (see createCollabLayer's `event` param, and
+ * updateCollabLayerAttachment for changing it later). Same search/debounce
+ * shape, but holds at most one picked `{id, name, identifier}` rather than
+ * a list.
  */
-function makeEventPicker(searchEvents) {
+function makeEventPicker(searchEvents, initial = null) {
     const picker = {};
-    picker.selected = ko.observable(null);
+    picker.selected = ko.observable(initial ? { ...initial } : null);
     picker.searchQuery = ko.observable('');
     picker.searchResults = ko.observableArray([]);
     picker.dropdownOpen = ko.observable(false);
@@ -578,6 +580,8 @@ export function ConfigVM(root, deps) {
         row.editMarkerMode(row.markerMode);
         row.editDeleteMode(row.deleteMode);
         row.editCommentMode(row.commentMode);
+        row.hqEditPicker?.reset(row.hqId ? { id: row.hqId, name: row.hqName } : null);
+        row.eventEditPicker?.reset(row.eventId ? { id: row.eventId, name: row.eventName, identifier: row.eventIdentifier } : null);
         self.permissionsModalRow(row);
         const modalEl = document.getElementById('collabPermissionsModal');
         if (!modalEl) return;
@@ -703,7 +707,9 @@ export function ConfigVM(root, deps) {
                 // grammar doesn't support the conditional (?:) operator.
                 moderatorCountLabel: `${moderators.length} moderator${moderators.length === 1 ? '' : 's'}`,
                 moderatorNamesLabel: moderators.map(m => m.name).join(', '),
+                eventId: layer.eventId || null,
                 eventName: layer.eventName || null,
+                eventIdentifier: layer.eventIdentifier || null,
                 // Precomputed (rather than a ternary in the data-bind
                 // attribute) because knockout-secure-binding's expression
                 // grammar doesn't support the conditional (?:) operator.
@@ -744,6 +750,20 @@ export function ConfigVM(root, deps) {
                 editMarkerMode: ko.observable(markerMode),
                 editDeleteMode: ko.observable(deleteMode),
                 editCommentMode: ko.observable(commentMode),
+                // HQ/event reassignment shares the same modal and the same
+                // authorization as the permission modes above (see
+                // updateLayerAttachment.js) -- same "draft, then commit"
+                // pickers as newLayerHqPicker/newLayerEventPicker in the
+                // create-layer form above, just seeded from this layer's
+                // current attachment instead of starting empty.
+                hqEditPicker: canManageModerators
+                    ? makeHqPicker(deps.entitiesSearch, layer.hqId ? { id: layer.hqId, name: layer.hqName } : null)
+                    : null,
+                eventEditPicker: canManageModerators
+                    ? makeEventPicker(deps.searchEvents, layer.eventId
+                        ? { id: layer.eventId, name: layer.eventName, identifier: layer.eventIdentifier }
+                        : null)
+                    : null,
             };
             if (layer.createdBy && root.resolvePersonName) {
                 root.resolvePersonName(layer.createdBy).then(name => row.authorName(name));
@@ -1014,15 +1034,24 @@ export function ConfigVM(root, deps) {
         }
     };
 
-    // Saves a row's in-progress marker/delete/comment mode radios (edited in
-    // #collabPermissionsModal) as the layer's new permissions, fired from
+    // Saves a row's in-progress marker/delete/comment mode radios *and* its
+    // in-progress HQ/event pickers (all edited in #collabPermissionsModal)
+    // as the layer's new permissions and attachment, fired from
     // row.savePermissions above. Only rows the creator or a current
     // moderator can manage ever get the "Manage permissions" control exposed
     // (see collabLayerRows' canManagePermissions), so there's no separate
     // authorization check needed here -- the Lambda enforces it
-    // authoritatively either way.
+    // authoritatively either way. Two independent PUTs (permissions and
+    // attachment are separate Lambda routes/S3 fields) fired together so one
+    // Save click covers everything the modal edits; either can fail on its
+    // own, in which case the modal stays open with the error shown rather
+    // than silently discarding whichever half didn't make it.
     self.saveRowPermissions = async (row) => {
         if (!deps.apiUrl || !row.canManagePermissions || row.savingPermissions()) return;
+        if (row.hqEditPicker && !row.hqEditPicker.selected()) {
+            row.permissionsError('An HQ is required.');
+            return;
+        }
 
         row.permissionsError('');
         row.savingPermissions(true);
@@ -1032,13 +1061,19 @@ export function ConfigVM(root, deps) {
                 deleteMode: row.editDeleteMode(),
                 commentMode: row.editCommentMode(),
             };
-            const saved = await updateCollabLayerPermissions(root, deps.apiUrl, row.layer.id, permissions, deps.getToken);
-            if (saved == null) throw new Error('Update failed');
-            // updateCollabLayerPermissions mutates row.layer's mode fields
-            // in place (it's the same object reference held in
-            // self.collabLayers()) -- force collabLayerRows to recompute so
-            // this row (and its canDelete/lock badges) reflect the new
-            // modes immediately, same as a poll-driven refresh would.
+            const [savedPermissions, savedAttachment] = await Promise.all([
+                updateCollabLayerPermissions(root, deps.apiUrl, row.layer.id, permissions, deps.getToken),
+                updateCollabLayerAttachment(root, deps.apiUrl, row.layer.id, {
+                    hq: row.hqEditPicker.selected(),
+                    event: row.eventEditPicker.selected(),
+                }, deps.getToken),
+            ]);
+            if (savedPermissions == null || savedAttachment == null) throw new Error('Update failed');
+            // Both update calls mutate row.layer's fields in place (it's the
+            // same object reference held in self.collabLayers()) -- force
+            // collabLayerRows to recompute so this row (and its
+            // canDelete/lock badges, HQ/event labels) reflects the new
+            // values immediately, same as a poll-driven refresh would.
             self.collabLayers.valueHasMutated();
             // Only close on success -- an error leaves the modal open (with
             // permissionsError shown) so the user can see what went wrong
@@ -1047,7 +1082,7 @@ export function ConfigVM(root, deps) {
             bootstrap.Modal.getOrCreateInstance(document.getElementById('collabPermissionsModal')).hide();
         } catch (err) {
             console.error('Error updating layer permissions:', err);
-            row.permissionsError('Failed to save permissions. Try again later.');
+            row.permissionsError('Failed to save changes. Try again later.');
         } finally {
             row.savingPermissions(false);
         }

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -3172,7 +3172,7 @@
                                                                  Unsubscribe above) so these administrative/destructive
                                                                  actions read as secondary and don't get confused with
                                                                  the primary Unsubscribe action. -->
-                                                            <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage permissions"
+                                                            <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage permissions, HQ and event"
                                                                 data-bind="visible: row.canManagePermissions && !row.confirmingDelete(), click: row.openPermissionsModal">
                                                                 <i class="fa fa-lock"></i>
                                                             </button>
@@ -3513,11 +3513,100 @@
             <div class="modal-content" data-bind="with: config.permissionsModalRow">
                 <div class="modal-header">
                     <h5 class="modal-title" id="collabPermissionsModalLabel">
-                        Permissions — <span data-bind="text: name"></span>
+                        Layer settings — <span data-bind="text: name"></span>
                     </h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
+                    <div class="collab-moderator-picker mb-2" data-bind="with: hqEditPicker">
+                        <div class="small text-muted mb-1">HQ (required)</div>
+                        <!-- ko if: !selected() -->
+                        <div class="input-group input-group-sm position-relative">
+                            <input type="text" class="form-control" placeholder="Search by name…" autocomplete="off" data-bind="
+                                value: searchQuery,
+                                valueUpdate: 'afterkeydown',
+                                hasFocus: hasFocus,
+                                event: { blur: closeDropdown, keydown: onSearchKeydown }">
+                            <ul class="dropdown-menu w-100 show collab-moderator-dropdown" data-bind="visible: dropdownOpen">
+                                <!-- ko if: loading -->
+                                <li>
+                                    <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2" style="pointer-events:none;">
+                                        <i class="fa fa-spinner fa-spin me-2"></i>Searching…
+                                    </div>
+                                </li>
+                                <!-- /ko -->
+                                <!-- ko ifnot: loading -->
+                                <!-- ko foreach: searchResults -->
+                                <li>
+                                    <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
+                                        data-bind="click: $parent.selectFromSearch">
+                                        <span class="text-truncate" data-bind="text: name"></span>
+                                    </div>
+                                </li>
+                                <!-- /ko -->
+                                <!-- ko if: searchResults().length === 0 -->
+                                <li>
+                                    <div class="dropdown-item text-muted text-center py-2" style="pointer-events:none;">No results found.</div>
+                                </li>
+                                <!-- /ko -->
+                                <!-- /ko -->
+                            </ul>
+                        </div>
+                        <!-- /ko -->
+                        <!-- ko if: selected -->
+                        <span class="badge bg-primary-subtle text-primary-emphasis collab-moderator-chip">
+                            <i class="fas fa-building"></i>
+                            <span data-bind="text: selected() && selected().name"></span>
+                            <button type="button" class="btn-close" title="Change HQ"
+                                data-bind="click: clearSelection"></button>
+                        </span>
+                        <!-- /ko -->
+                    </div>
+                    <div class="collab-moderator-picker mb-3 w-100" data-bind="with: eventEditPicker">
+                        <div class="small text-muted mb-1">Attach to event (optional)</div>
+                        <!-- ko if: !selected() -->
+                        <div class="input-group input-group-sm position-relative">
+                            <input type="text" class="form-control" placeholder="Search by name or identifier…" autocomplete="off" data-bind="
+                                value: searchQuery,
+                                valueUpdate: 'afterkeydown',
+                                hasFocus: hasFocus,
+                                event: { blur: closeDropdown, keydown: onSearchKeydown }">
+                            <ul class="dropdown-menu w-100 show collab-moderator-dropdown" data-bind="visible: dropdownOpen">
+                                <!-- ko if: loading -->
+                                <li>
+                                    <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2" style="pointer-events:none;">
+                                        <i class="fa fa-spinner fa-spin me-2"></i>Searching…
+                                    </div>
+                                </li>
+                                <!-- /ko -->
+                                <!-- ko ifnot: loading -->
+                                <!-- ko foreach: searchResults -->
+                                <li>
+                                    <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
+                                        data-bind="click: $parent.selectFromSearch">
+                                        <span class="text-truncate" data-bind="text: name"></span>
+                                        <span class="text-muted small ms-2 text-truncate" data-bind="text: identifier"></span>
+                                    </div>
+                                </li>
+                                <!-- /ko -->
+                                <!-- ko if: searchResults().length === 0 -->
+                                <li>
+                                    <div class="dropdown-item text-muted text-center py-2" style="pointer-events:none;">No results found.</div>
+                                </li>
+                                <!-- /ko -->
+                                <!-- /ko -->
+                            </ul>
+                        </div>
+                        <!-- /ko -->
+                        <!-- ko if: selected -->
+                        <span class="badge bg-info-subtle text-info-emphasis collab-moderator-chip">
+                            <i class="fas fa-calendar-day"></i>
+                            <span data-bind="text: selectedLabel"></span>
+                            <button type="button" class="btn-close" title="Remove event"
+                                data-bind="click: clearSelection"></button>
+                        </span>
+                        <!-- /ko -->
+                    </div>
                     <div class="small text-muted mb-1 w-100">Marker permissions</div>
                     <div class="form-check" title="Everyone can add, edit and delete markers (everyone can also comment, unless restricted below).">
                         <input class="form-check-input" type="radio" name="collabPermMarkerMode" id="collabPermMarkerModeAnyone"
@@ -3571,7 +3660,7 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                     <button type="button" class="btn btn-primary"
-                        data-bind="click: savePermissions, disable: savingPermissions">Save</button>
+                        data-bind="click: savePermissions, disable: savingPermissions() || !hqEditPicker.selected()">Save</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- A collaborative map layer's HQ and event attachment were previously fixed at creation with no later "reassign HQ" or "attach/detach event" flow.
- Adds `PUT /lad_v2/map-layers/{id}/attachment` (`lambda/map-layers-v2/handlers/updateLayerAttachment.js`), authorized the same way as `/permissions` and `/moderators` (layer creator or a current moderator). Extracted the HQ/event sanitizers shared with `createLayer.js` into `lib/attachment.js`.
- Extends the existing "Manage permissions" modal (now "Layer settings") with HQ and event pickers, reusing the same picker widgets from the create-layer form. One Save click updates permissions and attachment together.
- **Already deployed**: `LH-MapLayersv2` Lambda updated and the new API Gateway route added (same integration/auth as the existing routes, verified with a smoke-test 401). This PR is the corresponding code review/record for that change.

## Test plan
- [ ] Open the tasking map's collaborative layers panel, click "Manage permissions, HQ and event" on a layer you created/moderate.
- [ ] Change the HQ, confirm it saves and the row's HQ label updates.
- [ ] Attach/detach an event, confirm it saves and the row's event badge updates.
- [ ] Confirm the Save button is disabled if HQ is cleared with no replacement picked.
- [ ] Confirm a non-creator/non-moderator doesn't see the "Manage permissions" control at all.