### PR TITLE
Fix wrong apiHost passed to transport incidents ops log lookup

### DIFF
--- a/src/pages/tasking/mapLayers/transport.js
+++ b/src/pages/tasking/mapLayers/transport.js
@@ -152,7 +152,7 @@ export function registerTransportIncidentsLayer(vm, map, getToken, apiHost, para
 function getTransportApiKeyOpsLog(apiHost, userId, token, cb) {
 
     var opsId = null;
-
+  console.log("getTransportApiKeyOpsLog", apiHost, userId, token)
     switch (apiHost) {
         case 'https://previewbeacon.ses.nsw.gov.au':
             opsId = '46273';
@@ -205,7 +205,7 @@ async function fetchTransportIncidentsAsync(apiHost, userId, token) {
 
     if (!transportApiKeyCache) {
         transportApiKeyCache = await new Promise((resolve) => {
-            getTransportApiKeyOpsLog('https://trainbeacon.ses.nsw.gov.au', apiHost, userId, token, function (key) {
+            getTransportApiKeyOpsLog(apiHost, userId, token, function (key) {
                 sessionStorage.setItem(sessionKey, key);
                 resolve(key);
             });

--- a/src/pages/tasking/mapLayers/transport.js
+++ b/src/pages/tasking/mapLayers/transport.js
@@ -152,7 +152,6 @@ export function registerTransportIncidentsLayer(vm, map, getToken, apiHost, para
 function getTransportApiKeyOpsLog(apiHost, userId, token, cb) {
 
     var opsId = null;
-  console.log("getTransportApiKeyOpsLog", apiHost, userId, token)
     switch (apiHost) {
         case 'https://previewbeacon.ses.nsw.gov.au':
             opsId = '46273';


### PR DESCRIPTION
This pull request makes minor changes to the `transport.js` map layer code, focusing on improving debugging and fixing a parameter issue.


* Fixed an incorrect parameter in `fetchTransportIncidentsAsync` by passing the correct `apiHost` to `getTransportApiKeyOpsLog` instead of a hardcoded value.