### PR TITLE
Add team-type filter to tasking Team & Tasking Filters

### DIFF
--- a/src/pages/tasking/bindings/statusFilters.js
+++ b/src/pages/tasking/bindings/statusFilters.js
@@ -85,6 +85,7 @@ export function installStatusFilterBindings() {
     ko.bindingHandlers.jobStatusFilter = makeStatusFilterBinding("jobStatusFilter");
     ko.bindingHandlers.incidentTypeFilter = makeStatusFilterBinding("incidentTypeFilter");
     ko.bindingHandlers.teamTaskStatusFilter = makeStatusFilterBinding("teamTaskStatusFilter");
+    ko.bindingHandlers.teamTypeFilter = makeStatusFilterBinding("teamTypeFilter");
 
     // filters + fetch + save
     ko.bindingHandlers.teamStatusFilterAndFetch = makeStatusFilterBinding(
@@ -97,6 +98,14 @@ export function installStatusFilterBindings() {
 
     ko.bindingHandlers.teamTaskStatusFilterAndFetch = makeStatusFilterBinding(
         "teamTaskStatusFilter",
+        (vm, cfg) => {
+            cfg.save();
+            vm.fetchAllTeamData();
+        }
+    );
+
+    ko.bindingHandlers.teamTypeFilterAndFetch = makeStatusFilterBinding(
+        "teamTypeFilter",
         (vm, cfg) => {
             cfg.save();
             vm.fetchAllTeamData();

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -1085,6 +1085,7 @@ function VM() {
     self.teamMatchesConfigFilters = function (tm) {
         const allowed = self.config.teamStatusFilter(); // allow-list
         const allowedSet = new Set(allowed || []);
+        const allowedTypeSet = new Set(self.config.teamTypeFilter() || []); // allow-list of team type names
         const hqFilterIds = new Set((self.config.teamFilters() || []).map(f => String(f.id)));
         const applySectorsToTeams = self.config.applySectorsToTeams();
         const sectorIds = new Set((self.config.sectorFilters() || []).map(s => String(s.id)));
@@ -1109,6 +1110,16 @@ function VM() {
         // If allow-list non-empty, only show teams whose status is in it
         if (allowedSet.size > 0 && !allowedSet.has(status)) {
             return false;
+        }
+
+        // Team type allow-list (Field / Operations / Aviation). Beacon already
+        // filters the fetch by TypeIds; this also drops wrong-type teams that
+        // arrive via SignalR pushes. Lenient when the type is unknown.
+        if (allowedTypeSet.size > 0) {
+            const typeName = tm.teamType()?.Name;
+            if (typeName && !allowedTypeSet.has(typeName)) {
+                return false;
+            }
         }
 
         //must match HQ filter
@@ -3018,6 +3029,13 @@ function VM() {
             const entry = Object.values(Enum.TeamStatusType).find(e => e.Description === desc);
             return entry ? entry.Id : undefined;
         }).filter(id => id !== undefined);
+
+        // Team type allow-list (Field / Operations / Aviation) -> Beacon TypeIds.
+        // Empty array means "all types" -- teamSearch omits the param entirely.
+        const typeFilterToView = myViewModel.config.teamTypeFilter().map(name => {
+            const entry = Object.values(Enum.TeamType).find(e => e.Name === name);
+            return entry ? entry.Id : undefined;
+        }).filter(id => id !== undefined);
         var end = new Date();
         var start = new Date();
         start.setDate(end.getDate() - myViewModel.config.fetchPeriod());
@@ -3067,7 +3085,8 @@ function VM() {
                     }
                     myViewModel.getOrCreateTeam(t);
                 })
-            }
+            },
+            typeFilterToView //team type filter
         )
     }
 

--- a/src/pages/tasking/models/Team.js
+++ b/src/pages/tasking/models/Team.js
@@ -144,6 +144,7 @@ export function Team(data = {}, deps = {}) {
     self.callsign = ko.observable(data.Callsign ?? "");
     self.assignedTo = ko.observable(new Entity(data.AssignedTo || data.CreatedAt)); //safety code for beacon bug
     self.teamStatusType = ko.observable(data.TeamStatusType || null); // {Id,Name,Description}
+    self.teamType = ko.observable(data.TeamType || null); // {Id,Name} -- Field / Operations / Aviation
     self.sector = ko.observable(new Sector(data.Sector || {}));
     self.members = ko.observableArray(data.Members);
     self.taskedJobCount = ko.observable(data.TaskedJobCount || 0);
@@ -662,6 +663,15 @@ export function Team(data = {}, deps = {}) {
             }
             const cur = this.teamStatusType();
             if (!cur || cur.Id !== status?.Id) this.teamStatusType(status);
+        }
+        if (d.TeamType !== undefined) {
+            let type = d.TeamType;
+            if (type && type.Name === undefined && type.Id != null) {
+                // Reduced {Id} objects (some pushes) -- resolve the full entry.
+                type = Object.values(Enum.TeamType).find(t => t.Id === type.Id) || type;
+            }
+            const cur = this.teamType();
+            if (!cur || cur.Id !== type?.Id) this.teamType(type);
         }
         if (d.Members !== undefined) {
             // Members is an array of objects — compare by length + leader/person ids

--- a/src/pages/tasking/utils/enum.js
+++ b/src/pages/tasking/utils/enum.js
@@ -102,6 +102,33 @@ export const Enum = {
             "Colour": null
         }
     },
+    TeamType:
+    {
+        "Field": {
+            "Id": 1,
+            "Name": "Field",
+            "Description": "Field",
+            "ParentId": null,
+            "GroupId": null,
+            "Colour": null
+        },
+        "Operations": {
+            "Id": 2,
+            "Name": "Operations",
+            "Description": "Operations",
+            "ParentId": null,
+            "GroupId": null,
+            "Colour": null
+        },
+        "Aviation": {
+            "Id": 3,
+            "Name": "Aviation",
+            "Description": "Aviation",
+            "ParentId": null,
+            "GroupId": null,
+            "Colour": null
+        }
+    },
     JobStatusType:
     {
         "New": {

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1149,6 +1149,10 @@ export function ConfigVM(root, deps) {
 
     self.teamTaskStatusFilter = ko.observableArray([]);
 
+    // Team type allow-list (Field / Operations / Aviation). Empty = all types.
+    // blown away on load
+    self.teamTypeFilter = ko.observableArray([]);
+
     // Map clustering
     self.clusterEnabled = ko.observable(true);
     self.clusterRadius = ko.observable(60);   // maxClusterRadius in px (10–80)
@@ -1235,6 +1239,10 @@ export function ConfigVM(root, deps) {
         "Activated"
     ];
 
+    self.teamTypeFilterDefaults = [
+        "Field"
+    ];
+
     self.incidentTypeFilterDefaults = [
         "Tsunami",
         "Other",
@@ -1280,6 +1288,7 @@ export function ConfigVM(root, deps) {
         jobStatusFilter: ko.toJS(self.jobStatusFilter),
         incidentTypeFilter: ko.toJS(self.incidentTypeFilter),
         teamTaskStatusFilter: ko.toJS(self.teamTaskStatusFilter),
+        teamTypeFilter: ko.toJS(self.teamTypeFilter),
         sectorFilters: ko.toJS(self.sectorFilters),
         includeIncidentsWithoutSector: !!self.includeIncidentsWithoutSector(),
         applySectorsToIncidents: !!self.applySectorsToIncidents(),
@@ -1509,6 +1518,7 @@ export function ConfigVM(root, deps) {
             cfg.jobStatusFilter = self.jobStatusFilterDefaults;
             cfg.incidentTypeFilter = self.incidentTypeFilterDefaults;
             cfg.teamTaskStatusFilter = self.teamTaskStatusFilterDefaults;
+            cfg.teamTypeFilter = self.teamTypeFilterDefaults;
             cfg.sectorFilters = [];
             cfg.includeIncidentsWithoutSector = true;
             cfg.applySectorsToIncidents = false;
@@ -1585,6 +1595,13 @@ export function ConfigVM(root, deps) {
         }
         if (Array.isArray(cfg.teamTaskStatusFilter)) {
             self.teamTaskStatusFilter(cfg.teamTaskStatusFilter);
+        }
+        // Saved configs from before team-type filtering won't have this key --
+        // fall back to the default (Field only) rather than "all types".
+        if (Array.isArray(cfg.teamTypeFilter)) {
+            self.teamTypeFilter(cfg.teamTypeFilter);
+        } else {
+            self.teamTypeFilter(self.teamTypeFilterDefaults.slice());
         }
         if (Array.isArray(cfg.sectorFilters)) {
             self.sectorFilters(cfg.sectorFilters);

--- a/src/shared/BeaconClient/team.js
+++ b/src/shared/BeaconClient/team.js
@@ -61,7 +61,7 @@ export function get(id, viewModelType = 1, host, userId = 'notPassed', token, ca
 
 
 //make the call to beacon
-export function teamSearch(unit, host, StartDate, EndDate, userId = 'notPassed', token, callback, progressCallBack, statusTypes = [], onPage) {
+export function teamSearch(unit, host, StartDate, EndDate, userId = 'notPassed', token, callback, progressCallBack, statusTypes = [], onPage, typeIds = []) {
   console.debug("teamSearch called");
   let params = {};
   params['StatusStartDate'] = StartDate.toISOString();
@@ -70,6 +70,12 @@ export function teamSearch(unit, host, StartDate, EndDate, userId = 'notPassed',
   params['SortOrder'] = 'asc';
   params['StatusTypeId'] = statusTypes;
   params['IncludeDeleted'] = false;
+
+  // Beacon's Teams/Search filters on team type (Field / Operations / Aviation)
+  // when given TypeIds -- serialised traditionally as TypeIds=1&TypeIds=3.
+  if (Array.isArray(typeIds) && typeIds.length > 0) {
+    params['TypeIds'] = typeIds;
+  }
 
   if (unit !== null || typeof unit === 'undefined') {
     if (Array.isArray(unit) == false) {

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -149,6 +149,32 @@
                                     </div>
                                 </li>
                                 <li>
+                                    <button class="dropdown-item d-flex justify-content-between align-items-center"
+                                        type="button" data-bs-toggle="collapse"
+                                        data-bs-target="#teamTypeFilterMenu" aria-expanded="false"
+                                        aria-controls="teamTypeFilterMenu">
+                                        Team Type Filters
+                                        <span class="ms-2 fa fa-chevron-right small"></span>
+                                    </button>
+                                    <div class="collapse dropdown-collapse-body" id="teamTypeFilterMenu">
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" id="tddTeamTypeField"
+                                                data-bind="teamTypeFilterAndFetch: 'Field'">
+                                            <label class="form-check-label" for="tddTeamTypeField">Field</label>
+                                        </div>
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" id="tddTeamTypeOperations"
+                                                data-bind="teamTypeFilterAndFetch: 'Operations'">
+                                            <label class="form-check-label" for="tddTeamTypeOperations">Operations</label>
+                                        </div>
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" id="tddTeamTypeAviation"
+                                                data-bind="teamTypeFilterAndFetch: 'Aviation'">
+                                            <label class="form-check-label" for="tddTeamTypeAviation">Aviation</label>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li>
                                     <hr class="dropdown-divider">
                                 </li>
                                 <li>
@@ -2584,6 +2610,36 @@
                                                                     data-bind="teamTaskStatusFilter: 'CalledOff'">
                                                                 <label class="form-check-label"
                                                                     for="taskStatusCalledOff">CalledOff</label>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-6 col-lg-4">
+                                                        <label class="form-label d-block mb-2">Show Teams Of
+                                                            Type:</label>
+                                                        <div class="border rounded p-2" id="teamTypeBox">
+                                                            <div class="form-check">
+                                                                <input class="form-check-input team-status"
+                                                                    type="checkbox" id="teamTypeField"
+                                                                    value="Field"
+                                                                    data-bind="teamTypeFilter: 'Field'">
+                                                                <label class="form-check-label"
+                                                                    for="teamTypeField">Field</label>
+                                                            </div>
+                                                            <div class="form-check">
+                                                                <input class="form-check-input team-status"
+                                                                    type="checkbox" id="teamTypeOperations"
+                                                                    value="Operations"
+                                                                    data-bind="teamTypeFilter: 'Operations'">
+                                                                <label class="form-check-label"
+                                                                    for="teamTypeOperations">Operations</label>
+                                                            </div>
+                                                            <div class="form-check">
+                                                                <input class="form-check-input team-status"
+                                                                    type="checkbox" id="teamTypeAviation"
+                                                                    value="Aviation"
+                                                                    data-bind="teamTypeFilter: 'Aviation'">
+                                                                <label class="form-check-label"
+                                                                    for="teamTypeAviation">Aviation</label>
                                                             </div>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
## What

Adds a **team type** filter (Field / Operations / Aviation) to the tasking page's **Team & Tasking Filters**, alongside the existing team status and team task status filters. Defaults to **Field only** ticked.

## Changes

- **Enum** — new `Enum.TeamType`: `Field` (1), `Operations` (2), `Aviation` (3).
- **Beacon client** — `teamSearch(...)` takes an optional trailing `typeIds = []`; when non-empty it appends `TypeIds` to the query (`TypeIds=1&TypeIds=3`, same traditional-array style as the existing `StatusTypeId`). Empty ⇒ param omitted ⇒ all types. The two other callers (`teamsummary.js` `HackTheMatrix`, `getTeamGeoJson`) pass fewer positional args, so `typeIds` defaults to `[]` and their requests are unchanged.
- **Config** — new `teamTypeFilter` observable + `teamTypeFilterDefaults = ["Field"]`, persisted in `buildConfig` / restored in `loadFromStorage`. Saved configs from before this change (no `teamTypeFilter` key) fall back to **Field only** rather than "all types", so the default applies to existing users too.
- **Fetch** — `fetchAllTeamData` maps the filter names to `Enum.TeamType` ids and passes them to `teamSearch`.
- **Client-side backstop** — `teamMatchesConfigFilters` drops wrong-type teams that arrive via SignalR pushes; lenient when a team's type is unknown, so server-side `TypeIds` filtering does the real work.
- **Team model** — `teamType` observable (`{Id,Name}`), populated from `data.TeamType` and kept current in `updateFromJson` (resolving reduced `{Id}` push payloads via the enum, like `teamStatusType`).
- **UI** — new "Show Teams Of Type:" column in the config modal's Team & Tasking Filters accordion, and a "Team Type Filters" collapsible section in the team toolbar filter dropdown for parity with the other team filters.

## Assumptions

Assumes Beacon's `Teams/Search` accepts `TypeIds` and that tasking search results / pushes include a `TeamType` field — both are used elsewhere (`src/lib/getteams.js`, `src/pages/teamsummary.js`, the SignalR `knownEvents.js` comment). If the tasking search viewmodel omits `TeamType`, the row list still filters correctly server-side; only the push backstop goes quiet.

## Testing

- `npm run lint` clean on changed files
- `npx webpack --config webpack.dev.js` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)