### PR TITLE
Bump actions/checkout and chrome-extension-upload to Node 24 versions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install modules

--- a/.github/workflows/publish_dev.yml
+++ b/.github/workflows/publish_dev.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install modules
@@ -17,7 +17,7 @@ jobs:
       - name: Build package
         run: npm run dev
       - name: Chrome extension upload action
-        uses: mnao305/chrome-extension-upload@v4.0.1
+        uses: mnao305/chrome-extension-upload@v6.0.0
         with:
           file-path: build/*.zip
           extension-id: ${{ secrets.CHROMESTORE_DEV_ID }}

--- a/.github/workflows/publish_prod.yml
+++ b/.github/workflows/publish_prod.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install modules
@@ -18,7 +18,7 @@ jobs:
       - name: Build Package
         run: npm run prod
       - name: Chrome extension upload action
-        uses: mnao305/chrome-extension-upload@v4.0.1
+        uses: mnao305/chrome-extension-upload@v6.0.0
         with:
           file-path: build/*.zip
           extension-id: ${{ secrets.CHROMESTORE_PROD_ID }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from `v3` to `v7` in `linter.yml`, `publish_dev.yml`, `publish_prod.yml`
- Bump `mnao305/chrome-extension-upload` from `v4.0.1` to `v6.0.0` in `publish_dev.yml`, `publish_prod.yml`
- Both new versions target Node 24 natively, resolving the "Node.js 20 is deprecated" warning GitHub Actions was emitting when force-running these actions on Node 24

## Test plan
- [x] Confirm `Linter` workflow runs clean on this PR
- [x] Manually trigger `Publish Dev` workflow and confirm no deprecation warning and successful Chrome Store upload