### PR TITLE
Use an edit icon for the collab layer settings button

### DIFF
--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -3174,7 +3174,7 @@
                                                                  the primary Unsubscribe action. -->
                                                             <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage permissions, HQ and event"
                                                                 data-bind="visible: row.canManagePermissions && !row.confirmingDelete(), click: row.openPermissionsModal">
-                                                                <i class="fa fa-lock"></i>
+                                                                <i class="fa fa-pencil"></i>
                                                             </button>
                                                             <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage moderators"
                                                                 data-bind="visible: row.canManageModerators && !row.confirmingDelete(), click: row.toggleEditModerators">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -3174,7 +3174,7 @@
                                                                  the primary Unsubscribe action. -->
                                                             <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage permissions, HQ and event"
                                                                 data-bind="visible: row.canManagePermissions && !row.confirmingDelete(), click: row.openPermissionsModal">
-                                                                <i class="fa fa-pencil"></i>
+                                                                <i class="fa fa-pencil-alt"></i>
                                                             </button>
                                                             <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage moderators"
                                                                 data-bind="visible: row.canManageModerators && !row.confirmingDelete(), click: row.toggleEditModerators">


### PR DESCRIPTION
## Summary
- Swaps the padlock icon for a pencil on the collab layer row's "Manage permissions, HQ and event" button -- now that it opens the "Layer settings" modal (permissions + HQ + event, see #396), a padlock read as narrowly about restricting access.

## Test plan
- [ ] Open the tasking map's collaborative layers panel and confirm the button shows a pencil icon with the same tooltip/behavior as before.