### PR TITLE
Match dev build version format to prod

### DIFF
--- a/src/injectscripts/jobs/view.js
+++ b/src/injectscripts/jobs/view.js
@@ -255,12 +255,12 @@ function lighthouseResponseGems() {
 
       var closedNote = isClosed ? '<div class="lighthouse-response-gem-closed-note"><em>Activation closed</em></div>' : '';
 
-      // Quick path from "who's accepted" straight into a new team - only
-      // makes sense for the ActivationAccepted gem, only when there's
-      // someone to add, and only for users who could actually create a
-      // team in the first place.
+      // Quick path from "who's accepted/available" straight into a new
+      // team - only makes sense for the ActivationAccepted and Available
+      // gems, only when there's someone to add, and only for users who
+      // could actually create a team in the first place.
       var createTeamButtonHtml = '';
-      if (category === 'ActivationAccepted' && data.Names && data.Names.length && user.isInRole(Enum.Role.TeamManagement.Id)) {
+      if ((category === 'ActivationAccepted' || category === 'Available') && data.Names && data.Names.length && user.isInRole(Enum.Role.TeamManagement.Id)) {
         var memberIds = _.map(data.Names, function (person) { return person.MemberId; });
         createTeamButtonHtml = '<div class="lighthouse-create-team-btn-wrap">' +
           '<button type="button" class="btn btn-xs btn-primary lighthouse-create-team-btn" data-member-ids="' +

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,7 +6,7 @@ const moment = require('moment');
 
 const packageName = "Lighthouse Development Preview"
 const now = new moment();
-const versionString = now.utcOffset("+10:00").format('YYYY.MM.DD.HHmm')
+const versionString = now.utcOffset("+10:00").format('YYYY.M.D.Hm')
 const versionStringShort = now.utcOffset("+10:00").format('YYYY.MM.DD')
 
 // get git info from command line

--- a/webpack.watch.js
+++ b/webpack.watch.js
@@ -5,7 +5,7 @@ const moment = require('moment');
 
 const packageName = "Lighthouse Development Preview"
 const now = new moment();
-const versionString = now.format('YYYY.MM.DD.HHmm')
+const versionString = now.format('YYYY.M.D.Hm')
 const versionStringShort = now.utcOffset("+10:00").format('YYYY.MM.DD')
 
 // get git info from command line


### PR DESCRIPTION
## Summary
- Dev/watch builds zero-padded the version timestamp (`2026.08.16.0941`), which Chrome then displays with leading zeros stripped per segment (`2026.8.16.941`), making the on-disk manifest look out of sync with `chrome://extensions`. Align dev/watch with prod's unpadded `YYYY.M.D.Hm` format.
- Extend the "create team from responders" quick-action button to the `Available` gem, not just `ActivationAccepted`.

## Test plan
- [ ] `npm run dev` / `npm run start`, load unpacked extension, confirm version in `chrome://extensions` matches `dist/manifest.json`
- [ ] Verify "Create Team" button appears on both ActivationAccepted and Available response gems on a job view page

🤖 Generated with [Claude Code](https://claude.com/claude-code)