### PR TITLE
Add myAvailability response gems to job view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Lighthouse.zip
 .DS_Store
 *.DS_Store
 package-lock.json
+lambda/myavailability-incident/

--- a/src/contentscripts/jobs/view.js
+++ b/src/contentscripts/jobs/view.js
@@ -391,6 +391,22 @@ let job_lighthouse_actions = (
   </div>
 )
 
+// Row of response-count "gems" shown below the Incident Details header.
+// Counts and hover names are populated by lighthouseResponseGems() in
+// injectscripts/jobs/view.js once the (not yet written) lad_v2/job-responses
+// Lambda function is available - see the TODO there for placeholder data.
+let job_response_gems = (
+  <div id="lighthouse-response-gems" class="lighthouse-response-gems">
+    <span id="lighthouse-gem-activationaccepted" class="lighthouse-response-gem lighthouse-response-gem-activationaccepted">-</span>
+    <span id="lighthouse-gem-available" class="lighthouse-response-gem lighthouse-response-gem-available">-</span>
+    <span id="lighthouse-gem-conditional" class="lighthouse-response-gem lighthouse-response-gem-conditional">-</span>
+    <span id="lighthouse-gem-unavailable" class="lighthouse-response-gem lighthouse-response-gem-unavailable">-</span>
+    <span id="lighthouse-gem-unset" class="lighthouse-response-gem lighthouse-response-gem-unset">-</span>
+  </div>
+);
+
+$('#jobID').closest('.widget-header').append(job_response_gems);
+
 $('div.widget.actions-box').after(job_lighthouse_actions)
 $('#map').parent().before(job_nearest_asset_widget)
 

--- a/src/injectscripts/jobs/view.js
+++ b/src/injectscripts/jobs/view.js
@@ -61,6 +61,134 @@ masterViewModel.teamsViewModel.taskedTeams.subscribe(function () {
   setTimeout(lighthouseTasking, 0);
 });
 
+// The myavailability/incident Lambda only has data for production Beacon
+// (apibeacon.ses.nsw.gov.au) - trainbeacon/devbeacon jobIds don't exist in
+// that database. Gate on urls.Base (the API root Beacon's own page is
+// talking to) so we never send a real request outside prod.
+function isProductionBeaconApi() {
+  return typeof urls !== 'undefined' && typeof urls.Base === 'string' &&
+    urls.Base.indexOf('apibeacon.ses.nsw.gov.au') !== -1;
+}
+
+// Assumes Beacon's jobId is the same value as `activationId` in the mams
+// database (View_ActivationRequest) - if gems come back empty/wrong for a
+// job you know has responses, that assumption is the first thing to check.
+function getJobResponseSummary(jobId, cb) {
+  if (!isProductionBeaconApi()) {
+    // Non-prod Beacon (trainbeacon/devbeacon/local) - don't call the real
+    // Lambda, just show obviously-fake placeholder data so the widget is
+    // still visible for UI testing.
+    cb(null, {
+      closed: false,
+      categories: {
+        ActivationAccepted: { Count: 1, Names: ['Fake Test Member'] },
+        Available: { Count: 2, Names: ['Fake Test Member', 'Fake Test Member 2'] },
+        Conditional: { Count: 1, Names: ['Fake Test Member'] },
+        Unavailable: { Count: 1, Names: ['Fake Test Member'] },
+        Unset: { Count: 5, Names: [] },
+      },
+    });
+    return;
+  }
+
+  $.ajax({
+    url: 'https://lambda.lighthouse-extension.com/myavailability/incident',
+    method: 'GET',
+    data: { activationId: jobId },
+    beforeSend: function (n) {
+      n.setRequestHeader('Authorization', 'Bearer ' + user.accessToken);
+    },
+    dataType: 'json',
+    success: function (data) {
+      cb(null, data);
+    },
+    error: function (xhr, status, error) {
+      cb(error);
+    },
+  });
+}
+
+// Bootstrap's hover-trigger popover only reacts to the *next* mouseenter -
+// if the popover is initialized while the cursor is already sitting over
+// the element (very likely here, since this runs right as the async data
+// load finishes and someone's been hovering to see what loads), nothing
+// shows until they move away and back. Show it immediately in that case.
+function initGemPopover($gem, options) {
+  $gem.popover(options);
+  if ($gem.is(':hover')) {
+    $gem.popover('show');
+  }
+}
+
+// Fills in the response-count gems (below the Incident Details header,
+// built by contentscripts/jobs/view.js) and wires up hover popovers
+// listing the names of the people in each category. Once the activation
+// is closed, gems show `-` instead of a count and skip the name list.
+function lighthouseResponseGems() {
+  var gemSelectorsByCategory = {
+    ActivationAccepted: '#lighthouse-gem-activationaccepted',
+    Available: '#lighthouse-gem-available',
+    Conditional: '#lighthouse-gem-conditional',
+    Unavailable: '#lighthouse-gem-unavailable',
+    Unset: '#lighthouse-gem-unset',
+  };
+
+  $('#lighthouse-response-gems').addClass('is-loading');
+
+  getJobResponseSummary(jobId, function (err, summary) {
+    $('#lighthouse-response-gems').removeClass('is-loading');
+    if (err || !summary) return;
+
+    _.each(gemSelectorsByCategory, function (selector, category) {
+      var $gem = $(selector);
+      if ($gem.length === 0) return;
+
+      var title = '<img src="' + lighthouseUrl + 'icons/lh-black.png" style="width:14px;vertical-align:middle;margin-right:5px" />myAvailability: ' +
+        category.replace(/([a-z])([A-Z])/g, '$1 $2');
+      var data = (summary.categories && summary.categories[category]) || { Count: 0, Names: [] };
+
+      if (data.Count === null) {
+        $gem.text('-');
+        initGemPopover($gem, {
+          placement: 'bottom',
+          trigger: 'hover',
+          html: true,
+          title: title,
+          content: '<em>Activation closed</em>',
+          container: 'body',
+        });
+        return;
+      }
+
+      $gem.text(data.Count);
+
+      var MAX_NAMES_SHOWN = 20;
+      var namesHtml = data.Names && data.Names.length
+        ? '<ul class="lighthouse-response-gem-names">' + _.map(data.Names.slice(0, MAX_NAMES_SHOWN), function (name) {
+            return '<li>' + _.escape(name) + '</li>';
+          }).join('') +
+          (data.Names.length > MAX_NAMES_SHOWN
+            ? '<li><em>+' + (data.Names.length - MAX_NAMES_SHOWN) + ' more</em></li>'
+            : '') +
+          '</ul>'
+        : '<em>No responders</em>';
+
+      initGemPopover($gem, {
+        placement: 'bottom',
+        trigger: 'hover',
+        html: true,
+        title: title,
+        content: namesHtml,
+        container: 'body',
+      });
+    });
+  });
+}
+
+whenJobIsReady(function () {
+  lighthouseResponseGems();
+});
+
 function lighthouseETAFromNow() {
   var future = moment(masterViewModel.teamsViewModel.jobTeamStatusEstimatedCompletion.peek());
   var now = moment();

--- a/src/styles/jobs.view.css
+++ b/src/styles/jobs.view.css
@@ -139,3 +139,71 @@
 .nounderline {
   text-decoration: none !important
 }
+
+.lighthouse-response-gems {
+  display: flex;
+  align-items: center;
+  width: fit-content;
+  margin-left: auto;
+  margin-top: 4px;
+  padding: 3px;
+  background: rgb(238, 238, 238);
+}
+
+.lighthouse-response-gem {
+  flex: none;
+  min-width: 34px;
+  padding: 4px 10px;
+  text-align: center;
+  color: #fff;
+  font-weight: bold;
+  font-family: "latobold";
+  font-size: 13px;
+  cursor: default;
+}
+
+.lighthouse-response-gem:first-child {
+  border-radius: 4px 0 0 4px;
+}
+
+.lighthouse-response-gem:last-child {
+  border-radius: 0 4px 4px 0;
+}
+
+.lighthouse-response-gems.is-loading .lighthouse-response-gem {
+  animation: lighthouse-gem-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes lighthouse-gem-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.lighthouse-response-gem-activationaccepted {
+  background: #337ab7;
+}
+
+.lighthouse-response-gem-available {
+  background: #5cb85c;
+}
+
+.lighthouse-response-gem-conditional {
+  background: #f0ad4e;
+}
+
+.lighthouse-response-gem-unavailable {
+  background: #d9534f;
+}
+
+.lighthouse-response-gem-unset {
+  background: #777777;
+}
+
+.lighthouse-response-gem-names {
+  margin: 0;
+  padding-left: 18px;
+}


### PR DESCRIPTION
Adds a row of colour-coded count 'gems' (Activation Accepted, Available, Conditional, Unavailable, Unset) below the Incident Details header on the job view page. Counts and hover popovers listing responder names are populated via a new `lighthouseResponseGems()` function that calls the myavailability/incident Lambda (production only; non-prod Beacon gets placeholder data). Includes a loading pulse animation and full CSS styling for the gem bar.