### PR TITLE
Move collaborative layer moderator editing into the settings modal

### DIFF
--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -582,6 +582,7 @@ export function ConfigVM(root, deps) {
         row.editCommentMode(row.commentMode);
         row.hqEditPicker?.reset(row.hqId ? { id: row.hqId, name: row.hqName } : null);
         row.eventEditPicker?.reset(row.eventId ? { id: row.eventId, name: row.eventName, identifier: row.eventIdentifier } : null);
+        row.moderatorPicker?.reset(row.moderators);
         self.permissionsModalRow(row);
         const modalEl = document.getElementById('collabPermissionsModal');
         if (!modalEl) return;
@@ -728,12 +729,11 @@ export function ConfigVM(root, deps) {
                 authorName: ko.observable(''),
                 // Creator or any current moderator can manage moderators
                 // (enforced server-side too, see updateLayerModerators.js)
-                // -- everyone else doesn't get the "Manage moderators"
-                // control at all.
+                // -- everyone else doesn't get the moderator picker in
+                // #collabPermissionsModal at all. Edited in that same modal
+                // as permissions/HQ/event (see saveRowPermissions), not its
+                // own separate inline panel.
                 canManageModerators,
-                editingModerators: ko.observable(false),
-                savingModerators: ko.observable(false),
-                moderatorsError: ko.observable(''),
                 moderatorPicker: canManageModerators ? makeModeratorPicker(deps.searchMembers, moderators) : null,
                 // Same authorization as moderator management -- creator or
                 // any current moderator (see lambda
@@ -776,16 +776,6 @@ export function ConfigVM(root, deps) {
             row.requestDeleteLayer = () => row.confirmingDelete(true);
             row.cancelDeleteLayer = () => row.confirmingDelete(false);
             row.confirmDeleteLayer = () => self.deleteCollabLayer(row);
-            row.toggleEditModerators = () => {
-                row.moderatorsError('');
-                row.moderatorPicker?.reset(row.moderators);
-                row.editingModerators(!row.editingModerators());
-            };
-            row.cancelEditModerators = () => {
-                row.moderatorPicker?.reset(row.moderators);
-                row.editingModerators(false);
-            };
-            row.saveModerators = () => self.saveRowModerators(row);
             row.openPermissionsModal = () => self.openPermissionsModal(row);
             row.savePermissions = () => self.saveRowPermissions(row);
             return row;
@@ -1005,47 +995,19 @@ export function ConfigVM(root, deps) {
         }
     };
 
-    // Saves a row's in-progress moderator picker as the layer's new
-    // moderator list, fired from row.saveModerators above. Only rows the
-    // creator or a current moderator can manage ever get a moderatorPicker
-    // (see collabLayerRows' canManageModerators), so there's no separate
-    // authorization check needed here -- the Lambda enforces it
-    // authoritatively either way.
-    self.saveRowModerators = async (row) => {
-        if (!deps.apiUrl || !row.moderatorPicker || row.savingModerators()) return;
-
-        row.moderatorsError('');
-        row.savingModerators(true);
-        try {
-            const moderators = row.moderatorPicker.moderators();
-            const saved = await updateCollabLayerModerators(root, deps.apiUrl, row.layer.id, moderators, deps.getToken);
-            if (saved == null) throw new Error('Update failed');
-            // updateCollabLayerModerators mutates row.layer.moderators in
-            // place (it's the same object reference held in
-            // self.collabLayers()) -- force collabLayerRows to recompute so
-            // this row (and its canDelete/moderator badges) reflect the new
-            // list immediately, same as a poll-driven refresh would.
-            self.collabLayers.valueHasMutated();
-        } catch (err) {
-            console.error('Error updating layer moderators:', err);
-            row.moderatorsError('Failed to save moderators. Try again later.');
-        } finally {
-            row.savingModerators(false);
-        }
-    };
-
-    // Saves a row's in-progress marker/delete/comment mode radios *and* its
-    // in-progress HQ/event pickers (all edited in #collabPermissionsModal)
-    // as the layer's new permissions and attachment, fired from
+    // Saves a row's in-progress marker/delete/comment mode radios, its
+    // in-progress HQ/event pickers, *and* its in-progress moderator picker
+    // (all edited together in #collabPermissionsModal) as the layer's new
+    // permissions, attachment and moderator list, fired from
     // row.savePermissions above. Only rows the creator or a current
     // moderator can manage ever get the "Manage permissions" control exposed
     // (see collabLayerRows' canManagePermissions), so there's no separate
     // authorization check needed here -- the Lambda enforces it
-    // authoritatively either way. Two independent PUTs (permissions and
-    // attachment are separate Lambda routes/S3 fields) fired together so one
-    // Save click covers everything the modal edits; either can fail on its
-    // own, in which case the modal stays open with the error shown rather
-    // than silently discarding whichever half didn't make it.
+    // authoritatively either way. Three independent PUTs (permissions,
+    // attachment and moderators are separate Lambda routes/S3 fields) fired
+    // together so one Save click covers everything the modal edits; any can
+    // fail on its own, in which case the modal stays open with the error
+    // shown rather than silently discarding whichever part didn't make it.
     self.saveRowPermissions = async (row) => {
         if (!deps.apiUrl || !row.canManagePermissions || row.savingPermissions()) return;
         if (row.hqEditPicker && !row.hqEditPicker.selected()) {
@@ -1061,19 +1023,21 @@ export function ConfigVM(root, deps) {
                 deleteMode: row.editDeleteMode(),
                 commentMode: row.editCommentMode(),
             };
-            const [savedPermissions, savedAttachment] = await Promise.all([
+            const [savedPermissions, savedAttachment, savedModerators] = await Promise.all([
                 updateCollabLayerPermissions(root, deps.apiUrl, row.layer.id, permissions, deps.getToken),
                 updateCollabLayerAttachment(root, deps.apiUrl, row.layer.id, {
                     hq: row.hqEditPicker.selected(),
                     event: row.eventEditPicker.selected(),
                 }, deps.getToken),
+                updateCollabLayerModerators(root, deps.apiUrl, row.layer.id, row.moderatorPicker.moderators(), deps.getToken),
             ]);
-            if (savedPermissions == null || savedAttachment == null) throw new Error('Update failed');
-            // Both update calls mutate row.layer's fields in place (it's the
-            // same object reference held in self.collabLayers()) -- force
-            // collabLayerRows to recompute so this row (and its
-            // canDelete/lock badges, HQ/event labels) reflects the new
-            // values immediately, same as a poll-driven refresh would.
+            if (savedPermissions == null || savedAttachment == null || savedModerators == null) throw new Error('Update failed');
+            // All three update calls mutate row.layer's fields in place
+            // (it's the same object reference held in
+            // self.collabLayers()) -- force collabLayerRows to recompute so
+            // this row (and its canDelete/lock badges, HQ/event labels and
+            // moderator badges) reflects the new values immediately, same
+            // as a poll-driven refresh would.
             self.collabLayers.valueHasMutated();
             // Only close on success -- an error leaves the modal open (with
             // permissionsError shown) so the user can see what went wrong

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -3172,13 +3172,9 @@
                                                                  Unsubscribe above) so these administrative/destructive
                                                                  actions read as secondary and don't get confused with
                                                                  the primary Unsubscribe action. -->
-                                                            <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage permissions, HQ and event"
+                                                            <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage permissions, HQ, event and moderators"
                                                                 data-bind="visible: row.canManagePermissions && !row.confirmingDelete(), click: row.openPermissionsModal">
                                                                 <i class="fa fa-lock"></i>
-                                                            </button>
-                                                            <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage moderators"
-                                                                data-bind="visible: row.canManageModerators && !row.confirmingDelete(), click: row.toggleEditModerators">
-                                                                <i class="fa fa-user-shield"></i>
                                                             </button>
                                                             <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1"
                                                                 data-bind="visible: !row.confirmingDelete(), click: row.requestDeleteLayer, disable: !row.canDelete, attr: { title: row.deleteTitle }">
@@ -3191,57 +3187,6 @@
                                                                 <button type="button" class="btn btn-sm btn-secondary"
                                                                     data-bind="click: row.cancelDeleteLayer">Cancel</button>
                                                             </span>
-                                                        </div>
-                                                        <div class="collab-moderator-picker collab-moderator-edit mt-2"
-                                                            data-bind="visible: row.editingModerators, with: row.moderatorPicker">
-                                                            <div class="input-group input-group-sm position-relative">
-                                                                <input type="text" class="form-control" placeholder="Search by name or member number…" autocomplete="off" data-bind="
-                                                                    value: searchQuery,
-                                                                    valueUpdate: 'afterkeydown',
-                                                                    hasFocus: hasFocus,
-                                                                    event: { blur: closeDropdown, keydown: onSearchKeydown }">
-                                                                <button class="btn btn-outline-secondary" type="button" title="Clear"
-                                                                    data-bind="click: clearSearch, enable: searchQuery">&times;</button>
-                                                                <ul class="dropdown-menu w-100 show collab-moderator-dropdown" data-bind="visible: dropdownOpen">
-                                                                    <!-- ko if: loading -->
-                                                                    <li>
-                                                                        <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2" style="pointer-events:none;">
-                                                                            <i class="fa fa-spinner fa-spin me-2"></i>Searching…
-                                                                        </div>
-                                                                    </li>
-                                                                    <!-- /ko -->
-                                                                    <!-- ko ifnot: loading -->
-                                                                    <!-- ko foreach: searchResults -->
-                                                                    <li>
-                                                                        <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
-                                                                            data-bind="click: $parent.addFromSearch">
-                                                                            <span class="text-truncate" data-bind="text: name"></span>
-                                                                            <span class="text-muted small ms-2 text-truncate" data-bind="text: detail"></span>
-                                                                        </div>
-                                                                    </li>
-                                                                    <!-- /ko -->
-                                                                    <!-- ko if: searchResults().length === 0 -->
-                                                                    <li>
-                                                                        <div class="dropdown-item text-muted text-center py-2" style="pointer-events:none;">No results found.</div>
-                                                                    </li>
-                                                                    <!-- /ko -->
-                                                                    <!-- /ko -->
-                                                                </ul>
-                                                            </div>
-                                                            <div class="collab-moderator-chips mt-1" data-bind="visible: moderators().length > 0, foreach: moderators">
-                                                                <span class="badge bg-secondary collab-moderator-chip">
-                                                                    <span data-bind="text: name"></span>
-                                                                    <button type="button" class="btn-close btn-close-white" title="Remove"
-                                                                        data-bind="click: $parent.removeModerator"></button>
-                                                                </span>
-                                                            </div>
-                                                            <div class="text-danger small mt-1" data-bind="visible: $parent.moderatorsError, text: $parent.moderatorsError"></div>
-                                                            <div class="mt-2 d-flex gap-1">
-                                                                <button type="button" class="btn btn-sm btn-primary"
-                                                                    data-bind="click: $parent.saveModerators, disable: $parent.savingModerators">Save</button>
-                                                                <button type="button" class="btn btn-sm btn-secondary"
-                                                                    data-bind="click: $parent.cancelEditModerators">Cancel</button>
-                                                            </div>
                                                         </div>
                                                         </li>
                                                     </ul>
@@ -3606,6 +3551,50 @@
                                 data-bind="click: clearSelection"></button>
                         </span>
                         <!-- /ko -->
+                    </div>
+                    <div class="collab-moderator-picker mb-3" data-bind="with: moderatorPicker">
+                        <div class="small text-muted mb-1">Moderators</div>
+                        <div class="input-group input-group-sm position-relative">
+                            <input type="text" class="form-control" placeholder="Search by name or member number…" autocomplete="off" data-bind="
+                                value: searchQuery,
+                                valueUpdate: 'afterkeydown',
+                                hasFocus: hasFocus,
+                                event: { blur: closeDropdown, keydown: onSearchKeydown }">
+                            <button class="btn btn-outline-secondary" type="button" title="Clear"
+                                data-bind="click: clearSearch, enable: searchQuery">&times;</button>
+                            <ul class="dropdown-menu w-100 show collab-moderator-dropdown" data-bind="visible: dropdownOpen">
+                                <!-- ko if: loading -->
+                                <li>
+                                    <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2" style="pointer-events:none;">
+                                        <i class="fa fa-spinner fa-spin me-2"></i>Searching…
+                                    </div>
+                                </li>
+                                <!-- /ko -->
+                                <!-- ko ifnot: loading -->
+                                <!-- ko foreach: searchResults -->
+                                <li>
+                                    <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
+                                        data-bind="click: $parent.addFromSearch">
+                                        <span class="text-truncate" data-bind="text: name"></span>
+                                        <span class="text-muted small ms-2 text-truncate" data-bind="text: detail"></span>
+                                    </div>
+                                </li>
+                                <!-- /ko -->
+                                <!-- ko if: searchResults().length === 0 -->
+                                <li>
+                                    <div class="dropdown-item text-muted text-center py-2" style="pointer-events:none;">No results found.</div>
+                                </li>
+                                <!-- /ko -->
+                                <!-- /ko -->
+                            </ul>
+                        </div>
+                        <div class="collab-moderator-chips mt-1" data-bind="visible: moderators().length > 0, foreach: moderators">
+                            <span class="badge bg-secondary collab-moderator-chip">
+                                <span data-bind="text: name"></span>
+                                <button type="button" class="btn-close btn-close-white" title="Remove"
+                                    data-bind="click: $parent.removeModerator"></button>
+                            </span>
+                        </div>
                     </div>
                     <div class="small text-muted mb-1 w-100">Marker permissions</div>
                     <div class="form-check" title="Everyone can add, edit and delete markers (everyone can also comment, unless restricted below).">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -3174,7 +3174,7 @@
                                                                  the primary Unsubscribe action. -->
                                                             <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1" title="Manage permissions, HQ, event and moderators"
                                                                 data-bind="visible: row.canManagePermissions && !row.confirmingDelete(), click: row.openPermissionsModal">
-                                                                <i class="fa fa-lock"></i>
+                                                                <i class="fa fa-pencil-alt"></i>
                                                             </button>
                                                             <button type="button" class="btn btn-sm btn-link text-muted py-0 px-1"
                                                                 data-bind="visible: !row.confirmingDelete(), click: row.requestDeleteLayer, disable: !row.canDelete, attr: { title: row.deleteTitle }">


### PR DESCRIPTION
## Summary
- Moderators had their own inline expanding panel and separate Save/Cancel on each collab layer row, despite being gated by the same creator-or-moderator authorization as permissions/HQ/event. Moves moderator editing into `#collabPermissionsModal` (now "Layer settings") alongside them, so one Save click updates permissions, attachment and moderators together via three `Promise.all`'d PUT calls to the already-deployed `/permissions`, `/attachment` and `/moderators` routes -- no lambda changes needed.
- Removes the row's separate "Manage moderators" button/panel; the remaining "Manage permissions, HQ, event and moderators" button now covers everything.
- Also includes the `fa-lock` → `fa-pencil-alt` icon fix for that button (this branch forked before #397 merged, which made the same fix -- #397 has been closed as redundant).

## Test plan
- [x] Open the tasking map's collaborative layers panel, click the pencil icon on a layer you created/moderate.
- [x] Confirm the modal shows HQ, Event, Moderators, and the three permission mode sections all together.
- [x] Add/remove a moderator, change a permission mode, and change the HQ in the same session, click Save once, confirm all three persist (row's moderator badge, HQ label, and lock/comment-restricted badges all update).
- [x] Confirm a non-creator/non-moderator still doesn't see the button at all.