### PR TITLE
Add Recent Activations widget to Team Create

### DIFF
--- a/src/injectscripts/teams/create.js
+++ b/src/injectscripts/teams/create.js
@@ -302,7 +302,7 @@ function whenLighthouseIsReady(cb) {
 }
 
 function initRecentActivationsFieldset() {
-  if (!isProductionBeaconApi()) return; // no mams data outside prod
+  var isProd = isProductionBeaconApi();
 
   var $existingFieldset = $('#teamMemberSearch').closest('fieldset');
   if (!$existingFieldset.length) return;
@@ -312,13 +312,16 @@ function initRecentActivationsFieldset() {
       '<legend>' +
         '<img id="lighthouseRecentActivationsLogo" style="width:14px;vertical-align:middle;margin-right:5px" />' +
         'Recent myAvailability Activation Requests' +
-        '<button type="button" class="btn btn-xs btn-default lighthouse-recent-activations-refresh">' +
+        '<button type="button" class="btn btn-xs btn-default lighthouse-recent-activations-refresh"' + (isProd ? '' : ' disabled') + '>' +
           '<span class="fa fa-refresh"></span> Refresh' +
         '</button>' +
       '</legend>' +
       '<div class="form-group"><div class="col-xs-12">' +
         '<div class="lighthouse-recent-activations-list">' +
-          '<div class="lighthouse-recent-activations-empty">Click Refresh to load recent activations for the assigned unit.</div>' +
+          '<div class="lighthouse-recent-activations-empty">' +
+            (isProd ? 'Click Refresh to load recent activations for the assigned unit.' :
+              'myAvailability activation requests are only available on production Beacon (this is train/dev).') +
+          '</div>' +
         '</div>' +
       '</div></div>' +
     '</fieldset>'
@@ -328,6 +331,8 @@ function initRecentActivationsFieldset() {
   whenLighthouseIsReady(function () {
     $fieldset.find('#lighthouseRecentActivationsLogo').attr('src', lighthouseUrl + 'icons/lh-black.png');
   });
+
+  if (!isProd) return; // placeholder only - no mams data outside prod
 
   var $list = $fieldset.find('.lighthouse-recent-activations-list');
 


### PR DESCRIPTION
## Summary
- Adds a "Recent myAvailability Activation Requests" fieldset to the Beacon Team Create page: expand a recent activation for the assigned-to unit and click a name from its responses to add them straight to the team.
- On train/dev (where the myAvailability Lambdas have no data), the fieldset still renders but shows a disabled Refresh button and a placeholder message noting it's production-Beacon-only, instead of being hidden entirely.
- Standardises "responses" over "responders" in myAvailability UI text in jobs/view.js and teams/create.js.

## Test plan
- [ ] On production Beacon Team Create, set an Assigned To HQ, click Refresh, expand an activation, and confirm accepted/available/conditional responses list and add-to-team works.
- [ ] On train/dev Team Create, confirm the fieldset renders with a disabled Refresh button and the prod-only placeholder message (no requests sent).
- [ ] Confirm `?lhmembers=` / `?lhentityid=` prefill still works unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)