### PR TITLE
WIP: job status on incident markers

### DIFF
--- a/src/pages/tasking/components/job_icon.js
+++ b/src/pages/tasking/components/job_icon.js
@@ -1,4 +1,4 @@
-import {jobsToUI} from "../utils/jobTypesToUI.js";
+import {jobsToUI, statusPipColor, statusPipGlyph} from "../utils/jobTypesToUI.js";
 
 // --- SVG factory (shape+style → L.divIcon) ---
 import L from "leaflet";
@@ -121,33 +121,116 @@ function shapeInnerSvg({ shape, fill, stroke, radius = 7, strokeWidth = 2 }) {
     return inner;
 }
 
-export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2 }) {
+// White 1-glyph hint drawn inside the status pip, centred on (cx, cy) and
+// scaled to pip radius `r`. Returns "" for an unknown / absent key.
+function pipGlyphSvg(key, cx, cy, r) {
+    const g = r * 0.6;
+    const sw = Math.max(0.75, r * 0.28);
+    const n = (v) => v.toFixed(2);
+    const pt = (x, y) => `${n(cx + x)},${n(cy + y)}`;
+    const line = (x1, y1, x2, y2) =>
+        `<line x1="${n(cx + x1)}" y1="${n(cy + y1)}" x2="${n(cx + x2)}" y2="${n(cy + y2)}" />`;
+    const polyline = (...xy) => `<polyline points="${xy.map(([x, y]) => pt(x, y)).join(" ")}" />`;
+
+    if (key === "dot") {
+        return `<circle cx="${n(cx)}" cy="${n(cy)}" r="${n(r * 0.46)}" fill="#ffffff" />`;
+    }
+
+    let body = "";
+    switch (key) {
+        case "check":
+            body = polyline([-g, g * 0.05], [-g * 0.2, g * 0.8], [g, -g * 0.7]);
+            break;
+        case "cross":
+            body = line(-g, -g, g, g) + line(g, -g, -g, g);
+            break;
+        case "arrow":
+            body = line(-g, 0, g, 0) + polyline([g * 0.2, -g * 0.6], [g, 0], [g * 0.2, g * 0.6]);
+            break;
+        case "chevrons":
+            body = polyline([-g * 0.7, -g * 0.75], [0, 0], [-g * 0.7, g * 0.75])
+                 + polyline([0, -g * 0.75], [g * 0.7, 0], [0, g * 0.75]);
+            break;
+        default:
+            return "";
+    }
+    return `<g fill="none" stroke="#ffffff" stroke-width="${n(sw)}"
+                stroke-linecap="round" stroke-linejoin="round">${body}</g>`;
+}
+
+export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2, pip = null, pipGlyph = null }) {
     const d = radius * 2;
     const inner = shapeInnerSvg({ shape, fill, stroke, radius, strokeWidth });
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${d}" height="${d}" viewBox="0 0 ${d} ${d}">
+
+    if (!pip) {
+        const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${d}" height="${d}" viewBox="0 0 ${d} ${d}">
               ${inner}
+            </svg>`;
+
+        return L.divIcon({
+            className: "job-svg-marker",
+            html: svg,
+            iconSize: [d, d],
+            iconAnchor: [radius, radius],
+            popupAnchor: [0, -radius],
+            shapeDiameter: d
+        });
+    }
+
+    // Status pip: a small coloured dot in the top-right corner, optionally
+    // carrying a 1-glyph hint. The SVG box is padded symmetrically so
+    // iconAnchor stays at the shape centre, and the pulse ring keys off
+    // `shapeDiameter` (below) rather than this padded box.
+    const pr = Math.max(3.4, radius * 0.62);   // pip radius
+    const halo = pr + 1;
+    const pad = Math.ceil(halo);
+    const box = d + pad * 2;
+    const pcx = pad + d - pr * 0.4;             // tucked into the NE corner
+    const pcy = pad + pr * 0.4;
+
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${box}" height="${box}" viewBox="0 0 ${box} ${box}">
+              <g transform="translate(${pad}, ${pad})">${inner}</g>
+              <circle cx="${pcx}" cy="${pcy}" r="${halo}" fill="#ffffff" />
+              <circle cx="${pcx}" cy="${pcy}" r="${pr}" fill="${pip}" stroke="rgba(0,0,0,0.35)" stroke-width="0.75" />
+              ${pipGlyph ? pipGlyphSvg(pipGlyph, pcx, pcy, pr) : ""}
             </svg>`;
 
     return L.divIcon({
         className: "job-svg-marker",
         html: svg,
-        iconSize: [d, d],
-        iconAnchor: [radius, radius],
-        popupAnchor: [0, -radius]
+        iconSize: [box, box],
+        iconAnchor: [radius + pad, radius + pad],
+        popupAnchor: [0, -radius],
+        shapeDiameter: d
     });
 };
 
 // Build icon style for a given job
-export function styleForJob(job) {
+export function styleForJob(job, { showStatus = false } = {}) {
 
     const style = jobsToUI(job)
 
     // // Emphasise Priority/Immediate with larger radius
     // const radius = (/^(Priority|Immediate)$/i.test(job.priorityName())) ? 8.5 : 7;
     const radius = 7
-    
-    return { shape: style.shape, fill: style.fillcolor, stroke: style.strokecolor, radius, strokeWidth: 2.25 };
+
+    const out = { shape: style.shape, fill: style.fillcolor, stroke: style.strokecolor, radius, strokeWidth: 2.25 };
     // tweak strokeWidth if you need stronger outlines
+
+    // Only attach `pip` when the config option is on AND the status is known,
+    // so the JSON.stringify(style) change-detection key is byte-identical to
+    // the old behaviour whenever status pips are disabled.
+    if (showStatus) {
+        const status = job.statusName?.();
+        const pip = statusPipColor(status);
+        if (pip) {
+            out.pip = pip;
+            const glyph = statusPipGlyph(status);
+            if (glyph) out.pipGlyph = glyph;
+        }
+    }
+
+    return out;
 }
 
 /**

--- a/src/pages/tasking/components/job_icon.js
+++ b/src/pages/tasking/components/job_icon.js
@@ -1,4 +1,4 @@
-import {jobsToUI, statusPipColor, statusPipGlyph} from "../utils/jobTypesToUI.js";
+import {jobsToUI, statusClosedMark, ACTIVE_RING_COLOUR} from "../utils/jobTypesToUI.js";
 
 // --- SVG factory (shape+style → L.divIcon) ---
 import L from "leaflet";
@@ -121,48 +121,41 @@ function shapeInnerSvg({ shape, fill, stroke, radius = 7, strokeWidth = 2 }) {
     return inner;
 }
 
-// White 1-glyph hint drawn inside the status pip, centred on (cx, cy) and
-// scaled to pip radius `r`. Returns "" for an unknown / absent key.
-function pipGlyphSvg(key, cx, cy, r) {
-    const g = r * 0.6;
-    const sw = Math.max(0.75, r * 0.28);
-    const n = (v) => v.toFixed(2);
-    const pt = (x, y) => `${n(cx + x)},${n(cy + y)}`;
-    const line = (x1, y1, x2, y2) =>
-        `<line x1="${n(cx + x1)}" y1="${n(cy + y1)}" x2="${n(cx + x2)}" y2="${n(cy + y2)}" />`;
-    const polyline = (...xy) => `<polyline points="${xy.map(([x, y]) => pt(x, y)).join(" ")}" />`;
-
-    if (key === "dot") {
-        return `<circle cx="${n(cx)}" cy="${n(cy)}" r="${n(r * 0.46)}" fill="#ffffff" />`;
-    }
-
-    let body = "";
-    switch (key) {
-        case "check":
-            body = polyline([-g, g * 0.05], [-g * 0.2, g * 0.8], [g, -g * 0.7]);
-            break;
-        case "cross":
-            body = line(-g, -g, g, g) + line(g, -g, -g, g);
-            break;
-        case "arrow":
-            body = line(-g, 0, g, 0) + polyline([g * 0.2, -g * 0.6], [g, 0], [g * 0.2, g * 0.6]);
-            break;
-        case "chevrons":
-            body = polyline([-g * 0.7, -g * 0.75], [0, 0], [-g * 0.7, g * 0.75])
-                 + polyline([0, -g * 0.75], [g * 0.7, 0], [0, g * 0.75]);
-            break;
-        default:
-            return "";
-    }
-    return `<g fill="none" stroke="#ffffff" stroke-width="${n(sw)}"
-                stroke-linecap="round" stroke-linejoin="round">${body}</g>`;
+// Diagonal strike ("/") or cross ("✕") overlaid on a closed job's marker.
+// Dark line with a thin white casing underneath so it reads on any fill.
+// Sits right across the shape — barely past its edge.
+function closedMarkSvg(kind, c, radius) {
+    const e = radius + 1;
+    const w = Math.max(1.3, radius * 0.22);
+    const seg = (x1, y1, x2, y2) =>
+        `<line x1="${(c + x1).toFixed(2)}" y1="${(c + y1).toFixed(2)}" x2="${(c + x2).toFixed(2)}" y2="${(c + y2).toFixed(2)}" />`;
+    const lines = kind === "cross"
+        ? seg(-e, -e, e, e) + seg(e, -e, -e, e)
+        : seg(-e, e, e, -e); // "/"
+    return `<g stroke="#ffffff" stroke-width="${(w + 1.1).toFixed(2)}" stroke-linecap="round">${lines}</g>` +
+           `<g stroke="#12181e" stroke-width="${w.toFixed(2)}" stroke-linecap="round">${lines}</g>`;
 }
 
-export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2, pip = null, pipGlyph = null }) {
+// Red "!" pip in the NE corner — a job carrying an action-required tag.
+function alertPipSvg(pad, d, radius) {
+    const pr = Math.max(3.4, radius * 0.6);
+    const halo = pr + 1.1;
+    const x = pad + d - pr * 0.35;
+    const y = pad + pr * 0.35;
+    const n = (v) => v.toFixed(2);
+    return `<circle cx="${n(x)}" cy="${n(y)}" r="${n(halo)}" fill="#ffffff" />` +
+           `<circle cx="${n(x)}" cy="${n(y)}" r="${n(pr)}" fill="#e5484d" stroke="rgba(0,0,0,0.3)" stroke-width="0.7" />` +
+           `<g fill="#ffffff">` +
+             `<rect x="${n(x - pr * 0.16)}" y="${n(y - pr * 0.55)}" width="${n(pr * 0.32)}" height="${n(pr * 0.72)}" rx="${n(pr * 0.16)}" />` +
+             `<circle cx="${n(x)}" cy="${n(y + pr * 0.52)}" r="${n(pr * 0.17)}" />` +
+           `</g>`;
+}
+
+export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2, closedMark = null, alert = false }) {
     const d = radius * 2;
     const inner = shapeInnerSvg({ shape, fill, stroke, radius, strokeWidth });
 
-    if (!pip) {
+    if (!closedMark && !alert) {
         const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${d}" height="${d}" viewBox="0 0 ${d} ${d}">
               ${inner}
             </svg>`;
@@ -177,33 +170,43 @@ export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2
         });
     }
 
-    // Status pip: a small coloured dot in the top-right corner, optionally
-    // carrying a 1-glyph hint. The SVG box is padded symmetrically so
-    // iconAnchor stays at the shape centre, and the pulse ring keys off
-    // `shapeDiameter` (below) rather than this padded box.
-    const pr = Math.max(3.4, radius * 0.62);   // pip radius
-    const halo = pr + 1;
-    const pad = Math.ceil(halo);
+    // Padded symmetrically so iconAnchor stays at the shape centre; the pulse /
+    // status rings key off `shapeDiameter` rather than this padded box.
+    // ~radius*0.55 covers the "!" pip halo and the strike's small overhang.
+    const pad = Math.ceil(radius * 0.55);
     const box = d + pad * 2;
-    const pcx = pad + d - pr * 0.4;             // tucked into the NE corner
-    const pcy = pad + pr * 0.4;
+    const c = pad + radius;
 
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${box}" height="${box}" viewBox="0 0 ${box} ${box}">
-              <g transform="translate(${pad}, ${pad})">${inner}</g>
-              <circle cx="${pcx}" cy="${pcy}" r="${halo}" fill="#ffffff" />
-              <circle cx="${pcx}" cy="${pcy}" r="${pr}" fill="${pip}" stroke="rgba(0,0,0,0.35)" stroke-width="0.75" />
-              ${pipGlyph ? pipGlyphSvg(pipGlyph, pcx, pcy, pr) : ""}
-            </svg>`;
+    let overlay = `<g transform="translate(${pad}, ${pad})">${inner}</g>`;
+    if (closedMark) overlay += closedMarkSvg(closedMark, c, radius);
+    if (alert) overlay += alertPipSvg(pad, d, radius);
+
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${box}" height="${box}" viewBox="0 0 ${box} ${box}">${overlay}</svg>`;
 
     return L.divIcon({
         className: "job-svg-marker",
         html: svg,
         iconSize: [box, box],
-        iconAnchor: [radius + pad, radius + pad],
+        iconAnchor: [c, c],
         popupAnchor: [0, -radius],
         shapeDiameter: d
     });
 };
+
+/**
+ * SVG for the Active "marching ring" — a dashed circle in a spinning <g>.
+ * Rotation (compositor-only) reads as marching ants at this size and is far
+ * cheaper than animating stroke-dashoffset on every marker.
+ */
+export function buildStatusRingSvg(box, ringRadius, colour = ACTIVE_RING_COLOUR) {
+    const c = box / 2;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${box}" height="${box}" viewBox="0 0 ${box} ${box}">
+              <g class="status-ring-spin" style="transform-box:fill-box;transform-origin:center">
+                <circle cx="${c}" cy="${c}" r="${ringRadius}" fill="none" stroke="${colour}"
+                        stroke-width="2.75" stroke-linecap="round" stroke-dasharray="4 3.5" />
+              </g>
+            </svg>`;
+}
 
 // Build icon style for a given job
 export function styleForJob(job, { showStatus = false } = {}) {
@@ -217,17 +220,14 @@ export function styleForJob(job, { showStatus = false } = {}) {
     const out = { shape: style.shape, fill: style.fillcolor, stroke: style.strokecolor, radius, strokeWidth: 2.25 };
     // tweak strokeWidth if you need stronger outlines
 
-    // Only attach `pip` when the config option is on AND the status is known,
-    // so the JSON.stringify(style) change-detection key is byte-identical to
-    // the old behaviour whenever status pips are disabled.
+    // Only attach status keys when the option is on, so JSON.stringify(style)
+    // (the change-detection key) is byte-identical to the old behaviour when off.
+    // Note: the Active marching ring is a sibling layer, not part of this icon —
+    // see upsertStatusRing() in jobMarker.js.
     if (showStatus) {
-        const status = job.statusName?.();
-        const pip = statusPipColor(status);
-        if (pip) {
-            out.pip = pip;
-            const glyph = statusPipGlyph(status);
-            if (glyph) out.pipGlyph = glyph;
-        }
+        const mark = statusClosedMark(job.statusName?.());
+        if (mark) out.closedMark = mark;
+        if ((job.actionRequiredTags?.() || []).length > 0) out.alert = true;
     }
 
     return out;

--- a/src/pages/tasking/components/legend.js
+++ b/src/pages/tasking/components/legend.js
@@ -7,37 +7,36 @@ export const LegendControl = L.Control.extend({
   onAdd() {
     const div = L.DomUtil.create("div", "legend-container leaflet-bar");
 
-    // Status → pip rows. Hidden until config.showJobStatusOnMarkers is on
-    // (Map.applyJobStatusOnMarkers toggles the .legend-status-block wrapper).
-    const STATUS_PIPS = [
-      ["Active", "#159aab", "dot"],
-      ["Tasked", "#6b52d6", "arrow"],
-      ["Referred", "#566f86", "chevrons"],
-      ["Complete", "#2f8f5b", "check"],
-      ["Cancelled", "#8b949b", "cross"],
-      ["Finalised", "#5b636a", "check"],
-      ["Rejected", "#cc4460", "cross"],
-    ];
-    const pipGlyphSvg = (key) => {
-      const s = 'fill="none" stroke="#fff" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"';
-      switch (key) {
-        case "dot": return '<circle cx="16.5" cy="5.5" r="2" fill="#fff"/>';
-        case "arrow": return `<g ${s}><line x1="14" y1="5.5" x2="19" y2="5.5"/><polyline points="17.4,3.9 19,5.5 17.4,7.1"/></g>`;
-        case "chevrons": return `<g ${s}><polyline points="14.6,3.8 16.3,5.5 14.6,7.2"/><polyline points="16.9,3.8 18.6,5.5 16.9,7.2"/></g>`;
-        case "check": return `<polyline points="14.4,5.7 15.8,7.1 18.7,4.1" ${s}/>`;
-        case "cross": return `<g ${s}><line x1="14.6" y1="3.6" x2="18.4" y2="7.4"/><line x1="18.4" y1="3.6" x2="14.6" y2="7.4"/></g>`;
-        default: return "";
-      }
+    // Status → marker treatment rows. Hidden until config.showJobStatusOnMarkers
+    // is on (Map.applyJobStatusOnMarkers toggles the .legend-status-block wrapper).
+    // A grey circle marker (r6 @ 9,11) with the treatment drawn over it.
+    const strikeSvg = (cross) => {
+      const cas = 'stroke="#fff" stroke-width="3.6" stroke-linecap="round"';
+      const ink = 'stroke="#12181e" stroke-width="2.2" stroke-linecap="round"';
+      const a = cross
+        ? '<line x1="3" y1="5" x2="15" y2="17"/><line x1="3" y1="17" x2="15" y2="5"/>'
+        : '<line x1="3" y1="17" x2="15" y2="5"/>';
+      return `<g ${cas}>${a}</g><g ${ink}>${a}</g>`;
     };
-    const statusPipRows = STATUS_PIPS.map(([label, col, g]) => `
-        <div style="display:flex;align-items:center;gap:4px;">
-          <svg width="22" height="22" viewBox="0 0 22 22" style="flex-shrink:0;overflow:visible;">
-            <circle cx="9" cy="10" r="6" fill="#9aa3ad" stroke="#000" stroke-width="2"/>
-            <circle cx="16.5" cy="5.5" r="4.4" fill="#fff"/>
-            <circle cx="16.5" cy="5.5" r="3.6" fill="${col}" stroke="rgba(0,0,0,0.35)" stroke-width="0.75"/>
-            ${pipGlyphSvg(g)}
-          </svg>
-          <span>${label}</span>
+    const dot = '<circle cx="9" cy="11" r="6" fill="#9aa3ad" stroke="#000" stroke-width="2"/>';
+    const STATUS_ROWS = [
+      { label: "New",
+        svg: `<circle cx="9" cy="11" r="8.4" fill="none" stroke="#f7931d" stroke-width="2.2"/>${dot}` },
+      { label: "Active",
+        svg: `<circle cx="9" cy="11" r="8.2" fill="none" stroke="#e5399b" stroke-width="2.2" stroke-dasharray="3.4 3" stroke-linecap="round"/>${dot}` },
+      { label: "Tasked", svg: dot },
+      { label: "Complete / Referred / Finalised", svg: `${dot}${strikeSvg(false)}` },
+      { label: "Cancelled / Rejected", svg: `${dot}${strikeSvg(true)}` },
+      { label: "Action required (any status)",
+        svg: `${dot}
+              <circle cx="16.4" cy="4.4" r="4.4" fill="#fff"/>
+              <circle cx="16.4" cy="4.4" r="3.5" fill="#e5484d"/>
+              <rect x="15.8" y="2.5" width="1.2" height="2.6" rx="0.6" fill="#fff"/><circle cx="16.4" cy="6.3" r="0.7" fill="#fff"/>` },
+    ];
+    const statusPipRows = STATUS_ROWS.map((r) => `
+        <div style="display:flex;align-items:center;gap:5px;">
+          <svg width="22" height="22" viewBox="0 0 22 22" style="flex-shrink:0;overflow:visible;">${r.svg}</svg>
+          <span>${r.label}</span>
         </div>`).join("");
 
     div.innerHTML = `
@@ -82,8 +81,8 @@ export const LegendControl = L.Control.extend({
 
 
     <div class="legend-status-block d-none">
-      <div class="fw-semibold small mb-1 mt-2">Status → Pip <span class="text-muted fw-normal">(top-right dot; New = pulse ring)</span></div>
-      <div style="display:grid;grid-template-columns:1fr 1fr;column-gap:12px;row-gap:2px;" class="small">
+      <div class="fw-semibold small mb-1 mt-2">Job Status <span class="text-muted fw-normal">(Any type)</span></div>
+      <div style="display:grid;grid-template-columns:1fr;row-gap:3px;" class="small">
         ${statusPipRows}
       </div>
     </div>
@@ -116,10 +115,12 @@ export const LegendControl = L.Control.extend({
         </div>
         <div style="display:flex;align-items:center;gap:4px;">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 36 36" style="flex-shrink:0;overflow:visible;">
-            <polygon points="18,3 33,11.5 33,24.5 18,33 3,24.5 3,11.5" fill="#6b7280" stroke="rgba(247,147,29,0.9)" stroke-width="2"/>
+            <!-- Grey cluster badge with a solid pulsing orange hex outline,
+                 mirroring the real cluster-pulse-hex (Map.js iconCreateFunction). -->
+            <polygon points="18,0 36,10.5 36,25.5 18,36 0,25.5 0,10.5" fill="none" stroke="rgba(247,147,29,0.9)" stroke-width="2" style="transform-box:fill-box;transform-origin:center;animation:cluster-pulse-new 1.4s ease-out infinite;"/>
+            <polygon points="18,3 33,11.5 33,24.5 18,33 3,24.5 3,11.5" fill="#6b7280" stroke="#888" stroke-width="2"/>
             <polygon points="24.1,9 27.5,18 24.1,27 11.9,27 8.5,18 11.9,9" fill="#6b7280"/>
             <text x="18" y="18" text-anchor="middle" dominant-baseline="central" fill="#fff" font-size="13" font-weight="700" font-family="system-ui,sans-serif">3</text>
-            <polygon points="18,3 33,11.5 33,24.5 18,33 3,24.5 3,11.5" fill="none" stroke="#f7931d" stroke-width="2" stroke-dasharray="4 2"/>
           </svg>
           <span>Cluster Contains Unacked Incidents</span>
         </div>

--- a/src/pages/tasking/components/legend.js
+++ b/src/pages/tasking/components/legend.js
@@ -10,7 +10,6 @@ export const LegendControl = L.Control.extend({
     // Status → pip rows. Hidden until config.showJobStatusOnMarkers is on
     // (Map.applyJobStatusOnMarkers toggles the .legend-status-block wrapper).
     const STATUS_PIPS = [
-      ["New", "#e4661d", ""],
       ["Active", "#159aab", "dot"],
       ["Tasked", "#6b52d6", "arrow"],
       ["Referred", "#566f86", "chevrons"],
@@ -83,7 +82,7 @@ export const LegendControl = L.Control.extend({
 
 
     <div class="legend-status-block d-none">
-      <div class="fw-semibold small mb-1 mt-2">Status → Pip <span class="text-muted fw-normal">(top-right dot)</span></div>
+      <div class="fw-semibold small mb-1 mt-2">Status → Pip <span class="text-muted fw-normal">(top-right dot; New = pulse ring)</span></div>
       <div style="display:grid;grid-template-columns:1fr 1fr;column-gap:12px;row-gap:2px;" class="small">
         ${statusPipRows}
       </div>

--- a/src/pages/tasking/components/legend.js
+++ b/src/pages/tasking/components/legend.js
@@ -6,6 +6,41 @@ export const LegendControl = L.Control.extend({
 
   onAdd() {
     const div = L.DomUtil.create("div", "legend-container leaflet-bar");
+
+    // Status → pip rows. Hidden until config.showJobStatusOnMarkers is on
+    // (Map.applyJobStatusOnMarkers toggles the .legend-status-block wrapper).
+    const STATUS_PIPS = [
+      ["New", "#e4661d", ""],
+      ["Active", "#159aab", "dot"],
+      ["Tasked", "#6b52d6", "arrow"],
+      ["Referred", "#566f86", "chevrons"],
+      ["Complete", "#2f8f5b", "check"],
+      ["Cancelled", "#8b949b", "cross"],
+      ["Finalised", "#5b636a", "check"],
+      ["Rejected", "#cc4460", "cross"],
+    ];
+    const pipGlyphSvg = (key) => {
+      const s = 'fill="none" stroke="#fff" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"';
+      switch (key) {
+        case "dot": return '<circle cx="16.5" cy="5.5" r="2" fill="#fff"/>';
+        case "arrow": return `<g ${s}><line x1="14" y1="5.5" x2="19" y2="5.5"/><polyline points="17.4,3.9 19,5.5 17.4,7.1"/></g>`;
+        case "chevrons": return `<g ${s}><polyline points="14.6,3.8 16.3,5.5 14.6,7.2"/><polyline points="16.9,3.8 18.6,5.5 16.9,7.2"/></g>`;
+        case "check": return `<polyline points="14.4,5.7 15.8,7.1 18.7,4.1" ${s}/>`;
+        case "cross": return `<g ${s}><line x1="14.6" y1="3.6" x2="18.4" y2="7.4"/><line x1="18.4" y1="3.6" x2="14.6" y2="7.4"/></g>`;
+        default: return "";
+      }
+    };
+    const statusPipRows = STATUS_PIPS.map(([label, col, g]) => `
+        <div style="display:flex;align-items:center;gap:4px;">
+          <svg width="22" height="22" viewBox="0 0 22 22" style="flex-shrink:0;overflow:visible;">
+            <circle cx="9" cy="10" r="6" fill="#9aa3ad" stroke="#000" stroke-width="2"/>
+            <circle cx="16.5" cy="5.5" r="4.4" fill="#fff"/>
+            <circle cx="16.5" cy="5.5" r="3.6" fill="${col}" stroke="rgba(0,0,0,0.35)" stroke-width="0.75"/>
+            ${pipGlyphSvg(g)}
+          </svg>
+          <span>${label}</span>
+        </div>`).join("");
+
     div.innerHTML = `
       <div class="legend-header d-flex justify-content-between align-items-center">
         <span class="fw-semibold">Legend</span><br>
@@ -47,6 +82,13 @@ export const LegendControl = L.Control.extend({
     </div>
 
 
+    <div class="legend-status-block d-none">
+      <div class="fw-semibold small mb-1 mt-2">Status → Pip <span class="text-muted fw-normal">(top-right dot)</span></div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;column-gap:12px;row-gap:2px;" class="small">
+        ${statusPipRows}
+      </div>
+    </div>
+
     <div>
       <div class="fw-semibold small mb-1 mt-2">Overlays</div>
       <div style="display:grid;grid-template-columns:1fr 1fr;column-gap:12px;row-gap:4px;" class="small legend-ring">
@@ -86,6 +128,7 @@ export const LegendControl = L.Control.extend({
       </div>
 
 
+  <div>
   <div class="fw-semibold small mb-1 mt-2">Assets</div>
   <div style="display:grid;grid-template-columns:1fr 1fr;column-gap:12px;row-gap:2px;">
 
@@ -168,9 +211,9 @@ export const LegendControl = L.Control.extend({
     </div>
 
   </div>
+  </div>
 </div>
 
-    </div>
     `;
 
     this._container = div;

--- a/src/pages/tasking/markers/jobMarker.js
+++ b/src/pages/tasking/markers/jobMarker.js
@@ -25,7 +25,8 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
             : vm.mapVM.jobClusterGroup;          // normal clustering
     const markers = vm.mapVM.jobMarkerIndex;
     const pulseLayer = vm.mapVM.jobPulseLayer;
-    const style = styleForJob(job);
+    const showStatus = !!vm.config?.showJobStatusOnMarkers?.();
+    const style = styleForJob(job, { showStatus });
     const html = buildJobPopupKO();
     const contentEl = makePopupNode(html, 'job-pop-root')
 
@@ -77,6 +78,8 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
                     if (prev !== m._isNew && vm.mapVM.clusteringEnabled) {
                         vm.mapVM.jobClusterGroup.refreshClusters(m);
                     }
+                    // keep the status pip colour in sync when the option is on
+                    if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(m, job, vm, pulseLayer);
                 })
             );
         }
@@ -117,6 +120,8 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
             if (wasNew !== marker._isNew && vm.mapVM.clusteringEnabled) {
                 vm.mapVM.jobClusterGroup.refreshClusters(marker);
             }
+            // keep the status pip colour in sync when the option is on
+            if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(marker, job, vm, pulseLayer);
         })
     );
 
@@ -184,17 +189,50 @@ export function removeJobMarker(vm, jobOrId) {
     if (job) job.marker = null;
 }
 
+/**
+ * Re-evaluate every existing job marker's icon — used when the
+ * `showJobStatusOnMarkers` config option is toggled, so the status pip is
+ * added to / removed from markers that are already on the map.
+ */
+export function restyleAllJobMarkers(vm) {
+    const showStatus = !!vm.config?.showJobStatusOnMarkers?.();
+    const pulseLayer = vm.mapVM?.jobPulseLayer;
+    vm.jobsById?.forEach((job) => {
+        const m = job.marker;
+        if (!m) return;
+        const newStyle = styleForJob(job, { showStatus });
+        const key = JSON.stringify(newStyle);
+        if (m._styleKey === key) return;
+
+        m.setIcon(makeShapeIcon(newStyle));
+        m._styleKey = key;
+        m._priorityColor = newStyle.fill || '#6b7280';
+
+        // The icon box size changed, so any existing pulse ring is now sized
+        // for the old geometry — rebuild it against the new icon.
+        if (m._pulseRing && pulseLayer) {
+            m._pulseRing._detach?.();
+            pulseLayer.removeLayer(m._pulseRing);
+            m._pulseRing = null;
+            upsertPulseRing(pulseLayer, job, m);
+        }
+    });
+    vm.mapVM?._syncPulseRings?.();
+}
+
 //complicated for some reason. has to support different icons sizes and anchors
 function upsertPulseRing(layerGroup, job, marker) {
     const isNew = (job.statusName?.() || '').toLowerCase() === 'new';
     const base = marker.options.icon?.options || {};
-    const baseSize = base.iconSize || [14, 14];
-    const baseAnchor = base.iconAnchor || [baseSize[0] / 2, baseSize[1] / 2];
+    const iconSize = base.iconSize || [14, 14];
+    // Ring is sized to the actual shape, not the (possibly pip-padded) icon box.
+    const shapeD = base.shapeDiameter || Math.min(iconSize[0], iconSize[1]);
+    const baseSize = [shapeD, shapeD];
 
     if (isNew && !marker._pulseRing) {
         const k = 3;
         const ringSize = [Math.round(baseSize[0] * k), Math.round(baseSize[1] * k)];
-        const ringAnchor = [Math.round(baseAnchor[0] * k), Math.round(baseAnchor[1] * k)];
+        const ringAnchor = [Math.round(ringSize[0] / 2), Math.round(ringSize[1] / 2)];
 
         const shape = styleForJob(job).shape || 'circle';
         const pulseSvg = buildPulseRingSvg(shape, ringSize[0], ringSize[1]);
@@ -235,7 +273,8 @@ function upsertPulseRing(layerGroup, job, marker) {
  * reassignment + cluster refresh as needed.
  */
 function syncMarkerStyle(marker, job, vm, pulseLayer) {
-    const newStyle = styleForJob(job);
+    const showStatus = !!vm.config?.showJobStatusOnMarkers?.();
+    const newStyle = styleForJob(job, { showStatus });
     const newKey = JSON.stringify(newStyle);
 
     // Update icon if the visual style actually changed

--- a/src/pages/tasking/markers/jobMarker.js
+++ b/src/pages/tasking/markers/jobMarker.js
@@ -2,7 +2,8 @@ var L = require('leaflet');
 var ko = require('knockout');
 
 import { buildJobPopupKO } from '../components/job_popup.js';
-import { makeShapeIcon, styleForJob, buildPulseRingSvg } from '../components/job_icon.js';
+import { makeShapeIcon, styleForJob, buildPulseRingSvg, buildStatusRingSvg } from '../components/job_icon.js';
+import { statusHasRing } from '../utils/jobTypesToUI.js';
 
 
 import { makePopupNode, bindKoToPopup, unbindKoFromPopup, deferPopupUpdate } from '../utils/popup_dom_utils.js';
@@ -60,8 +61,9 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
         m._priorityColor = style.fill || '#6b7280';
         if (!m._popupBound) { m.setPopupContent(node); wireKoForPopup(ko, m, job, vm, vm.mapVM.makeJobPopupVM(job)); }
 
-        // keep the "New" ring and _isNew flag in correct state
+        // keep the "New" pulse ring and the Active marching ring in correct state
         upsertPulseRing(pulseLayer, job, m);
+        if (showStatus) upsertStatusRing(vm.mapVM.jobStatusRingLayer, job, m);
         const wasNew = m._isNew;
         m._isNew = (job.statusName?.() || '').toLowerCase() === 'new';
         if (wasNew !== m._isNew && vm.mapVM.clusteringEnabled) {
@@ -78,7 +80,7 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
                     if (prev !== m._isNew && vm.mapVM.clusteringEnabled) {
                         vm.mapVM.jobClusterGroup.refreshClusters(m);
                     }
-                    // keep the status pip colour in sync when the option is on
+                    // restyle icon (strike / X) + Active marching ring when the option is on
                     if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(m, job, vm, pulseLayer);
                 })
             );
@@ -90,6 +92,14 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
                 syncMarkerStyle(m, job, vm, pulseLayer);
             });
             (m._subs ||= []).push(m._prioritySub);
+        }
+
+        // action-required tags → "!" pip on the icon
+        if (!m._alertSub && job.actionRequiredTags) {
+            m._alertSub = job.actionRequiredTags.subscribe(() => {
+                if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(m, job, vm, pulseLayer);
+            });
+            (m._subs ||= []).push(m._alertSub);
         }
 
         job.marker = m;
@@ -111,6 +121,7 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
     job.marker = marker;
 
     upsertPulseRing(pulseLayer, job, marker);
+    if (showStatus) upsertStatusRing(vm.mapVM.jobStatusRingLayer, job, marker);
     (marker._pulseSubs ||= []).push(
         job.statusName.subscribe(() => {
             upsertPulseRing(pulseLayer, job, marker);
@@ -120,7 +131,7 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
             if (wasNew !== marker._isNew && vm.mapVM.clusteringEnabled) {
                 vm.mapVM.jobClusterGroup.refreshClusters(marker);
             }
-            // keep the status pip colour in sync when the option is on
+            // restyle icon (strike / X) + Active marching ring when the option is on
             if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(marker, job, vm, pulseLayer);
         })
     );
@@ -134,14 +145,22 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
         syncMarkerStyle(marker, job, vm, pulseLayer);
     });
 
+    // action-required tags → "!" pip on the icon
+    marker._alertSub = job.actionRequiredTags
+        ? job.actionRequiredTags.subscribe(() => {
+            if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(marker, job, vm, pulseLayer);
+        })
+        : null;
+
     // live position updates from KO observables
     marker._subs = [
         job.address.latitude.subscribe(() => safeMove(marker, job)),
         job.address.longitude.subscribe(() => safeMove(marker, job)),
         marker._prioritySub,
-    ];
+        marker._alertSub,
+    ].filter(Boolean);
 
-    // Sync pulse ring visibility after adding
+    // Sync pulse / status ring visibility after adding
     vm.mapVM._syncPulseRings?.();
 
     return marker;
@@ -172,12 +191,20 @@ export function removeJobMarker(vm, jobOrId) {
     const popupEl = m.getPopup()?.getElement?.();
     if (popupEl && popupEl.__ko_bound__) { try { ko.cleanNode(popupEl); } catch { /* empty */ } delete popupEl.__ko_bound__; }
 
+    // statusName subscription drives both the pulse ring and the Active ring
+    (m._pulseSubs || []).forEach(s => { try { s.dispose?.(); } catch { /* empty */ } });
+    m._pulseSubs = [];
+
     if (m._pulseRing) {
         m._pulseRing._detach?.();
-        (m._pulseSubs || []).forEach(s => { try { s.dispose?.(); } catch { /* empty */ } });
-        m._pulseSubs = [];
         pulseLayer.removeLayer(m._pulseRing);
         m._pulseRing = null;
+    }
+
+    if (m._statusRing) {
+        m._statusRing._detach?.();
+        vm.mapVM.jobStatusRingLayer?.removeLayer(m._statusRing);
+        m._statusRing = null;
     }
 
     // Remove from whichever layer it's in
@@ -190,32 +217,40 @@ export function removeJobMarker(vm, jobOrId) {
 }
 
 /**
- * Re-evaluate every existing job marker's icon — used when the
- * `showJobStatusOnMarkers` config option is toggled, so the status pip is
- * added to / removed from markers that are already on the map.
+ * Re-evaluate every existing job marker — used when the `showJobStatusOnMarkers`
+ * config option is toggled, so the strike / X / "!" pip and the Active marching
+ * ring are added to / removed from markers already on the map.
  */
 export function restyleAllJobMarkers(vm) {
     const showStatus = !!vm.config?.showJobStatusOnMarkers?.();
     const pulseLayer = vm.mapVM?.jobPulseLayer;
+    const statusRingLayer = vm.mapVM?.jobStatusRingLayer;
     vm.jobsById?.forEach((job) => {
         const m = job.marker;
         if (!m) return;
+
         const newStyle = styleForJob(job, { showStatus });
         const key = JSON.stringify(newStyle);
-        if (m._styleKey === key) return;
-
-        m.setIcon(makeShapeIcon(newStyle));
-        m._styleKey = key;
-        m._priorityColor = newStyle.fill || '#6b7280';
-
-        // The icon box size changed, so any existing pulse ring is now sized
-        // for the old geometry — rebuild it against the new icon.
-        if (m._pulseRing && pulseLayer) {
-            m._pulseRing._detach?.();
-            pulseLayer.removeLayer(m._pulseRing);
-            m._pulseRing = null;
-            upsertPulseRing(pulseLayer, job, m);
+        if (m._styleKey !== key) {
+            m.setIcon(makeShapeIcon(newStyle));
+            m._styleKey = key;
+            m._priorityColor = newStyle.fill || '#6b7280';
+            // icon box may have resized — rebuild the pulse ring against it
+            if (m._pulseRing && pulseLayer) {
+                m._pulseRing._detach?.();
+                pulseLayer.removeLayer(m._pulseRing);
+                m._pulseRing = null;
+                upsertPulseRing(pulseLayer, job, m);
+            }
         }
+
+        // Active marching ring: rebuild if on, tear down if the option is off
+        if (m._statusRing && statusRingLayer) {
+            m._statusRing._detach?.();
+            statusRingLayer.removeLayer(m._statusRing);
+            m._statusRing = null;
+        }
+        if (showStatus) upsertStatusRing(statusRingLayer, job, m);
     });
     vm.mapVM?._syncPulseRings?.();
 }
@@ -265,6 +300,63 @@ function upsertPulseRing(layerGroup, job, marker) {
     }
 }
 
+/**
+ * Active jobs get a magenta "marching ring" — a sibling non-interactive marker
+ * on jobStatusRingLayer, following the main marker, sized to the real shape.
+ * Same lifecycle model as the pulse ring.  Callers gate on the config option.
+ */
+function upsertStatusRing(layerGroup, job, marker) {
+    if (!layerGroup) return;
+    const want = statusHasRing(job.statusName?.());
+
+    if (want && !marker._statusRing) {
+        const base = marker.options.icon?.options || {};
+        const iconSize = base.iconSize || [14, 14];
+        const shapeD = base.shapeDiameter || Math.min(iconSize[0], iconSize[1]);
+        const ringR = shapeD / 2 + 4;                 // clear of the shape edge
+        const size = Math.ceil((ringR + 3) * 2);
+        const anchor = [Math.round(size / 2), Math.round(size / 2)];
+
+        const ring = L.marker(marker.getLatLng(), {
+            pane: 'pane-tippy-top',
+            icon: L.divIcon({
+                className: 'status-ring-icon',
+                html: buildStatusRingSvg(size, ringR),
+                iconSize: [size, size],
+                iconAnchor: anchor
+            }),
+            interactive: false,
+            keyboard: false
+        });
+
+        const follow = () => ring.setLatLng(marker.getLatLng());
+        marker.on('move', follow);
+        ring._detach = () => marker.off('move', follow);
+
+        // Sit behind the marker so the shape and the "!" pip always win their
+        // pixels — the ring is a background accent, not an overlay.
+        ring.setZIndexOffset((marker.options?.zIndexOffset || 0) - 100);
+        ring.addTo(layerGroup);
+        marker._statusRing = ring;
+    }
+
+    if (!want && marker._statusRing) {
+        marker._statusRing._detach?.();
+        layerGroup.removeLayer(marker._statusRing);
+        marker._statusRing = null;
+    }
+}
+
+/** Tear down and (if still wanted) rebuild the status ring against the current icon. */
+function rebuildStatusRing(layerGroup, job, marker) {
+    if (marker._statusRing && layerGroup) {
+        marker._statusRing._detach?.();
+        layerGroup.removeLayer(marker._statusRing);
+        marker._statusRing = null;
+    }
+    upsertStatusRing(layerGroup, job, marker);
+}
+
 // --- internals ---
 
 /**
@@ -283,6 +375,15 @@ function syncMarkerStyle(marker, job, vm, pulseLayer) {
         marker._styleKey = newKey;
     }
     marker._priorityColor = newStyle.fill || '#6b7280';
+
+    // Active marching ring — rebuild against the (possibly resized) icon
+    if (showStatus) {
+        rebuildStatusRing(vm.mapVM.jobStatusRingLayer, job, marker);
+    } else if (marker._statusRing) {
+        marker._statusRing._detach?.();
+        vm.mapVM.jobStatusRingLayer?.removeLayer(marker._statusRing);
+        marker._statusRing = null;
+    }
 
     // Check whether rescue status flipped
     const wasRescue = marker._isRescue;

--- a/src/pages/tasking/utils/jobTypesToUI.js
+++ b/src/pages/tasking/utils/jobTypesToUI.js
@@ -23,7 +23,7 @@ export function jobsToUI(job) {
 // Job status → pip colour. A lifecycle ramp kept clear of the priority hues
 // below, shown on markers only when config.showJobStatusOnMarkers is enabled.
 const statusPipMap = {
-    "New":       "#e4661d", // orange (matches the "new" pulse ring)
+    // New has no pip — the pulse ring already flags unacknowledged jobs.
     "Active":    "#159aab", // teal
     "Tasked":    "#6b52d6", // violet
     "Referred":  "#566f86", // slate

--- a/src/pages/tasking/utils/jobTypesToUI.js
+++ b/src/pages/tasking/utils/jobTypesToUI.js
@@ -20,40 +20,28 @@ export function jobsToUI(job) {
     return result;
 }
 
-// Job status → pip colour. A lifecycle ramp kept clear of the priority hues
-// below, shown on markers only when config.showJobStatusOnMarkers is enabled.
-const statusPipMap = {
-    // New has no pip — the pulse ring already flags unacknowledged jobs.
-    "Active":    "#159aab", // teal
-    "Tasked":    "#6b52d6", // violet
-    "Referred":  "#566f86", // slate
-    "Complete":  "#2f8f5b", // green
-    "Cancelled": "#8b949b", // grey
-    "Finalised": "#5b636a", // dark grey
-    "Rejected":  "#cc4460", // rose
-};
+// ── Status on markers (config.showJobStatusOnMarkers) ─────────────────────
+// New       → orange pulse ring (existing, unchanged)
+// Active    → magenta marching ring (drawn as a spinning dashed <g>)
+// Tasked    → nothing (a job someone is on shouldn't compete for attention)
+// Complete / Referred / Finalised → struck through  "/"
+// Cancelled / Rejected            → crossed out      "✕"
+// Any status with an action-required tag → red "!" pip, NE corner
+export const ACTIVE_RING_COLOUR = "#e5399b"; // magenta — clear of orange + priority fills
 
-// Job status → optional 1-glyph hint drawn inside the pip. New has no glyph
-// (an empty pip reads as "untouched"); closed states share a glyph with their
-// resolved-ok / resolved-not sibling and are told apart by colour.
-const statusPipGlyphMap = {
-    "Active":    "dot",       // live / being worked
-    "Tasked":    "arrow",     // dispatched to a team
-    "Referred":  "chevrons",  // forwarded elsewhere
-    "Complete":  "check",
-    "Cancelled": "cross",
-    "Finalised": "check",
-    "Rejected":  "cross",
-};
+const CLOSED_RESOLVED = new Set(["Complete", "Referred", "Finalised"]);
+const CLOSED_DEAD = new Set(["Cancelled", "Rejected"]);
 
-// Resolve a job's status name to its pip colour (null for unknown/blank).
-export function statusPipColor(statusName) {
-    return statusPipMap[statusName] || null;
+// "strike" (resolved) | "cross" (dead) | null
+export function statusClosedMark(statusName) {
+    if (CLOSED_RESOLVED.has(statusName)) return "strike";
+    if (CLOSED_DEAD.has(statusName)) return "cross";
+    return null;
 }
 
-// Resolve a job's status name to its pip glyph key (null for none).
-export function statusPipGlyph(statusName) {
-    return statusPipGlyphMap[statusName] || null;
+// Does this status get the marching ring?
+export function statusHasRing(statusName) {
+    return statusName === "Active";
 }
 
 // Priority → stroke color

--- a/src/pages/tasking/utils/jobTypesToUI.js
+++ b/src/pages/tasking/utils/jobTypesToUI.js
@@ -20,6 +20,42 @@ export function jobsToUI(job) {
     return result;
 }
 
+// Job status → pip colour. A lifecycle ramp kept clear of the priority hues
+// below, shown on markers only when config.showJobStatusOnMarkers is enabled.
+const statusPipMap = {
+    "New":       "#e4661d", // orange (matches the "new" pulse ring)
+    "Active":    "#159aab", // teal
+    "Tasked":    "#6b52d6", // violet
+    "Referred":  "#566f86", // slate
+    "Complete":  "#2f8f5b", // green
+    "Cancelled": "#8b949b", // grey
+    "Finalised": "#5b636a", // dark grey
+    "Rejected":  "#cc4460", // rose
+};
+
+// Job status → optional 1-glyph hint drawn inside the pip. New has no glyph
+// (an empty pip reads as "untouched"); closed states share a glyph with their
+// resolved-ok / resolved-not sibling and are told apart by colour.
+const statusPipGlyphMap = {
+    "Active":    "dot",       // live / being worked
+    "Tasked":    "arrow",     // dispatched to a team
+    "Referred":  "chevrons",  // forwarded elsewhere
+    "Complete":  "check",
+    "Cancelled": "cross",
+    "Finalised": "check",
+    "Rejected":  "cross",
+};
+
+// Resolve a job's status name to its pip colour (null for unknown/blank).
+export function statusPipColor(statusName) {
+    return statusPipMap[statusName] || null;
+}
+
+// Resolve a job's status name to its pip glyph key (null for none).
+export function statusPipGlyph(statusName) {
+    return statusPipGlyphMap[statusName] || null;
+}
+
 // Priority → stroke color
 const priorityStroke = {
     "Priority": "#FFA500",  // goldy yellow

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1153,6 +1153,7 @@ export function ConfigVM(root, deps) {
     self.clusterEnabled = ko.observable(true);
     self.clusterRadius = ko.observable(60);   // maxClusterRadius in px (10–80)
     self.clusterRescueJobs = ko.observable(true);
+    self.showJobStatusOnMarkers = ko.observable(false);
     self.alertsCollapsibleRules = ko.observable(true);
     self.taskingCountActiveOnly = ko.observable(false);
 
@@ -1290,6 +1291,7 @@ export function ConfigVM(root, deps) {
         clusterEnabled: !!self.clusterEnabled(),
         clusterRadius: Number(self.clusterRadius()) || 60,
         clusterRescueJobs: !!self.clusterRescueJobs(),
+        showJobStatusOnMarkers: !!self.showJobStatusOnMarkers(),
         alertsCollapsibleRules: !!self.alertsCollapsibleRules(),
         taskingCountActiveOnly: !!self.taskingCountActiveOnly(),
         suggestionEnabled: !!self.suggestionEnabled(),
@@ -1612,6 +1614,9 @@ export function ConfigVM(root, deps) {
         if (typeof cfg.clusterRescueJobs === 'boolean') {
             self.clusterRescueJobs(cfg.clusterRescueJobs);
         }
+        if (typeof cfg.showJobStatusOnMarkers === 'boolean') {
+            self.showJobStatusOnMarkers(cfg.showJobStatusOnMarkers);
+        }
         if (typeof cfg.alertsCollapsibleRules === 'boolean') {
             self.alertsCollapsibleRules(cfg.alertsCollapsibleRules);
         }
@@ -1757,6 +1762,7 @@ export function ConfigVM(root, deps) {
         root.mapVM?.applyPaneOrder?.(self.paneOrder().map(p => p.id));
         root.mapVM?.applyClusterRadius?.(Number(self.clusterRadius()) || 60);
         root.mapVM?.applyClusterEnabled?.(!!self.clusterEnabled());
+        root.mapVM?.applyJobStatusOnMarkers?.(!!self.showJobStatusOnMarkers());
         applyLayoutPresetClass(normalizeLayoutPreset(self.layoutPreset()));
         // Apply dark mode
         self._applyDarkMode();
@@ -1805,6 +1811,11 @@ export function ConfigVM(root, deps) {
 
     self.clusterRescueJobs.subscribe((v) => {
         root.mapVM?.applyRescueClusterSetting?.(!!v);
+        self.save();
+    })
+
+    self.showJobStatusOnMarkers.subscribe((v) => {
+        root.mapVM?.applyJobStatusOnMarkers?.(!!v);
         self.save();
     })
 

--- a/src/pages/tasking/viewmodels/Map.js
+++ b/src/pages/tasking/viewmodels/Map.js
@@ -241,8 +241,11 @@ export function MapVM(Lmap, root) {
   // Track whether clustering is currently active
   self.clusteringEnabled = true;
 
-  // Separate plain layer for pulse rings – not clustered
+  // Separate plain layers for the pulse ring (New) and the marching ring
+  // (Active) – not clustered, follow their marker, visibility kept in sync
+  // by _syncPulseRings.
   self.jobPulseLayer = L.layerGroup().addTo(self.map);
+  self.jobStatusRingLayer = L.layerGroup().addTo(self.map);
 
   // id → marker lookup (flat, no per-type groups)
   self.jobMarkerIndex = new Map();
@@ -1005,52 +1008,36 @@ export function MapVM(Lmap, root) {
     self.clearJobAssetBullseye();
   };
 
-  // Pulse ring visibility management for clustering
-  // When markers get clustered, hide their pulse rings.
-  // When unclustered or spiderfied, show them again.
+  // Ring visibility management for clustering.  The pulse ring (New) and the
+  // marching ring (Active) are only shown while their marker is individually
+  // visible — hidden while it's inside a cluster, shown again on spiderfy /
+  // unclustered / zoom-in.  Both rings follow the same rule.
   self._syncPulseRings = function () {
+    const setVisible = (ring, layer, visible) => {
+      if (!ring) return;
+      const has = layer.hasLayer(ring);
+      if (visible && !has) layer.addLayer(ring);
+      else if (!visible && has) layer.removeLayer(ring);
+    };
+
     self.jobMarkerIndex.forEach((marker) => {
-      if (!marker._pulseRing) return;
+      if (!marker._pulseRing && !marker._statusRing) return;
 
-      // Markers on the standalone rescue layer (not in the cluster group)
-      // are always individually visible – skip cluster logic for them.
+      let visible;
       if (self.rescueJobLayer.hasLayer(marker)) {
-        if (!self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.addLayer(marker._pulseRing);
-        }
-        return;
-      }
-
-      // When clustering is disabled, all markers are individually visible.
-      if (!self.clusteringEnabled || self.unclusteredJobLayer.hasLayer(marker)) {
-        if (!self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.addLayer(marker._pulseRing);
-        }
-        return;
-      }
-
-      let visibleParent;
-      try {
-        visibleParent = self.jobClusterGroup.getVisibleParent(marker);
-      } catch (err) {
-        // On error, hide the pulse ring to be safe
-        if (self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.removeLayer(marker._pulseRing);
-        }
-        return;
-      }
-
-      if (visibleParent === marker) {
-        // Marker is individually visible – show pulse ring
-        if (!self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.addLayer(marker._pulseRing);
-        }
+        visible = true;
+      } else if (!self.clusteringEnabled || self.unclusteredJobLayer.hasLayer(marker)) {
+        visible = true;
       } else {
-        // Marker is inside a cluster – hide pulse ring
-        if (self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.removeLayer(marker._pulseRing);
+        try {
+          visible = self.jobClusterGroup.getVisibleParent(marker) === marker;
+        } catch (err) {
+          visible = false; // on error, hide to be safe
         }
       }
+
+      setVisible(marker._pulseRing, self.jobPulseLayer, visible);
+      setVisible(marker._statusRing, self.jobStatusRingLayer, visible);
     });
   };
 

--- a/src/pages/tasking/viewmodels/Map.js
+++ b/src/pages/tasking/viewmodels/Map.js
@@ -5,6 +5,7 @@ import 'leaflet.markercluster';
 
 import { AssetPopupViewModel } from './AssetPopUp';
 import { JobPopupViewModel } from './JobPopUp';
+import { restyleAllJobMarkers } from '../markers/jobMarker.js';
 
 export function MapVM(Lmap, root) {
   const self = this;
@@ -279,6 +280,19 @@ export function MapVM(Lmap, root) {
       }
     });
     self._syncPulseRings();
+  };
+
+  /**
+   * Re-render all job marker icons — called when the "show status on markers"
+   * config option is toggled.
+   */
+  self.applyJobStatusOnMarkers = function (on) {
+    // `on` is passed explicitly by Config (root.config isn't wired yet when
+    // this first runs from afterConfigLoad); fall back to reading it live.
+    const enabled = (on === undefined) ? !!root.config?.showJobStatusOnMarkers?.() : !!on;
+    document.querySelectorAll('.legend-status-block')
+      .forEach((el) => el.classList.toggle('d-none', !enabled));
+    restyleAllJobMarkers(root);
   };
 
   /**

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2862,14 +2862,16 @@
                                                                     data-bind="checked: config.showJobStatusOnMarkers">
                                                                 <label class="form-check-label"
                                                                     for="jobStatusOnMarkersToggle">
-                                                                    Show status pip on incident markers
+                                                                    Show job status on incident markers
                                                                 </label>
                                                             </div>
                                                             <div class="form-text">
-                                                                Adds a small coloured dot to the top-right of each
-                                                                incident marker showing its lifecycle status — New,
-                                                                Active, Tasked, Referred, Complete, Cancelled,
-                                                                Finalised or Rejected.
+                                                                Active jobs get a magenta marching ring so they catch
+                                                                the eye; Complete / Referred / Finalised are struck
+                                                                through, Cancelled / Rejected crossed out. A red
+                                                                &ldquo;!&rdquo; corner dot marks any job with an
+                                                                action-required tag. New keeps its orange pulse ring;
+                                                                Tasked is left unmarked.
                                                             </div>
                                                         </fieldset>
                                                     </div>

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2850,6 +2850,30 @@
                                                         </fieldset>
                                                     </div>
 
+                                                    <!-- Incident status on markers -->
+                                                    <div class="col-md-6">
+                                                        <fieldset>
+                                                            <legend class="form-label fw-semibold mb-2">
+                                                                <i class="fa fa-circle-info me-1"></i>Incident Status on Markers
+                                                            </legend>
+                                                            <div class="form-check form-switch mb-2">
+                                                                <input class="form-check-input" type="checkbox"
+                                                                    role="switch" id="jobStatusOnMarkersToggle"
+                                                                    data-bind="checked: config.showJobStatusOnMarkers">
+                                                                <label class="form-check-label"
+                                                                    for="jobStatusOnMarkersToggle">
+                                                                    Show status pip on incident markers
+                                                                </label>
+                                                            </div>
+                                                            <div class="form-text">
+                                                                Adds a small coloured dot to the top-right of each
+                                                                incident marker showing its lifecycle status — New,
+                                                                Active, Tasked, Referred, Complete, Cancelled,
+                                                                Finalised or Rejected.
+                                                            </div>
+                                                        </fieldset>
+                                                    </div>
+
                                                 </div>
 
                                                 <hr class="my-4">

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -1445,6 +1445,35 @@ tr.job:hover {
   }
 }
 
+/* STATUS RING — the Active "marching ring" (separate follower marker).
+   A dashed circle whose <g> rotates, which reads as marching ants and is
+   compositor-only (cheap) unlike animating stroke-dashoffset. */
+.status-ring-icon {
+  pointer-events: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  line-height: 0;
+  font-size: 0;
+}
+
+.status-ring-spin {
+  animation: status-ring-spin 9s linear infinite;
+}
+
+@keyframes status-ring-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-ring-spin {
+    animation: none;
+  }
+}
+
 .no-drag {
   user-select: text !important;
   cursor: text !important;

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -1707,7 +1707,12 @@ overflow: hidden;
   border-radius: 8px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
   min-width: 120px;
-  max-width: 80vw;
+  /* cap the spread (~3 narrow columns) so it can't sheet across the map;
+     anything past this scrolls inside the box */
+  max-width: min(88vw, 620px);
+  max-height: calc(100vh - 24px);
+  max-height: calc(100dvh - 24px);
+  overflow: auto;
   font-size: 13px;
 }
 
@@ -1715,13 +1720,19 @@ overflow: hidden;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  max-height: calc(100vh - 120px);
-  gap: 0 20px;
+  /* keep wrapped columns packed to the left rather than spread across */
+  align-content: flex-start;
+  /* Wrap into a new column (rightwards) before the stack climbs into the
+     zoom / tool buttons running down the left edge of the map. The 180px
+     floor stops it collapsing to slivers on very short windows. */
+  max-height: max(180px, calc(100vh - 300px));
+  max-height: max(180px, calc(100dvh - 300px));
+  gap: 0 18px;
 }
 
 .legend-body > div {
-  min-width: 190px;
-  max-width: 300px;
+  min-width: 165px;
+  max-width: 260px;
 }
 
 .legend-container i {


### PR DESCRIPTION
**Draft / WIP — not yet verified across all zoom / cluster states on a running map.**

## What

Config-gated (**Page settings → Display Settings → Incident Status on Markers**, off by default). Status treatments never touch the marker body — **shape stays job type, fill stays priority**.

| Status | Treatment |
|---|---|
| **New / unacknowledged** | orange pulse ring — *existing, unchanged* |
| **Active** | magenta **marching ring** (the one thing that pulls the eye) |
| **Tasked** | nothing — a job someone's already on shouldn't compete for attention |
| **Complete / Referred / Finalised** | dark `/` strike over the marker |
| **Cancelled / Rejected** | dark `✕` |
| *any status with an action-required tag* | red `!` pip, NE corner |

Closed markers keep **full priority colour and full opacity** — the strike / `✕` is the whole signal (thin dark line + white casing so it reads on any fill). The `!` pip is independent of status (`job.actionRequiredTags`, tag group 27).

The design was worked through in an artifact; this is the "in context" option from it.

## How

- **`utils/jobTypesToUI.js`** — `statusClosedMark()` (strike/cross), `statusHasRing()` (Active), `ACTIVE_RING_COLOUR`.
- **`components/job_icon.js`** — `makeShapeIcon()` draws the strike/`✕` and the `!` pip in a symmetrically-padded box (keeps `shapeDiameter` so the rings stay sized to the real shape). New `buildStatusRingSvg()` — a dashed circle in a `<g>` that's **rotated** via CSS (`transform: rotate()`, compositor-only) rather than animating `stroke-dashoffset` on every marker.
- **`markers/jobMarker.js`** — `upsertStatusRing()` / `rebuildStatusRing()`: the marching ring as a sibling non-interactive follower marker (same model as the pulse ring), sitting behind the marker (`zIndexOffset -100`) so the shape and pip win their pixels. New `actionRequiredTags` subscription. `restyleAllJobMarkers()` / `removeJobMarker()` / `syncMarkerStyle()` updated.
- **`viewmodels/Map.js`** — new `jobStatusRingLayer`; `_syncPulseRings()` refactored to sync **both** rings (pulse + marching) against one cluster/zoom visibility rule.
- **`components/legend.js`** — "Job Status (Any type)" section with example rows for New / Active / Tasked / strike / cross / `!`. *(Also carries a small unrelated cluster-pulse-hex legend tweak that was already in the working tree.)*
- **`styles/pages/tasking.css`** — `.status-ring-spin` keyframes + `prefers-reduced-motion` guard (static ring).
- **`static/pages/tasking.html`** — toggle description rewritten.

Config observable `showJobStatusOnMarkers` was already wired (previous commit) — no change.

## Known limitation

`actionRequiredTags` is only fetched **per-job** (`fetchUnresolvedActionsLog`, via `job.refreshData()` — popup open, SignalR `jobUpdated`/`jobCreated`, or the periodic refresh), **not** in the bulk job-list payload. So `!` pips populate as jobs refresh rather than immediately on load. Making the toggle-on trigger a refresh for all filtered-in jobs is an option if that's not acceptable.

## Testing

- `npm run lint` — clean
- `npm run dev` — builds
- ⚠️ Screenshotted once mid-development (strike was oversized, since tightened). Still needs a proper pass: marching ring at real zoom, strike/`✕` legibility over each priority fill, `!` vs Rescue-red, ring show/hide on cluster + spiderfy, reduced-motion fallback, the `!` pip appearing after a job's action log loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)