### PR TITLE
Handle lowercase Beacon URLs for Lighthouse menus and content scripts

### DIFF
--- a/src/injectscripts/all.js
+++ b/src/injectscripts/all.js
@@ -304,7 +304,7 @@ whenWeAreReady(function () {
   }
 
   //lighthouse menu for teams
-  if (location.pathname == '/Teams') {
+  if (location.pathname.toLowerCase() == '/teams') {
     let regionfilter;
     if (user.hq.EntityTypeId != 1) {
       //make region level more obvious
@@ -481,7 +481,7 @@ whenWeAreReady(function () {
   }
 
   //lighthouse menu for situation map
-  if (location.pathname == '/Jobs/SituationalAwareness') {
+  if (location.pathname.toLowerCase() == '/jobs/situationalawareness') {
     let regionfilter;
     if (user.currentHqTypeId != 1) {
       //make region level more obvious
@@ -604,7 +604,7 @@ whenWeAreReady(function () {
 
   //lighthouse menu for jobs
 
-  if (location.pathname === '/Jobs') {
+  if (location.pathname.toLowerCase() === '/jobs') {
     let regionfilter;
     if (user.hq.EntityTypeId != 1) {
       //make region level more obvious

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -77,7 +77,8 @@
     {
       "matches": [
         "https://*.ses.nsw.gov.au/Jobs?q=*",
-        "https://*.ses.nsw.gov.au/Jobs"
+        "https://*.ses.nsw.gov.au/Jobs",
+        "https://*.ses.nsw.gov.au/jobs"
       ],
       "js": ["contentscripts/jobs/jobs.js"]
     },
@@ -89,6 +90,7 @@
         "https://*.ses.nsw.gov.au/Jobs/Sectors*",
         "https://*.ses.nsw.gov.au/Jobs/*/Edit",
         "https://*.ses.nsw.gov.au/Jobs",
+        "https://*.ses.nsw.gov.au/jobs",
         "https://*.ses.nsw.gov.au/Jobs/Create",
         "https://*.ses.nsw.gov.au/Jobs/Create?*"
       ],
@@ -108,6 +110,7 @@
     {
       "matches": [
         "https://*.ses.nsw.gov.au/Messages/Create",
+        "https://*.ses.nsw.gov.au/messages/create/",
         "https://*.ses.nsw.gov.au/Messages/Create/",
         "https://*.ses.nsw.gov.au/Messages/Create?*"
       ],


### PR DESCRIPTION
## Problem

Beacon routes are case-insensitive server-side, so navigating to a lowercase path such as `/jobs` serves a fully working page. Lighthouse, however, gated its enhancements on case-sensitive URL checks, so on those URLs:

- the **Lighthouse Quick Filters** menu (jobs list, teams list, situational awareness) never appeared — the inject script compared `location.pathname` against exact strings like `/Jobs`
- the jobs-list buttons (Summary / Statistics / Advanced Export) and the Messages compose enhancements never loaded — the content-script `matches` patterns in `manifest.json` are case-sensitive on the path

## Changes

**`src/injectscripts/all.js`** — lower-case `location.pathname` before comparing, for the three affected menus:
- Jobs list quick filters (`/jobs`)
- Teams list quick filters (`/teams`)
- Situational Awareness menu (`/jobs/situationalawareness`)

**`static/manifest.json`** — add lowercase match entries:
- `https://*.ses.nsw.gov.au/jobs` to the `contentscripts/jobs/jobs.js` matches, and the matching `exclude_matches` entry for `contentscripts/jobs/view.js`
- `https://*.ses.nsw.gov.au/messages/create/` to the `contentscripts/messages/create.js` matches

## Not exhaustive

The added manifest entries cover the lowercase root path only. Other case variants (e.g. `/jobs?q=*`, `/messages/create` without a trailing slash or with `?*`) still have capitalised forms only. A fuller fix would move these registrations to background injection with case-insensitive regexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)