### PR TITLE
Route Contact Group SMS recipients through a separate ContactGroups field

### DIFF
--- a/src/shared/BeaconClient/messages.js
+++ b/src/shared/BeaconClient/messages.js
@@ -8,13 +8,23 @@ const data = {
   JobId: jobId
 };
 
-recipients.forEach((recipient, index) => {
+// Contact Groups (ContactTypeId 0) have no Detail/phone number of their own -
+// Beacon resolves their membership server-side and echoes it back as a
+// separate ContactGroups field, so they can't go through Recipients[i].
+const contactGroups = recipients.filter(recipient => recipient.ContactTypeId === 0);
+const individualContacts = recipients.filter(recipient => recipient.ContactTypeId !== 0);
+
+individualContacts.forEach((recipient, index) => {
   data[`Recipients[${index}][Recipient]`]      = recipient.Detail;
   data[`Recipients[${index}][Description]`]   = recipient.FirstName
     ? `${recipient.FirstName} ${recipient.LastName}`
     : recipient.Description;
   data[`Recipients[${index}][ContactId]`]     = recipient.Id;
   data[`Recipients[${index}][ContactTypeId]`] = recipient.ContactTypeId;
+});
+
+contactGroups.forEach((group, index) => {
+  data[`ContactGroups[${index}]`] = group.Id;
 });
 
   $.ajax({


### PR DESCRIPTION
## Summary
- Follow-up to #402. A Contact Group search result (`ContactTypeId: 0`) has no `Detail`/phone number of its own — Beacon resolves group membership server-side and echoes the result back on the sent message as a separate `ContactGroups` field, not as entries in `Recipients[]`.
- `messages.js`'s `send()` now splits recipients: `ContactTypeId === 0` (groups) go into `ContactGroups[i] = <GroupId>`, everything else continues through `Recipients[i][Recipient/Description/ContactId/ContactTypeId]` as before.

This is a best-effort implementation of the wire format based on the bracket-array convention already used elsewhere in this file — there's no separate reference implementation to check against, so it needs to be verified against a real send.

## Test plan
- [ ] Send an SMS to a Contact Group only, confirm the group actually receives the message (not just a 200 response).
- [ ] Send an SMS to a mix of a Contact Group and an individual contact in one message, confirm both are addressed correctly.
- [ ] Confirm sending to individual contacts only is unaffected (still works as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)