### PR TITLE
Enhance myAvailability gems with closed-state and Create Team action

### DIFF
--- a/src/injectscripts/jobs/view.js
+++ b/src/injectscripts/jobs/view.js
@@ -81,10 +81,10 @@ function getJobResponseSummary(jobId, cb) {
     cb(null, {
       closed: false,
       categories: {
-        ActivationAccepted: { Count: 1, Names: ['Fake Test Member'] },
-        Available: { Count: 2, Names: ['Fake Test Member', 'Fake Test Member 2'] },
-        Conditional: { Count: 1, Names: ['Fake Test Member'] },
-        Unavailable: { Count: 1, Names: ['Fake Test Member'] },
+        ActivationAccepted: { Count: 1, Names: [{ MemberId: -1, Name: 'Fake Test Member' }] },
+        Available: { Count: 2, Names: [{ MemberId: -2, Name: 'Fake Test Member' }, { MemberId: -3, Name: 'Fake Test Member 2' }] },
+        Conditional: { Count: 1, Names: [{ MemberId: -4, Name: 'Fake Test Member' }] },
+        Unavailable: { Count: 1, Names: [{ MemberId: -5, Name: 'Fake Test Member' }] },
         Unset: { Count: 5, Names: [] },
       },
     });
@@ -108,22 +108,77 @@ function getJobResponseSummary(jobId, cb) {
   });
 }
 
-// Bootstrap's hover-trigger popover only reacts to the *next* mouseenter -
-// if the popover is initialized while the cursor is already sitting over
-// the element (very likely here, since this runs right as the async data
-// load finishes and someone's been hovering to see what loads), nothing
-// shows until they move away and back. Show it immediately in that case.
+// Shows on hover (as a preview) and pins open on click so it stays visible
+// after the mouse leaves - click again, or click anywhere outside the gem
+// and its popover, to unpin/close it. Uses a manual trigger and drives
+// show/hide ourselves so click-to-pin and hover-preview don't fight each
+// other the way combining Bootstrap's built-in "hover click" triggers does.
 function initGemPopover($gem, options) {
-  $gem.popover(options);
+  $gem.data('lighthouse-pinned', false);
+  $gem.popover(_.extend({}, options, { trigger: 'manual' }));
+
+  $gem.off('.lighthouseGem');
+
+  $gem.on('mouseenter.lighthouseGem', function () {
+    $gem.popover('show');
+  });
+  $gem.on('mouseleave.lighthouseGem', function () {
+    if (!$gem.data('lighthouse-pinned')) {
+      $gem.popover('hide');
+    }
+  });
+  $gem.on('click.lighthouseGem', function (e) {
+    e.stopPropagation();
+    var pinned = !$gem.data('lighthouse-pinned');
+    $gem.data('lighthouse-pinned', pinned);
+    $gem.popover(pinned ? 'show' : 'hide');
+  });
+
+  // Popovers initialized while the cursor is already sitting over the gem
+  // (very likely right as the async data load finishes) miss the next
+  // mouseenter - show immediately in that case.
   if ($gem.is(':hover')) {
     $gem.popover('show');
   }
 }
 
+// Click anywhere outside a pinned gem/popover unpins and closes it.
+$(document).off('click.lighthouseGemsDismiss').on('click.lighthouseGemsDismiss', function (e) {
+  var $target = $(e.target);
+  if ($target.closest('.lighthouse-response-gem').length || $target.closest('.popover').length) {
+    return;
+  }
+  $('.lighthouse-response-gem').each(function () {
+    var $g = $(this);
+    if ($g.data('lighthouse-pinned')) {
+      $g.data('lighthouse-pinned', false);
+      $g.popover('hide');
+    }
+  });
+});
+
+// Delegated (popover content is only in the DOM while shown, so this can't
+// bind directly): opens /Teams/Create with the accepted members' ids, the
+// same lhquickrecipient-style pattern used for the SMS "message a team"
+// button above - teams/create.js's inject script picks the params back up.
+// Also passes the incident's own HQ (entityAssignedTo) so the new team
+// gets assigned to the HQ that owns the incident, not whatever HQ the
+// person creating the team happens to be logged in under.
+$(document).off('click.lighthouseCreateTeam').on('click.lighthouseCreateTeam', '.lighthouse-create-team-btn', function (e) {
+  e.stopPropagation();
+  var memberIds = $(this).data('member-ids');
+  var entityId = masterViewModel.entityAssignedTo.peek() ? masterViewModel.entityAssignedTo.peek().Id : null;
+  window.open(
+    '/Teams/Create?lhmembers=' + escape(JSON.stringify(memberIds)) + '&lhentityid=' + escape(entityId),
+    '_blank',
+  );
+});
+
 // Fills in the response-count gems (below the Incident Details header,
 // built by contentscripts/jobs/view.js) and wires up hover popovers
 // listing the names of the people in each category. Once the activation
-// is closed, gems show `-` instead of a count and skip the name list.
+// is closed, real counts/names still show - a lock icon on the row and a
+// note in each popover just indicate the activation is closed.
 function lighthouseResponseGems() {
   var gemSelectorsByCategory = {
     ActivationAccepted: '#lighthouse-gem-activationaccepted',
@@ -133,11 +188,18 @@ function lighthouseResponseGems() {
     Unset: '#lighthouse-gem-unset',
   };
 
-  $('#lighthouse-response-gems').addClass('is-loading');
+  var $gemsRow = $('#lighthouse-response-gems');
+  $gemsRow.addClass('is-loading');
 
   getJobResponseSummary(jobId, function (err, summary) {
-    $('#lighthouse-response-gems').removeClass('is-loading');
+    $gemsRow.removeClass('is-loading');
     if (err || !summary) return;
+
+    var isClosed = !!summary.closed;
+    $gemsRow.toggleClass('is-closed', isClosed);
+    if (isClosed && $gemsRow.find('.lighthouse-response-gems-closed-icon').length === 0) {
+      $gemsRow.prepend('<em class="fa fa-lock lighthouse-response-gems-closed-icon" title="Activation closed"></em>');
+    }
 
     _.each(gemSelectorsByCategory, function (selector, category) {
       var $gem = $(selector);
@@ -147,25 +209,14 @@ function lighthouseResponseGems() {
         category.replace(/([a-z])([A-Z])/g, '$1 $2');
       var data = (summary.categories && summary.categories[category]) || { Count: 0, Names: [] };
 
-      if (data.Count === null) {
-        $gem.text('-');
-        initGemPopover($gem, {
-          placement: 'bottom',
-          trigger: 'hover',
-          html: true,
-          title: title,
-          content: '<em>Activation closed</em>',
-          container: 'body',
-        });
-        return;
-      }
-
       $gem.text(data.Count);
 
       var MAX_NAMES_SHOWN = 20;
       var namesHtml = data.Names && data.Names.length
-        ? '<ul class="lighthouse-response-gem-names">' + _.map(data.Names.slice(0, MAX_NAMES_SHOWN), function (name) {
-            return '<li>' + _.escape(name) + '</li>';
+        ? '<ul class="lighthouse-response-gem-names">' + _.map(data.Names.slice(0, MAX_NAMES_SHOWN), function (person) {
+            // MemberId travels with each entry for future use (e.g. linking
+            // to a profile) but is deliberately not rendered here.
+            return '<li data-member-id="' + _.escape(person.MemberId) + '">' + _.escape(person.Name) + '</li>';
           }).join('') +
           (data.Names.length > MAX_NAMES_SHOWN
             ? '<li><em>+' + (data.Names.length - MAX_NAMES_SHOWN) + ' more</em></li>'
@@ -173,12 +224,26 @@ function lighthouseResponseGems() {
           '</ul>'
         : '<em>No responders</em>';
 
+      var closedNote = isClosed ? '<div class="lighthouse-response-gem-closed-note"><em>Activation closed</em></div>' : '';
+
+      // Quick path from "who's accepted" straight into a new team - only
+      // makes sense for the ActivationAccepted gem, only when there's
+      // someone to add, and only for users who could actually create a
+      // team in the first place.
+      var createTeamButtonHtml = '';
+      if (category === 'ActivationAccepted' && data.Names && data.Names.length && user.isInRole(Enum.Role.TeamManagement.Id)) {
+        var memberIds = _.map(data.Names, function (person) { return person.MemberId; });
+        createTeamButtonHtml = '<div class="lighthouse-create-team-btn-wrap">' +
+          '<button type="button" class="btn btn-xs btn-primary lighthouse-create-team-btn" data-member-ids="' +
+          _.escape(JSON.stringify(memberIds)) + '">Create Team</button></div>';
+      }
+
       initGemPopover($gem, {
         placement: 'bottom',
         trigger: 'hover',
         html: true,
         title: title,
-        content: namesHtml,
+        content: closedNote + namesHtml + createTeamButtonHtml,
         container: 'body',
       });
     });

--- a/src/injectscripts/teams/create.js
+++ b/src/injectscripts/teams/create.js
@@ -1,4 +1,4 @@
-/* global teamViewModel, $ */
+/* global teamViewModel, $, _, ko */
 //edit and create page.
 // background js fiddles with create page to expose same viewmodel as OutageDisplayType
 
@@ -8,6 +8,88 @@ var callsign = teamViewModel.callsign.peek();
 if (typeof callsign !== 'undefined' && callsign !== null) {
   document.title = callsign;
 }
+
+//prefill members from a ?lhmembers=[id,id,...] param - same
+//lhquickrecipient-style pattern messages/create.js uses for jobId/recipients
+function parse_query_string(query) {
+  var vars = query.split('&');
+  var query_string = {};
+  for (var i = 0; i < vars.length; i++) {
+    var pair = vars[i].split('=');
+    if (typeof query_string[pair[0]] === 'undefined') {
+      query_string[pair[0]] = decodeURIComponent(pair[1]);
+    } else if (typeof query_string[pair[0]] === 'string') {
+      var arr = [query_string[pair[0]], decodeURIComponent(pair[1])];
+      query_string[pair[0]] = arr;
+    } else {
+      query_string[pair[0]].push(decodeURIComponent(pair[1]));
+    }
+  }
+  return query_string;
+}
+
+// memberId here is a RegistrationNumber (mams's identifier), not Beacon's
+// internal Person.Id, so lookup goes through PersonManager.SearchPeople.
+// ViewModelType: 3 (Enum.PeopleViewModelType.Team.Id, same type
+// loadPeople() requests) gets back a person shaped correctly to add
+// straight to the team, no separate GetPersonById needed. Prefer an
+// already-loaded person from teamViewModel.people() when there's a match
+// (has isSelected wired up already); otherwise the search result needs
+// isSelected manually attached as a ko.observable before addPersonToTeam
+// can call person.isSelected(true) on it.
+async function addTeamMemberById(memberId) {
+  var matched = _.find(teamViewModel.people(), function (p) { return String(p.RegistrationNumber) === String(memberId); });
+
+  if (!matched) {
+    try {
+      var searchResponse = await teamViewModel.PersonManager.SearchPeople({ RegistrationNumber: String(memberId), ViewModelType: 2 });
+      var data = searchResponse && searchResponse.Results && searchResponse.Results[0];
+      if (!data) {
+        console.log('lighthouse: could not find person for registration number ' + memberId + ' to add to team');
+        return;
+      }
+      data.isSelected = ko.observable(false);
+      matched = data;
+    } catch (err) {
+      console.log('lighthouse: error looking up person ' + memberId + ' to add to team - ' + (err && err.message));
+      return;
+    }
+  }
+
+  teamViewModel.addPersonToTeam(matched);
+}
+
+// Sets the team's Assigned To HQ to the incident's own HQ (rather than
+// leaving it defaulted to whatever HQ the person creating the team is
+// logged in under) - GetEntityById is async and resolves to the full
+// entity object entityAssignedTo expects, not just an id.
+async function setTeamEntityById(entityId) {
+  try {
+    var entity = await teamViewModel.EntityManager.GetEntityById(entityId);
+    if (entity) {
+      teamViewModel.entityAssignedTo(entity);
+    }
+  } catch (err) {
+    console.log('lighthouse: error loading entity ' + entityId + ' to assign team to - ' + (err && err.message));
+  }
+}
+
+$(document).ready(function () {
+  var query = window.location.search.substring(1);
+  if (!query) return;
+  var qs = parse_query_string(query);
+
+  if (typeof qs.lhmembers !== 'undefined') {
+    var memberIds = JSON.parse(unescape(qs.lhmembers));
+    $.each(memberIds, function (k, memberId) {
+      addTeamMemberById(memberId);
+    });
+  }
+
+  if (typeof qs.lhentityid !== 'undefined' && qs.lhentityid !== 'null') {
+    setTeamEntityById(unescape(qs.lhentityid));
+  }
+});
 
 //when team members change
 teamViewModel.members.subscribe(function() {

--- a/src/styles/jobs.view.css
+++ b/src/styles/jobs.view.css
@@ -162,11 +162,11 @@
   cursor: default;
 }
 
-.lighthouse-response-gem:first-child {
+.lighthouse-response-gem:first-of-type {
   border-radius: 4px 0 0 4px;
 }
 
-.lighthouse-response-gem:last-child {
+.lighthouse-response-gem:last-of-type {
   border-radius: 0 4px 4px 0;
 }
 
@@ -181,6 +181,16 @@
   50% {
     opacity: 0.35;
   }
+}
+
+.lighthouse-response-gems-closed-icon {
+  color: #555555;
+  font-size: 12px;
+  margin-right: 6px;
+}
+
+.lighthouse-response-gem-closed-note {
+  margin-bottom: 4px;
 }
 
 .lighthouse-response-gem-activationaccepted {
@@ -206,4 +216,11 @@
 .lighthouse-response-gem-names {
   margin: 0;
   padding-left: 18px;
+}
+
+.lighthouse-create-team-btn-wrap {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid #e5e5e5;
+  text-align: right;
 }

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -121,7 +121,8 @@
     {
       "matches": [
         "https://*.ses.nsw.gov.au/Teams/Create",
-        "https://*.ses.nsw.gov.au/Teams/Create/"
+        "https://*.ses.nsw.gov.au/Teams/Create/",
+        "https://*.ses.nsw.gov.au/Teams/Create?*"
       ],
       "js": ["contentscripts/teams/create.js"]
     },


### PR DESCRIPTION
This pull request introduces several improvements to the job response summary and team creation workflow, focusing on better user experience and streamlined workflows for creating teams from activation-accepted responders. The most significant changes include adding a "Create Team" button directly to the activation-accepted popover, handling activation-closed states more clearly, and supporting pre-filling the team creation form with selected members and the correct HQ.

**Enhancements to job response popovers and team creation:**

* Added a "Create Team" button to the `ActivationAccepted` response gem's popover, which is only shown to users with team management permissions and when there are accepted responders. Clicking this button opens the team creation page with the selected members prefilled. [[1]](diffhunk://#diff-f657e495cc71938d71934b257ceeee9c47794798bd838b9807e3b89757513349L150-R246) [[2]](diffhunk://#diff-f657e495cc71938d71934b257ceeee9c47794798bd838b9807e3b89757513349L111-R181)
* Updated the structure of the `Names` array in job response summaries to include `MemberId` alongside `Name`, enabling member identification for team creation and future features.

**Activation closed state improvements:**

* When an activation is closed, the response gems now display a lock icon and a note in each popover, rather than hiding counts or names, for clearer communication to users. [[1]](diffhunk://#diff-f657e495cc71938d71934b257ceeee9c47794798bd838b9807e3b89757513349L136-R203) [[2]](diffhunk://#diff-f657e495cc71938d71934b257ceeee9c47794798bd838b9807e3b89757513349L150-R246) [[3]](diffhunk://#diff-5f64c82b69193d6aae61763842a874b4e158b5ee734de6235da5101994a4554aR186-R195)

**Team creation page enhancements:**

* The team creation page (`Teams/Create`) now supports pre-filling members and the assigned HQ via URL parameters (`lhmembers`, `lhentityid`). This includes logic to look up and add members by registration number and assign the correct HQ entity. [[1]](diffhunk://#diff-479a8882c194509bac1cb167d7bc9eb293b15c9fcca27f45887db80fdef57da1R12-R93) [[2]](diffhunk://#diff-c0eb04b279c83eb3e6113c1ec2beeac82c6526bc38ba5287f1a59d236204ba14L124-R125)

**UI and style improvements:**

* Added and adjusted CSS for the lock icon, closed-state notes, and the new "Create Team" button for consistent and clear UI presentation. [[1]](diffhunk://#diff-5f64c82b69193d6aae61763842a874b4e158b5ee734de6235da5101994a4554aR186-R195) [[2]](diffhunk://#diff-5f64c82b69193d6aae61763842a874b4e158b5ee734de6235da5101994a4554aR220-R226) [[3]](diffhunk://#diff-5f64c82b69193d6aae61763842a874b4e158b5ee734de6235da5101994a4554aL165-R169)

These changes collectively streamline the workflow for creating teams from incident responders and improve the clarity of activation status in the UI.