### PR TITLE
Clean up marker audit notice and show create-layer progress/success

### DIFF
--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -776,11 +776,11 @@ function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getTo
         <div class="collab-char-counter"></div>
         <textarea class="collab-desc-input" placeholder="Description" rows="2" maxlength="${TEXT_CHAR_LIMIT}">${escHtml(stripAuditFooter(currentEntry?.Text))}</textarea>
         <div class="collab-char-counter"></div>
-        <div class="collab-marker-audit-notice"><i class="fas fa-info-circle"></i> All marker actions -- create, edit, delete, and comments -- create an Ops Log entries.</div>
         <div class="collab-form-actions">
             <button type="button" class="btn btn-sm btn-secondary collab-cancel-btn">Cancel</button>
             <button type="button" class="btn btn-sm btn-primary collab-save-btn">Save</button>
         </div>
+        <div class="collab-marker-audit-notice">Actions on this marker are logged to the Ops Log.</div>
     `;
 
     const previewEl = el.querySelector(".collab-style-preview");

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -565,6 +565,9 @@ export function ConfigVM(root, deps) {
         self.newLayerDeleteMode() === 'moderators' ||
         self.newLayerCommentMode() === 'moderators');
     self.creatingCollabLayer = ko.observable(false);
+    // Held true just long enough for the Create button to flash its
+    // success state before the form closes -- see createCollabLayer below.
+    self.collabLayerCreated = ko.observable(false);
     self.collabLayerError = ko.observable('');
     self.collabLayerSearch = ko.observable(''); // filters "My layers" by name -- mainly useful once you've subscribed to a lot of them
     self.refreshingCollabLayers = ko.observable(false);
@@ -952,11 +955,17 @@ export function ConfigVM(root, deps) {
             };
             const layer = await createCollabLayer(root, deps.apiUrl, name, deps.actorId, deps.getToken, permissions, deps.getMemberId);
             if (!layer) throw new Error('Create failed');
+            self.creatingCollabLayer(false);
+            // Hold the button in its success state briefly so the user
+            // actually sees it succeed, rather than the form vanishing the
+            // instant the request resolves.
+            self.collabLayerCreated(true);
+            await new Promise((resolve) => setTimeout(resolve, 900));
+            self.collabLayerCreated(false);
             resetNewLayerForm();
         } catch (err) {
             console.error('Error creating collaborative layer:', err);
             self.collabLayerError('Failed to create layer. Try again later.');
-        } finally {
             self.creatingCollabLayer(false);
         }
     };

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -3035,13 +3035,23 @@
                                                 <div class="text-danger small mb-2"
                                                     data-bind="visible: config.collabLayerError, text: config.collabLayerError"></div>
                                                 <div class="d-flex gap-2">
-                                                    <button type="button" class="btn btn-sm btn-primary"
+                                                    <button type="button" class="btn btn-sm"
                                                         data-bind="click: config.createCollabLayer,
-                                                            enable: config.newLayerName().trim().length > 0 && !!config.newLayerHqPicker.selected() && !config.creatingCollabLayer()">
+                                                            css: { 'btn-primary': !config.collabLayerCreated(), 'btn-success': config.collabLayerCreated() },
+                                                            enable: config.newLayerName().trim().length > 0 && !!config.newLayerHqPicker.selected() && !config.creatingCollabLayer() && !config.collabLayerCreated()">
+                                                        <!-- ko if: config.collabLayerCreated -->
+                                                        <i class="fa fa-check me-1"></i>Created
+                                                        <!-- /ko -->
+                                                        <!-- ko if: config.creatingCollabLayer -->
+                                                        <i class="fa fa-spinner fa-spin me-1"></i>Creating…
+                                                        <!-- /ko -->
+                                                        <!-- ko if: !config.creatingCollabLayer() && !config.collabLayerCreated() -->
                                                         <i class="fa fa-plus me-1"></i>Create layer
+                                                        <!-- /ko -->
                                                     </button>
                                                     <button type="button" class="btn btn-sm btn-outline-secondary"
-                                                        data-bind="click: config.cancelCreateLayer">
+                                                        data-bind="click: config.cancelCreateLayer,
+                                                            enable: !config.creatingCollabLayer() && !config.collabLayerCreated()">
                                                         Cancel
                                                     </button>
                                                 </div>

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2960,17 +2960,10 @@ overflow: hidden;
   font-size: 12px;
 }
 .collab-marker-audit-notice {
-  display: flex;
-  align-items: flex-start;
-  gap: 5px;
-  color: #888;
-  font-size: 10.5px;
-  line-height: 1.35;
-  margin-bottom: 8px;
-}
-.collab-marker-audit-notice .fa-info-circle {
-  margin-top: 1px;
-  flex-shrink: 0;
+  color: #9aa4ad;
+  font-size: 10px;
+  line-height: 1.3;
+  margin-top: 6px;
 }
 .collab-form-actions {
   display: flex;


### PR DESCRIPTION
## Summary
- Move the collaborative marker create/edit popup's audit disclaimer below the button row as a quiet single-line caption, instead of the boxed/tooltip variants tried along the way — fixes the messy layout in the original screenshot.
- The "Create layer" button now shows its in-flight state (spinner + "Creating…") and a brief success state (checkmark + "Created") before the form closes, instead of closing the instant the create request resolves.

## Test plan
- [ ] Open a collaborative layer, right-click to add a marker, confirm the audit caption sits under Cancel/Save and reads cleanly at the popup's width.
- [ ] Open the "New layer" form, click Create layer, confirm the button shows a spinner while the request is in flight, then a checkmark before the form closes.
- [ ] Trigger a failed create (e.g. no HQ selected) and confirm the error message still shows and the button returns to its normal state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)