### PR TITLE
Fix BMB unit HQ coordinates in SES_HQs.geojson

### DIFF
--- a/static/resources/SES_HQs.geojson
+++ b/static/resources/SES_HQs.geojson
@@ -5719,8 +5719,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          150.17824054029796,
-          -35.708913376383755
+          150.2024332,
+          -35.7654855
         ]
       },
       "properties": {
@@ -5729,8 +5729,8 @@
         "SES_LEVEL": "Unit",
         "REGCODE": "ISR",
         "UNIT_CODE": "BMB",
-        "POINT_X": 150.1782352,
-        "POINT_Y": -35.70892614,
+        "POINT_X": 150.2024332,
+        "POINT_Y": -35.7654855,
         "ZoneCode": "SEZ",
         "C_Code": "EUC",
         "STArea__": 0.79910844,


### PR DESCRIPTION
This pull request updates the location coordinates for a SES Unit in the `static/resources/SES_HQs.geojson` file. The main change is correcting the longitude and latitude values for the unit.

Geospatial Data Correction:

* Updated both the `geometry.coordinates` and the `properties.POINT_X` / `POINT_Y` fields to new longitude and latitude values for the SES Unit with `UNIT_CODE` "BMB". [[1]](diffhunk://#diff-94422a8973fb49ca02f65da98d8d8b9e12990c9a4d36288f96e21405baea64f6L5722-R5723) [[2]](diffhunk://#diff-94422a8973fb49ca02f65da98d8d8b9e12990c9a4d36288f96e21405baea64f6L5732-R5733)