### PR TITLE
Add closed-state, pinning, and Create Team action to myAvailability gems

### DIFF
--- a/src/injectscripts/jobs/view.js
+++ b/src/injectscripts/jobs/view.js
@@ -119,16 +119,45 @@ function initGemPopover($gem, options) {
 
   $gem.off('.lighthouseGem');
 
+  var hideTimer = null;
+  function cancelHide() {
+    if (hideTimer) {
+      clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+  }
+  function scheduleHide() {
+    cancelHide();
+    hideTimer = setTimeout(function () {
+      if (!$gem.data('lighthouse-pinned')) {
+        $gem.popover('hide');
+      }
+    }, 200);
+  }
+
   $gem.on('mouseenter.lighthouseGem', function () {
+    cancelHide();
     $gem.popover('show');
   });
-  $gem.on('mouseleave.lighthouseGem', function () {
-    if (!$gem.data('lighthouse-pinned')) {
-      $gem.popover('hide');
+  // The popover panel itself is a separate element appended to <body>, not
+  // a child of the gem - moving the mouse from the gem into the panel is a
+  // real mouseleave on the gem, so without this the popover would vanish
+  // the instant the cursor crosses into it. Track hover on the panel too
+  // (bound once it actually exists, via shown.bs.popover) and use a short
+  // delay before hiding so crossing the gap between the two is forgiving.
+  $gem.on('shown.bs.popover.lighthouseGem', function () {
+    var popoverInstance = $gem.data('bs.popover');
+    var $tip = popoverInstance && (popoverInstance.$tip || (popoverInstance.tip && popoverInstance.tip()));
+    if ($tip && $tip.length) {
+      $tip.off('.lighthouseGem');
+      $tip.on('mouseenter.lighthouseGem', cancelHide);
+      $tip.on('mouseleave.lighthouseGem', scheduleHide);
     }
   });
+  $gem.on('mouseleave.lighthouseGem', scheduleHide);
   $gem.on('click.lighthouseGem', function (e) {
     e.stopPropagation();
+    cancelHide();
     var pinned = !$gem.data('lighthouse-pinned');
     $gem.data('lighthouse-pinned', pinned);
     $gem.popover(pinned ? 'show' : 'hide');


### PR DESCRIPTION
## Summary
- Response gems now show real counts/names even when the activation is closed (a lock icon + popover note indicate closed status instead of blanking the numbers)
- Popovers pin open on click (stay visible after the mouse leaves) instead of only showing on hover; click again or click elsewhere to unpin. Also fixes a flicker where moving the cursor from the gem into the popover panel would hide it instantly.
- Each name carries its member id (not displayed) for future use, and long name lists are capped at 20 with a "+N more" indicator
- Popover titles are branded ("myAvailability: <Category>") with the Lighthouse logo, and camelCase categories are spaced for display
- Adds a "Create Team" button on the Activation Accepted gem (only shown when there's someone to add, and gated on `user.isInRole(Enum.Role.TeamManagement.Id)`) that opens `/Teams/Create` pre-filled with the accepted members (via `PersonManager.SearchPeople`) and the incident's own HQ (via `EntityManager.GetEntityById`)
- `static/manifest.json`: added the `Teams/Create?*` match pattern needed for the content script to inject when a query string is present (mirrors the existing `Messages/Create` pattern)

## Test plan
- [ ] Load a job/incident page and confirm the gems still render and hover/pin behavior works, including crossing from the gem into the popover without it disappearing
- [ ] Confirm a closed activation shows real counts with the lock icon + "Activation closed" popover note
- [ ] As a user with Team Management permission, click "Create Team" on the Activation Accepted gem and confirm the new tab opens at `/Teams/Create` with the accepted members added and the correct HQ assigned
- [ ] As a user without Team Management permission, confirm the "Create Team" button does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)