### PR TITLE
Improve collaborative layer moderator/HQ/event picker UX

### DIFF
--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -83,11 +83,16 @@ function makeModeratorPicker(searchMembers, initial = []) {
             // when a Disabled flag was set on training/test accounts).
             const cleaned = (rows || [])
                 .filter(r => r.Username)
-                .map(r => ({
-                    id: String(r.Username),
-                    name: [r.Firstname, r.Lastname].filter(Boolean).join(' ') || String(r.Username),
-                    detail: String(r.Username),
-                }));
+                .map(r => {
+                    const entity = r.Entity ? String(r.Entity).trim() : '';
+                    return {
+                        id: String(r.Username),
+                        name: [r.Firstname, r.Lastname].filter(Boolean).join(' ') || String(r.Username),
+                        // Unit name alongside the member number disambiguates
+                        // same-named members across different units.
+                        detail: entity ? `${entity} · ${r.Username}` : String(r.Username),
+                    };
+                });
             picker.searchResults(cleaned);
         } catch (err) {
             console.error('Member search failed:', err);
@@ -904,11 +909,11 @@ export function ConfigVM(root, deps) {
         unsubscribeFromLayer(root, row.layer.id);
     };
 
-    // Shared by a successful create and an explicit Cancel -- puts the form
-    // back to its just-opened state. HQ resets to the resolved default (not
-    // empty), since creating several layers in a row, or reopening the form
-    // later, is almost always for the same HQ; everything else resets to
-    // its "no customisation" default.
+    // Shared by a successful create and an explicit Cancel -- closes the
+    // form and puts it back to its just-opened state, ready for next time.
+    // HQ resets to the resolved default (not empty), since reopening the
+    // form later is almost always for the same HQ; everything else resets
+    // to its "no customisation" default.
     function resetNewLayerForm() {
         self.newLayerName('');
         self.newLayerMarkerMode('anyone');
@@ -917,12 +922,12 @@ export function ConfigVM(root, deps) {
         self.newLayerModeratorPicker.reset([]);
         self.newLayerEventPicker.reset(null);
         self.newLayerHqPicker.reset(self.defaultHq());
+        self.showCreateLayerForm(false);
     }
 
     self.cancelCreateLayer = () => {
         self.collabLayerError('');
         resetNewLayerForm();
-        self.showCreateLayerForm(false);
     };
 
     self.createCollabLayer = async () => {

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2865,7 +2865,8 @@
                                                     </div>
                                                     <!-- /ko -->
                                                     <!-- ko if: selected -->
-                                                    <span class="badge bg-primary-subtle text-primary-emphasis collab-moderator-chip">
+                                                    <span class="badge bg-primary-subtle text-primary-emphasis collab-moderator-chip" style="cursor: pointer;"
+                                                        title="Click to change HQ" data-bind="click: clearSelection">
                                                         <i class="fas fa-building"></i>
                                                         <span data-bind="text: selected() && selected().name"></span>
                                                         <button type="button" class="btn-close" title="Change HQ"
@@ -2917,7 +2918,8 @@
                                                         </div>
                                                         <!-- /ko -->
                                                         <!-- ko if: selected -->
-                                                        <span class="badge bg-info-subtle text-info-emphasis collab-moderator-chip">
+                                                        <span class="badge bg-info-subtle text-info-emphasis collab-moderator-chip" style="cursor: pointer;"
+                                                            title="Click to change event" data-bind="click: clearSelection">
                                                             <i class="fas fa-calendar-day"></i>
                                                             <span data-bind="text: selectedLabel"></span>
                                                             <button type="button" class="btn-close" title="Remove event"
@@ -3090,7 +3092,8 @@
                                                     </div>
                                                     <!-- /ko -->
                                                     <!-- ko if: selected -->
-                                                    <span class="badge bg-primary-subtle text-primary-emphasis collab-moderator-chip">
+                                                    <span class="badge bg-primary-subtle text-primary-emphasis collab-moderator-chip" style="cursor: pointer;"
+                                                        title="Click to change HQ" data-bind="click: clearSelection">
                                                         <i class="fas fa-building"></i>
                                                         <span data-bind="text: selected() && selected().name"></span>
                                                         <button type="button" class="btn-close" title="Change HQ"
@@ -3499,7 +3502,8 @@
                         </div>
                         <!-- /ko -->
                         <!-- ko if: selected -->
-                        <span class="badge bg-primary-subtle text-primary-emphasis collab-moderator-chip">
+                        <span class="badge bg-primary-subtle text-primary-emphasis collab-moderator-chip" style="cursor: pointer;"
+                            title="Click to change HQ" data-bind="click: clearSelection">
                             <i class="fas fa-building"></i>
                             <span data-bind="text: selected() && selected().name"></span>
                             <button type="button" class="btn-close" title="Change HQ"
@@ -3544,7 +3548,8 @@
                         </div>
                         <!-- /ko -->
                         <!-- ko if: selected -->
-                        <span class="badge bg-info-subtle text-info-emphasis collab-moderator-chip">
+                        <span class="badge bg-info-subtle text-info-emphasis collab-moderator-chip" style="cursor: pointer;"
+                            title="Click to change event" data-bind="click: clearSelection">
                             <i class="fas fa-calendar-day"></i>
                             <span data-bind="text: selectedLabel"></span>
                             <button type="button" class="btn-close" title="Remove event"


### PR DESCRIPTION
Shows each candidate's unit alongside their member number in the moderator search dropdown, closes the create-layer form automatically after a successful create (it previously stayed open with the fields reset), and makes the selected HQ/event chip itself clickable to reopen search rather than only the small "x" button, so it reads more like the searchable dropdown pattern used elsewhere.