### PR TITLE
Highlight FR-1 rows and shore up push-notification reliability on tasking

### DIFF
--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -948,6 +948,14 @@ function VM() {
 
         end.setDate(end.getDate() + self.config.fetchForward());
 
+        // Same drift/clock-skew allowance as start, above -- without it, a
+        // job admitted via push the instant it's created (jobReceived from
+        // the notification's own CreatedOn, essentially "now") sits right
+        // on the end boundary, and a few hundred ms of processing lag or
+        // any client/server clock skew is enough to flip jobDate > end and
+        // evict it (confirmed live: fetchForward=0 gave zero tolerance).
+        end.setMinutes(end.getMinutes() + 5);
+
         const statusName = jb.statusName();
         const jobHqId = String(jb.entityAssignedTo.id());
         const hqMatch = hqIds.size === 0 || hqIds.has(jobHqId);
@@ -970,8 +978,17 @@ function VM() {
             return false;
         }
 
-        // If incident type filter non-empty, only show jobs whose type is in it
-        if (incidentTypeSet.size > 0 && !incidentTypeSet.has(String(jb.typeId()))) {
+        // If incident type filter non-empty, only show jobs whose type is in
+        // it -- but only reject when we actually know the type. A job built
+        // straight from the jobCreated notification has no type information
+        // at all (unlike status/priority, there's no id to resolve either),
+        // so typeId() is "" until refreshData() backfills it; treating that
+        // as "known not to match" would evict every new job whenever any
+        // type filter is active. isFilteredIn corrects itself reactively
+        // once the real type lands, so being lenient here at admission time
+        // costs nothing beyond a job briefly sitting untracked-by-filter.
+        const typeId = jb.typeId();
+        if (incidentTypeSet.size > 0 && typeId && !incidentTypeSet.has(String(typeId))) {
             return false;
         }
 
@@ -2973,6 +2990,11 @@ function VM() {
 
             myViewModel._markInitialFetchDone();
             myViewModel.jobsLoading(false);
+            // Runs here (not alongside the fetchAllJobsData() call itself)
+            // so it sees this cycle's actual results -- fetchAllJobsData is
+            // async and its merges land in this callback, after the network
+            // round-trip, not synchronously when it's called.
+            self.fetchAllUnacceptedNotifications();
         }, function (_val, _total) {
             //console.log("Progress: " + _val + " / " + _total)
         }, function (jobs) { //call back as they come in per page
@@ -3060,6 +3082,16 @@ function VM() {
     };
 
 
+    // No batch API exists for unaccepted notifications (unlike tasking),
+    // so this is still one REST call per ICEMS job -- but triggered by the
+    // shared jobs/teams refresh cycle below instead of each job running its
+    // own independent 30s timer.
+    self.fetchAllUnacceptedNotifications = function () {
+        self.filteredJobs().forEach(job => {
+            if (job.icemsIncidentIdentifier()) job.refreshUnacceptedNotifications();
+        });
+    };
+
     // ---------------- REFRESH TIMER FOR JOBS + TEAMS -----------------
 
     let jobsTeamsTimer = null;
@@ -3071,7 +3103,7 @@ function VM() {
         const interval = effectiveRefreshIntervalMs();
 
         jobsTeamsTimer = setInterval(() => {
-            self.fetchAllJobsData();
+            self.fetchAllJobsData(); // triggers fetchAllUnacceptedNotifications itself, once its results land
             self.fetchAllTeamData();
         }, interval);
 
@@ -3132,7 +3164,7 @@ function VM() {
     self.UserPressedSaveOnTheConfigModal = function () {
         //re-fetch data based on new config
         initialFetchesPending = 2; // teams, jobs
-        self.fetchAllJobsData();
+        self.fetchAllJobsData(); // triggers fetchAllUnacceptedNotifications itself, once its results land
         self.fetchAllTeamData();
         self.fetchAllTrackableAssets();
 
@@ -3837,9 +3869,26 @@ document.addEventListener('DOMContentLoaded', function () {
             EntityAssignedTo: n.Entity,
         });
 
+        // JobReceived isn't in any of these notifications at all -- without
+        // it, jobMatchesConfigFilters' date check always fails (new
+        // Date(null) is epoch, always outside the configured range), so a
+        // brand-new admission would get silently evicted instead of
+        // admitted. The notification's own CreatedOn is a reasonable proxy.
+        // Only applied when not already tracked -- otherwise this would
+        // clobber an existing job's real jobReceived with the
+        // notification's timestamp. Applies to jobUpdated/jobRejected too,
+        // not just jobCreated: a job evicted while "New" (outside the
+        // status filter) hits this same first-admission path again the
+        // moment a later jobUpdated brings its status back into scope.
+        const withJobReceivedFallback = (jobJson, notification, alreadyTracked) => {
+            if (!alreadyTracked) jobJson.JobReceived = notification.CreatedOn;
+            return jobJson;
+        };
+
         const admitJobIfInFilter = (notification) => {
             const jobJson = mapJobNotificationToJobJson(notification);
             const alreadyTracked = myViewModel.jobsById.has(jobJson.Id);
+            withJobReceivedFallback(jobJson, notification, alreadyTracked);
             const job = myViewModel.getOrCreateJob(jobJson);
             if (!alreadyTracked && !myViewModel.jobMatchesConfigFilters(job)) {
                 myViewModel.jobsById.delete(job.id());
@@ -3859,6 +3908,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const admitJobCreatedIfInFilter = (notification) => {
             const jobJson = mapJobNotificationToJobJson(notification);
             const alreadyTracked = myViewModel.jobsById.has(jobJson.Id);
+            withJobReceivedFallback(jobJson, notification, alreadyTracked);
             const job = myViewModel.getOrCreateJob(jobJson);
             if (alreadyTracked) return; // duplicate/late delivery, already handled elsewhere
 
@@ -3969,12 +4019,7 @@ document.addEventListener('DOMContentLoaded', function () {
         // either a new IUM arriving or an existing one being acknowledged
         // (by us or someone else) without needing to distinguish which.
         const refreshUnacceptedNotificationsFromPush = (message) => {
-            const job = myViewModel.jobsById.get(message.JobId);
-            job?.refreshUnacceptedNotifications();
-            // Push already did what the 30s poll would have -- re-arm it
-            // for another full 30s from now instead of letting it fire
-            // again moments later.
-            job?.resetUnacceptedNotificationsPolling();
+            myViewModel.jobsById.get(message.JobId)?.refreshUnacceptedNotifications();
         };
         getSubject('NotificationAcknowledged').subscribe(refreshUnacceptedNotificationsFromPush);
         getSubject('IUMReceived').subscribe(refreshUnacceptedNotificationsFromPush);

--- a/src/pages/tasking/models/Job.js
+++ b/src/pages/tasking/models/Job.js
@@ -72,8 +72,13 @@ export function Job(data = {}, deps = {}) {
     self.permissionToEnterPremises = ko.observable(!!data.PermissionToEnterPremises);
     self.howToEnterPremises = ko.observable(data.HowToEnterPremises ?? null);
     self.jobReceived = ko.observable(data.JobReceived ?? null);
-    self.jobPriorityType = ko.observable(data.JobPriorityType || null); // {Id,Name,Description}
-    self.jobStatusType = ko.observable(data.JobStatusType || null);     // {Id,Name,Description}
+    // Some sources (e.g. the jobCreated/jobUpdated push notification) only
+    // carry JobPriorityTypeId/JobStatusTypeId, not the full object -- same
+    // fallback updateFromJson uses below, so a job constructed straight
+    // from one of those isn't left with a blank status/priority (which
+    // would otherwise fail jobMatchesConfigFilters' status check).
+    self.jobPriorityType = ko.observable(data.JobPriorityType || _resolveEnumById(Enum.JobPriorityType, data.JobPriorityTypeId) || null); // {Id,Name,Description}
+    self.jobStatusType = ko.observable(data.JobStatusType || _resolveEnumById(Enum.JobStatusType, data.JobStatusTypeId) || null);     // {Id,Name,Description}
     self.jobType = ko.observable(data.JobType || null);                 // {Id,Name,...}
     self.entityAssignedTo = new Entity(data.EntityAssignedTo || {});
     self.lga = ko.observable(data.LGA ?? "");
@@ -316,6 +321,8 @@ export function Job(data = {}, deps = {}) {
     self.tagsCsv = ko.pureComputed(() => self.tags().map(t => t.name()).join(", "));
     self.receivedAt = ko.pureComputed(() => (self.jobReceived() ? moment(self.jobReceived()).format("DD/MM/YYYY HH:mm:ss") : null));
     self.receivedAtShort = ko.pureComputed(() => (self.jobReceived() ? moment(self.jobReceived()).format("DD/MM/YY HH:mm:ss") : null));
+    self.receivedAtTimeShort = ko.pureComputed(() => (self.jobReceived() ? moment(self.jobReceived()).format("HH:mm:ss") : null));
+    self.receivedAtDateShort = ko.pureComputed(() => (self.jobReceived() ? moment(self.jobReceived()).format("DD/MM/YY") : null));
     self.latLongDisplay = ko.pureComputed(function () {
         var lat = self.address.latitude();
         var lng = self.address.longitude();
@@ -387,6 +394,9 @@ export function Job(data = {}, deps = {}) {
         return moment(self.lastDataUpdate()).fromNow();
     });
 
+    // No per-job timer -- refreshed as part of the shared jobs/teams refresh
+    // cycle (fetchAllUnacceptedNotifications in main.js) and by push
+    // (NotificationAcknowledged/IUMReceived/UrgentIUMReceived).
     self.refreshUnacceptedNotifications = async function () {
         if (!self.icemsIncidentIdentifier()) return;
 
@@ -425,26 +435,6 @@ export function Job(data = {}, deps = {}) {
     };
 
 
-    // ---- UNACCEPTED NOTIFICATIONS POLLING ----
-    const unacceptedNotificationsInterval = makeFilteredInterval(() => {
-        // extra guard: only if ICEMS id exists
-        if (!self.icemsIncidentIdentifier()) return;
-        console.log("Polling unaccepted notifications for job", self.id());
-        self.refreshUnacceptedNotifications();
-    }, 30000, { runImmediately: true });
-
-    self.startUnacceptedNotificationsPolling = function () {
-        unacceptedNotificationsInterval.start();
-    };
-
-    self.stopUnacceptedNotificationsPolling = function () {
-        unacceptedNotificationsInterval.stop();
-    };
-
-    self.resetUnacceptedNotificationsPolling = function () {
-        unacceptedNotificationsInterval.reset();
-    };
-
     // ICEMS agency data: refreshed when the job is expanded (toggleAndLoad)
     // and by push (rsuReceived/iuaReceived/isuReceived in main.js) -- no
     // periodic poll. Push calls pass force:true (an authoritative "this
@@ -472,19 +462,6 @@ export function Job(data = {}, deps = {}) {
         }
     };
 
-
-    // Unaccepted notifications polling: filtered in + ICEMS id (original logic)
-    self.shouldPollUnacceptedNotifications = ko.pureComputed(() => {
-        return self.icemsIncidentIdentifier() && self.isFilteredIn();
-    });
-
-    self.shouldPollUnacceptedNotifications.subscribe((shouldPoll) => {
-        if (shouldPoll) {
-            self.startUnacceptedNotificationsPolling();
-        } else {
-            self.stopUnacceptedNotificationsPolling();
-        }
-    });
 
     self.toggleAndLoad = function () {
         if (!self.expanded()) {
@@ -575,6 +552,9 @@ export function Job(data = {}, deps = {}) {
     });
 
     self.rowColour = ko.pureComputed(() => {
+        if (self.priorityName() === 'Rescue' && self.typeName() === 'FR' && self.categoriesName() === 'Category1') {
+            return 'row-rescue-fr1';
+        }
         switch (self.priorityName()) {
             case 'Rescue': return 'row-rescue';
             case 'Priority': return 'row-priority';
@@ -883,6 +863,18 @@ export function Job(data = {}, deps = {}) {
         self.refreshIcemsIncident(opts);
     }
 
+    // Manual "refresh this incident" trigger (see the refresh button next to
+    // "Refreshed X ago" in tasking.html) -- forced, since a deliberate click
+    // should never silently no-op because of a cooldown meant to dedupe
+    // background timer/push refreshes. Covers every piece of a job's data,
+    // including unaccepted notifications, which refreshDataAndTasking
+    // doesn't (that one's also used by paths that shouldn't imply "and
+    // check ICEMS notifications too").
+    self.refreshAllData = function () {
+        self.refreshDataAndTasking({ force: true });
+        self.refreshUnacceptedNotifications();
+    }
+
     self.fetchTasking = function (opts = {}) {
         const force = opts.force === true;
         if (!force) {
@@ -918,45 +910,6 @@ export function Job(data = {}, deps = {}) {
         });
     };
 
-
-    // interval that only runs while job is filtered in
-    function makeFilteredInterval(fn, intervalMs, { runImmediately = false } = {}) {
-        let handle = null;
-
-        const tick = () => {
-            // global guard: only run if still filtered in
-            if (!self.isFilteredIn()) return;
-            fn();
-        };
-
-        const start = () => {
-            if (!self.isFilteredIn()) return; // don't start if already filtered out
-            if (handle) clearInterval(handle);
-            if (runImmediately) tick();
-            handle = setInterval(tick, intervalMs);
-        };
-
-        const stop = () => {
-            if (handle) {
-                clearInterval(handle);
-                handle = null;
-            }
-        };
-
-        // Re-arms the interval for another full intervalMs from now, without
-        // firing immediately (unlike start()) -- for when something else
-        // (e.g. a push) already just did what this timer would have done,
-        // so the next scheduled tick shouldn't land moments later. Only has
-        // an effect if already polling; never starts a new poll.
-        const reset = () => {
-            if (!handle) return;
-            if (!self.isFilteredIn()) return;
-            clearInterval(handle);
-            handle = setInterval(tick, intervalMs);
-        };
-
-        return { start, stop, reset };
-    }
 
 }
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -18,16 +18,16 @@
         <aside class="sidebar"><!-- fixed-width column in tasking.css -->
             <div class="pane pane--top" id="paneTop">
                 <!-- TEAMS (top pane) -->
-                <div class="d-flex align-items-center justify-content-between px-2">
+                <div class="d-flex align-items-center justify-content-between px-2 pane-toolbar">
                     <div
-                        class="d-flex align-items-center gap-2 flex-grow-1 small fw-semibold text-center text-muted incidents-header">
+                        class="d-flex align-items-center gap-2 flex-grow-1 small fw-semibold text-center text-muted incidents-header toolbar-label">
                         <div class="flex-grow-1 d-flex justify-content-center">
                             <span>Teams (<span data-bind="text: filteredTeams().length"></span>)</span>
                         </div>
                     </div>
 
                     <div class="d-flex align-items-center gap-2">
-                        <div class="input-group input-group-sm" style="width:250px;">
+                        <div class="input-group input-group-sm toolbar-search">
                             <span class="input-group-text py-0 px-1"><i class="fa fa-search"></i></span>
                             <input type="search" id="teamSearch" class="form-control form-control-sm py-0"
                                 placeholder="Search" data-bind="value: teamSearch, valueUpdate: 'input'">
@@ -39,20 +39,20 @@
                             data-bind="click: togglePinnedTeamsOnly, css: { active: showPinnedTeamsOnly }, disable: !countPinnedTeams()">
                             <i class="fa fa-star fa-center"></i>
                         </button>
-                            <button class="btn btn-sm btn-outline-secondary py-0 px-2" title="Ops Log"
+                            <button class="btn btn-sm btn-outline-secondary py-0 px-2 toolbar-collapsible" title="Ops Log"
                                 data-bind="click: openBlankOpsLogModal">
                                 <span class="position-relative d-inline-block" style="left: -4px; width:1.5em; height:1em; line-height:1;" aria-hidden="true">
                                     <i class="fa fa-book"></i>
                                     <i class="fa fa-plus position-absolute" style="top:-1px; left:19px; font-size:0.7em;"></i>
                                 </span>
                             </button>
-                        <button class="btn btn-sm btn-outline-secondary py-0 px-2" title="Radio Log"
+                        <button class="btn btn-sm btn-outline-secondary py-0 px-2 toolbar-collapsible" title="Radio Log"
                             data-bind="click: openBlankRadioOpsLogModal">
                             <span class="position-relative d-inline-block" style="left: -3px; width:1.5em; height:1em; line-height:1;" aria-hidden="true">
                                 <i class="fa fa-microphone"></i>
                                 <i class="fa fa-plus position-absolute" style="top:-1px; left:18px; font-size:0.7em;"></i>
                             </span>
-                        </button>                    
+                        </button>
                         <div class="dropdown">
                             <button class="btn btn-sm btn-outline-secondary dropdown-toggle py-0 px-2" type="button"
                                 id="teamMenu" data-bs-toggle="dropdown" data-bs-auto-close="outside"
@@ -162,11 +162,29 @@
                             click: fetchAllTeamData,
                             disable: teamsLoading">
                             <i class="fa fa-sync" data-bind="css: { 'fa-spin': teamsLoading }"></i>
-                        </button>                        
-                        <button class="btn btn-sm btn-outline-secondary py-0 px-2" title="Page Config"
+                        </button>
+                        <button class="btn btn-sm btn-outline-secondary py-0 px-2 toolbar-collapsible" title="Page Config"
                             data-bs-toggle="modal" data-bs-target="#configModal">
                             <i class="fa fa-cog"></i>
                         </button>
+                        <div class="dropdown toolbar-overflow">
+                            <button class="btn btn-sm btn-outline-secondary py-0 px-2" type="button"
+                                id="teamToolbarOverflow" data-bs-toggle="dropdown" aria-expanded="false"
+                                title="More actions">
+                                <i class="fa fa-ellipsis-v"></i>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="teamToolbarOverflow">
+                                <li><button class="dropdown-item" type="button"
+                                        data-bind="click: openBlankOpsLogModal"><i class="fa fa-book me-2"></i>Ops
+                                        Log</button></li>
+                                <li><button class="dropdown-item" type="button"
+                                        data-bind="click: openBlankRadioOpsLogModal"><i
+                                            class="fa fa-microphone me-2"></i>Radio Log</button></li>
+                                <li><button class="dropdown-item" type="button" data-bs-toggle="modal"
+                                        data-bs-target="#configModal"><i class="fa fa-cog me-2"></i>Page
+                                        Config</button></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
                 <div class="table-responsive team-table-container">
@@ -729,15 +747,15 @@
 
             <div class="pane pane--bottom" id="paneBottom">
                 <!-- JOBS (bottom pane) -->
-                <div class="d-flex align-items-center justify-content-between px-2">
+                <div class="d-flex align-items-center justify-content-between px-2 pane-toolbar">
                     <div
-                        class="d-flex align-items-center gap-2 flex-grow-1 small fw-semibold text-center text-muted incidents-header">
+                        class="d-flex align-items-center gap-2 flex-grow-1 small fw-semibold text-center text-muted incidents-header toolbar-label">
                         <div class="flex-grow-1 d-flex justify-content-center">
                             <span>Incidents (<span data-bind="text: filteredJobs().length"></span>)</span>
                         </div>
                     </div>
                     <div class="d-flex align-items-center gap-2">
-                        <div class="position-relative" style="width:250px;">
+                        <div class="position-relative toolbar-search">
                             <div class="input-group input-group-sm">
                                 <span class="input-group-text py-0 px-1"><i class="fa fa-search"></i></span>
                                 <input type="search" id="jobSearch" class="form-control form-control-sm py-0"
@@ -762,14 +780,14 @@
                             data-bind="click: togglePinnedIncidentsOnly, css: { active: showPinnedIncidentsOnly }, disable: !countPinnedIncidents()">
                             <i class="fa fa-star fa-center"></i>
                         </button>
-                        <button class="btn btn-sm btn-outline-secondary py-0 px-2" title="Ops Log"
+                        <button class="btn btn-sm btn-outline-secondary py-0 px-2 toolbar-collapsible" title="Ops Log"
                             data-bind="click: openBlankOpsLogModal">
                                 <span class="position-relative d-inline-block" style="left: -4px; width:1.5em; height:1em; line-height:1;" aria-hidden="true">
                                     <i class="fa fa-book"></i>
                                     <i class="fa fa-plus position-absolute" style="top:-1px; left:19px; font-size:0.7em;"></i>
                                 </span>
                         </button>
-                        <button class="btn btn-sm btn-outline-secondary py-0 px-2" title="Radio Log"
+                        <button class="btn btn-sm btn-outline-secondary py-0 px-2 toolbar-collapsible" title="Radio Log"
                             data-bind="click: openBlankRadioOpsLogModal">
                             <span class="position-relative d-inline-block" style="left: -2px; width:1.5em; height:1em; line-height:1;" aria-hidden="true">
                                 <i class="fa fa-microphone"></i>
@@ -968,10 +986,28 @@
                             disable: jobsLoading">
                             <i class="fa fa-sync" data-bind="css: { 'fa-spin': jobsLoading }"></i>
                         </button>
-                        <button class="btn btn-sm btn-outline-secondary py-0 px-2" title="Page Config"
+                        <button class="btn btn-sm btn-outline-secondary py-0 px-2 toolbar-collapsible" title="Page Config"
                             data-bs-toggle="modal" data-bs-target="#configModal">
                             <i class="fa fa-cog"></i>
                         </button>
+                        <div class="dropdown toolbar-overflow">
+                            <button class="btn btn-sm btn-outline-secondary py-0 px-2" type="button"
+                                id="jobToolbarOverflow" data-bs-toggle="dropdown" aria-expanded="false"
+                                title="More actions">
+                                <i class="fa fa-ellipsis-v"></i>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="jobToolbarOverflow">
+                                <li><button class="dropdown-item" type="button"
+                                        data-bind="click: openBlankOpsLogModal"><i class="fa fa-book me-2"></i>Ops
+                                        Log</button></li>
+                                <li><button class="dropdown-item" type="button"
+                                        data-bind="click: openBlankRadioOpsLogModal"><i
+                                            class="fa fa-microphone me-2"></i>Radio Log</button></li>
+                                <li><button class="dropdown-item" type="button" data-bs-toggle="modal"
+                                        data-bs-target="#configModal"><i class="fa fa-cog me-2"></i>Page
+                                        Config</button></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
                 <div class="table-responsive job-table-container">
@@ -987,9 +1023,9 @@
                                     data-bind="event: { click: setJobSortFromElement }">
                                     <span class="th-label">Id</span> <i class="fa sort-icon fa-sort"></i>
                                 </th>
-                                <th class="sortable" data-sort-key="receivedAt" aria-sort="none"
+                                <th class="sortable" data-sort-key="receivedAt" aria-sort="none" title="Received"
                                     data-bind="event: { click: setJobSortFromElement }">
-                                    <span class="th-label">Received</span> <i class="fa sort-icon fa-sort"></i>
+                                    <span class="th-label">Recv</span> <i class="fa sort-icon fa-sort"></i>
                                 </th>
                                 <th class="sortable" data-sort-key="entityAssignedTo.code" aria-sort="none"
                                     data-bind="event: { click: setJobSortFromElement }">
@@ -1039,22 +1075,25 @@
 
                                             <!-- 2. Id -->
                                             <div class="job-cell job-cell--id">
-                                                <span data-bind="text: j.identifierTrimmed"></span>
-                                                <button type="button"
-                                                    class="btn btn-link p-0 text-decoration-none fa-center images-button"
-                                                    title="View incident images"
-                                                    data-bind="visible: j.imageCount() > 0, flashTextOnChange: j.imageCount, click: $root.openIncidentImages, clickBubble: false">
-                                                    <i class="far fa-image"></i>
-                                                    <span class="visually-hidden">Images</span>
-                                                </button>
-                                                <em class="fa fa-fw fa-share-alt" style="width: 1em;"
-                                                    data-bind="visible: j.icemsIncidentIdentifier, attr:{ title: j.icemsIncidentIdentifier }, css: { 'text-danger': j.hasUnacceptedNotifications() }, flashTextOnChange: j.hasUnacceptedNotifications"></em>
+                                                <div class="job-id-text" data-bind="text: j.identifierTrimmed"></div>
+                                                <div class="job-id-icons">
+                                                    <button type="button"
+                                                        class="btn btn-link p-0 text-decoration-none fa-center images-button"
+                                                        title="View incident images"
+                                                        data-bind="visible: j.imageCount() > 0, flashTextOnChange: j.imageCount, click: $root.openIncidentImages, clickBubble: false">
+                                                        <i class="far fa-image"></i>
+                                                        <span class="visually-hidden">Images</span>
+                                                    </button>
+                                                    <em class="fa fa-fw fa-share-alt" style="width: 1em;"
+                                                        data-bind="visible: j.icemsIncidentIdentifier, attr:{ title: j.icemsIncidentIdentifier }, css: { 'text-danger': j.hasUnacceptedNotifications() }, flashTextOnChange: j.hasUnacceptedNotifications"></em>
+                                                </div>
                                             </div>
 
                                             <!-- 3. Received -->
-                                            <div class="job-cell job-cell--received">
-                                                <span data-bind="text: j.receivedAtShort, attr:{ title: j.receivedAt }"
-                                                    data-bs-toggle="tooltip"></span>
+                                            <div class="job-cell job-cell--received" data-bs-toggle="tooltip"
+                                                data-bind="attr:{ title: j.receivedAt }">
+                                                <div class="received-time" data-bind="text: j.receivedAtTimeShort"></div>
+                                                <div class="received-date" data-bind="text: j.receivedAtDateShort"></div>
                                             </div>
 
                                             <!-- 4. HQ -->
@@ -1356,8 +1395,12 @@
                                                                     </div>
                                                                     <!-- /ko -->
                                                                     <!-- ko ifnot: j.dataLoading() -->
-                                                                    <div class="text-center" style="font-size: 0.85em; color: #888; margin-top: 0.25em;" data-bind="text: 'Refreshed ' + j.lastRefreshedAgo(), visible: j.lastRefreshedAgo">
-                                                                    </div>
+                                                                    <button type="button" class="btn btn-link btn-sm p-0 w-100 text-center"
+                                                                        style="font-size: 0.85em; color: #888; margin-top: 0.25em; text-decoration: none;"
+                                                                        title="Refresh this incident's data"
+                                                                        data-bind="click: j.refreshAllData, clickBubble: false, visible: j.lastRefreshedAgo">
+                                                                        <i class="fa fa-sync-alt me-1"></i><span data-bind="text: 'Refreshed ' + j.lastRefreshedAgo()"></span>
+                                                                    </button>
                                                                     <!-- /ko -->
                                                                 </div>
                                                             </div>

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -461,6 +461,15 @@ body.dark-mode .row-rescue * {
   color: #e0e0e0 !important;
 }
 
+body.dark-mode .row-rescue-fr1 {
+  background-color: #7a2f22 !important;
+  color: #e0e0e0 !important;
+}
+
+body.dark-mode .row-rescue-fr1 * {
+  color: #e0e0e0 !important;
+}
+
 body.dark-mode .row-priority {
   background-color: #54483a !important;
   color: #e0e0e0 !important;

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -462,7 +462,7 @@ body.dark-mode .row-rescue * {
 }
 
 body.dark-mode .row-rescue-fr1 {
-  background-color: #7a2f22 !important;
+  background-color: #521c16 !important;
   color: #e0e0e0 !important;
 }
 

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -26,6 +26,10 @@ body {
   background-color: #f1bfbf !important;
 }
 
+.row-rescue-fr1 {
+  background-color: #e9a3a3 !important;
+}
+
 .row-priority {
   background-color: #fcf8e3 !important;
 }
@@ -44,6 +48,16 @@ body {
 }
 
 .row-rescue > div > button > .not-pinned {
+  font-size: 11px !important;
+  color: var(--bs-secondary-color) !important;
+}
+
+.row-rescue-fr1 > div > button > .is-pinned {
+  color: white !important;
+  --bs-text-opacity: 1 !important;
+}
+
+.row-rescue-fr1 > div > button > .not-pinned {
   font-size: 11px !important;
   color: var(--bs-secondary-color) !important;
 }
@@ -1126,8 +1140,15 @@ tr.job:hover {
 }
 
 .teams {
-  --team-cols: 30px /* chevron */ 30px /* pin */ 1.35fr /* callsign */ 0.5fr /* status */ 60px /* HQ */ 120px
-    /* task count */ 1fr /* leader */ 140px; /* actions (fixed) */
+  /* status/HQ/task count are short, roughly fixed-format content ("Stood
+     down", "On Alert"), so they get a minmax() floor+ceiling instead of
+     competing with callsign/leader for proportional space — and unlike a
+     bare px track, minmax() can still shrink at narrow pane widths instead
+     of forcing the row into horizontal scroll. chevron/pin/actions stay
+     true fixed widths since they hold buttons, not text. */
+  --team-cols: 30px /* chevron */ 30px /* pin */ 1.35fr /* callsign */ minmax(64px, 90px)
+    /* status */ minmax(40px, 60px) /* HQ */ minmax(80px, 120px) /* task count */ 1fr
+    /* leader */ 140px; /* actions (fixed) */
 }
 
 /* header */
@@ -1854,8 +1875,16 @@ overflow: hidden;
 
 /* one source of truth (jobs) */
 .jobs {
-  --job-cols: 30px /* chev */ 20px /* pin */ 0.38fr /* Id */ 0.5fr /* Received */ 0.3fr /* HQ */ 0.3fr /* Type */ 1.5fr
-    /* Situation */ 0.5fr /* Status */ 0.9fr; /* Address */
+  /* Id/Received/HQ/Type/Status are short, roughly fixed-format content, so they
+     get a minmax() floor+ceiling sized to fit that content (Received wraps
+     date/time onto two lines rather than needing full-line width) instead of
+     a rigid px width — a bare px track can't shrink, so at narrow pane widths
+     it was pushing Situation/Address off into horizontal scroll. minmax()
+     lets every column compress together first. */
+  --job-cols: 30px /* chev */ 20px /* pin */ minmax(50px, 80px) /* Id */
+    minmax(58px, 72px) /* Received (wraps 2 lines) */ minmax(36px, 64px) /* HQ */
+    minmax(50px, 80px) /* Type */ minmax(90px, 1.6fr) /* Situation */
+    minmax(64px, 90px) /* Status */ minmax(70px, 1fr); /* Address */
 }
 
 /* body */
@@ -1897,6 +1926,8 @@ overflow: hidden;
   padding-right: 5px;
   padding-left: 5px;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Allow wrapping for the “long” columns so you don't lose information */
@@ -1904,6 +1935,69 @@ overflow: hidden;
 .job-cell--address {
   white-space: normal;
   overflow-wrap: anywhere;
+}
+
+/* Cap wrapped text to a few lines with an ellipsis, instead of letting it
+   balloon the row height when text wraps onto many short/fragmented lines. */
+.job-cell--address .btn,
+.job-cell--situation {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: normal;
+}
+
+.job-cell--situation {
+  -webkit-line-clamp: 3;
+  max-height: 4em;
+}
+
+.job-cell--address .btn {
+  -webkit-line-clamp: 5;
+  max-height: 6.5em;
+  text-align: center;
+}
+
+/* Time is more actionable at a glance than the date, so it goes on top;
+   two explicit lines rather than a wrapped string. */
+.job-cell--received {
+  text-align: center;
+}
+
+.job-cell--received .received-time {
+  font-weight: 600;
+}
+
+.job-cell--received .received-date {
+  font-size: 0.85em;
+  color: #6c757d;
+}
+
+/* Id text on top, its (optional) images/ICEMS icons on their own row below,
+   so a couple of small icons don't force the id text to truncate. */
+.job-cell--id {
+  text-align: center;
+}
+
+.job-id-icons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+/* .images-button is a Bootstrap <button> (border + line-height baked in) next
+   to a plain <em> icon — normalize both to the same box so neither sits
+   higher/lower than the other. */
+.job-id-icons > .images-button,
+.job-id-icons > em {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 1em;
+  line-height: 1;
+  border: 0;
+  margin: 0;
 }
 
 .job-cell--chev {
@@ -3321,6 +3415,59 @@ input[type='search']::-ms-clear {
 }
 .pin-toggle.active {
   border-color: #ffc107;
+}
+
+/* ── Responsive toolbar (Teams / Incidents panes) ──
+   Panes sit in a resizable sidebar, so viewport-based media queries can't
+   react to the sidebar getting narrow — use container queries instead.
+   Scoped to the toolbar row (not .pane) so it doesn't hand the table's
+   overflow:auto region layout containment, which would break the other
+   position:fixed dropdown menus nested in the table rows that rely on an
+   unconstrained ancestor to escape that clipping. */
+.pane-toolbar {
+  container-type: inline-size;
+  container-name: toolbar-pane;
+}
+
+.toolbar-search {
+  flex: 3 1 240px;
+  min-width: 110px;
+  max-width: 420px;
+}
+
+/* The label pill has Bootstrap's .flex-grow-1 utility, which competes with
+   the search box (also flex-grow) for leftover row space. Weight the search
+   box's growth higher so it claims space first; once it hits max-width,
+   the pill absorbs whatever's left, so it still fills the row. */
+.toolbar-label {
+  flex-grow: 1 !important;
+  max-width: 55%;
+}
+
+.toolbar-overflow {
+  display: none;
+}
+
+/* Toolbar dropdowns (filter + overflow menus) sit right above the table's
+   sticky thead (z-index: 1050) and would otherwise render underneath it
+   wherever they overlap. */
+.pane-toolbar .dropdown-menu {
+  z-index: 1051;
+}
+
+@container toolbar-pane (max-width: 520px) {
+  .toolbar-collapsible {
+    display: none !important;
+  }
+  .toolbar-overflow {
+    display: inline-block;
+  }
+}
+
+@container toolbar-pane (max-width: 360px) {
+  .toolbar-label {
+    display: none !important;
+  }
 }
 
 /* hide popups + tooltips while hotkey held */


### PR DESCRIPTION
## Summary
- Give FR-1 (Flood Rescue, Category 1) incident rows a distinct colour in both light and dark mode, subtly deeper than a normal Rescue-priority row
- Move unaccepted-notification refresh onto the shared jobs/teams refresh cycle (instead of a per-job 30s timer) and fall back JobReceived from the push notification's CreatedOn so jobs admitted via push aren't evicted by date filtering
- Add clock-skew tolerance to the end-of-range date check (mirroring the existing start-of-range one)
- Make the incidents/teams toolbars and table columns responsive to a narrow sidebar, split Received into time/date lines, clamp wrapped Situation/Address text, and add a manual per-incident refresh button

## Test plan
- [ ] Load tasking page, confirm FR-1 incidents render with the new colour in both light and dark mode, and other Rescue-priority rows are unchanged
- [ ] Narrow the sidebar and confirm toolbar buttons collapse into the overflow menu and table columns stay usable without horizontal scroll
- [ ] Verify a job created via SignalR push is admitted/retained correctly under an active date/type filter
- [ ] Click the manual refresh button on an expanded incident and confirm its data (including unaccepted notifications) updates