### PR TITLE
Reorganise the tasking Page Config modal into a left-rail section nav

### DIFF
--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1216,6 +1216,11 @@ export function ConfigVM(root, deps) {
     self.alertsCollapsibleRules = ko.observable(true);
     self.taskingCountActiveOnly = ko.observable(false);
 
+    // On/Off pill labels for the Appearance pane switches
+    self.darkModeLabel = ko.pureComputed(() => (self.darkMode() ? 'On' : 'Off'));
+    self.alertsCollapseLabel = ko.pureComputed(() => (self.alertsCollapsibleRules() ? 'On' : 'Off'));
+    self.taskingCountLabel = ko.pureComputed(() => (self.taskingCountActiveOnly() ? 'On' : 'Off'));
+
     // pinned rows
     self.pinnedTeamIds = ko.observableArray([]);
     self.pinnedIncidentIds = ko.observableArray([]);

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1103,6 +1103,36 @@ export function ConfigVM(root, deps) {
         return `every ${Math.round(s / 60)} min`;
     });
     self.liveUpdatesLabel = ko.pureComputed(() => (self.signalrEnabled() ? 'On' : 'Off'));
+
+    // Data pane -- one-tap presets for the values these are actually set to.
+    // The number field beside each row stays as the escape hatch for odd
+    // values; an off-preset value simply leaves no preset highlighted.
+    self.refreshPresets = [
+        { value: 30, label: '30s' },
+        { value: 60, label: '1 min' },
+        { value: 120, label: '2 min' },
+        { value: 180, label: '3 min' },
+        { value: 300, label: '5 min' },
+        { value: 600, label: '10 min' }
+    ];
+    self.historyPresets = [
+        { value: 0, label: 'Today' },
+        { value: 1, label: '1 day' },
+        { value: 3, label: '3 days' },
+        { value: 7, label: '1 week' },
+        { value: 14, label: '2 weeks' },
+        { value: 31, label: '1 month' }
+    ];
+    self.lookaheadPresets = [
+        { value: 0, label: 'None' },
+        { value: 1, label: '1 day' },
+        { value: 3, label: '3 days' },
+        { value: 7, label: '1 week' }
+    ];
+    self.pickRefreshPreset = (p) => self.refreshInterval(p.value);
+    self.pickHistoryPreset = (p) => self.fetchPeriod(p.value);
+    self.pickLookaheadPreset = (p) => self.fetchForward(p.value);
+
     self.showAdvanced = ko.observable(false);
     self.darkMode = ko.observable(false);
 

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -411,7 +411,10 @@ export function ConfigVM(root, deps) {
     // Other settings
     self.signalrEnabled = ko.observable(true);
     self.refreshInterval = ko.observable(180);
-    // Guard for reckless refresh interval changes
+    // Guard for an aggressively short full-refresh interval. Slower is always
+    // safe, so only prompt when the new value drops below this many seconds --
+    // that's where every open copy of LAD starts hammering Beacon.
+    const REFRESH_GATE_SECONDS = 60;
     let lastRefreshInterval = self.refreshInterval();
     let suppressRecklessModal = false;
     self.refreshInterval.subscribe(function(newVal) {
@@ -419,9 +422,9 @@ export function ConfigVM(root, deps) {
             lastRefreshInterval = newVal;
             return;
         }
-        // Only trigger if the value is being changed to something different
-        if (Number(newVal) !== Number(lastRefreshInterval)) {
-            showRecklessModal({
+        const n = Number(newVal);
+        if (Number.isFinite(n) && n < REFRESH_GATE_SECONDS && n !== Number(lastRefreshInterval)) {
+            showShortRefreshModal(n, {
                 onConfirm: () => {
                     lastRefreshInterval = newVal;
                 },
@@ -432,60 +435,65 @@ export function ConfigVM(root, deps) {
                     suppressRecklessModal = false;
                 }
             });
+        } else {
+            lastRefreshInterval = newVal;
         }
     });
 
-    // Modal logic for reckless confirmation
-    function showRecklessModal({ onConfirm, onCancel }) {
-        // Create modal HTML if not present
-        let modal = document.getElementById('recklessModal');
+    // Confirm dialog for a very short full-refresh interval.
+    function showShortRefreshModal(seconds, { onConfirm, onCancel }) {
+        let modal = document.getElementById('shortRefreshModal');
         if (!modal) {
             modal = document.createElement('div');
-            modal.id = 'recklessModal';
+            modal.id = 'shortRefreshModal';
             modal.className = 'modal fade';
             modal.tabIndex = -1;
             modal.innerHTML = `
                 <div class="modal-dialog modal-dialog-centered">
                   <div class="modal-content">
-                    <div class="modal-header bg-danger text-white">
-                      <h5 class="modal-title">Are you sure?</h5>
+                    <div class="modal-header bg-warning text-dark">
+                      <h5 class="modal-title" id="shortRefreshTitle"></h5>
                       <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                      <p>Changing the refresh interval can have unintended consequences. To proceed, type <b>reckless</b> below and press Confirm.</p>
-                      <input id="recklessInput" type="text" class="form-control" placeholder="Type 'reckless' to confirm">
-                      <div id="recklessError" class="text-danger mt-2" style="display:none;">You must type 'reckless' to confirm.</div>
+                      <p>This will re-query <b>every</b> incident, team and tasking in your window from Beacon, on your machine, this often. Each sweep is a heavy set of calls and the board churns while it runs.</p>
+                      <p class="mb-3">Live updates already keep your board current between sweeps &mdash; you rarely need the full refresh this frequent.</p>
+                      <label class="form-label mb-1" for="shortRefreshInput">Type <b id="shortRefreshNum"></b> to confirm.</label>
+                      <input id="shortRefreshInput" type="text" class="form-control" autocomplete="off" inputmode="numeric">
+                      <div id="shortRefreshError" class="text-danger small mt-2" style="display:none;"></div>
                     </div>
                     <div class="modal-footer">
-                      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="recklessCancel">Cancel</button>
-                      <button type="button" class="btn btn-danger" id="recklessConfirm">Confirm</button>
+                      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="shortRefreshCancel">Keep previous</button>
+                      <button type="button" class="btn btn-warning" id="shortRefreshConfirm">Use this interval</button>
                     </div>
                   </div>
                 </div>
             `;
             document.body.appendChild(modal);
         }
+        modal.querySelector('#shortRefreshTitle').textContent = `Full refresh every ${seconds} seconds?`;
+        modal.querySelector('#shortRefreshNum').textContent = String(seconds);
+
         const bsModal = bootstrap.Modal.getOrCreateInstance(modal);
         bsModal.show();
 
-        // Reset input and error
-        const input = modal.querySelector('#recklessInput');
-        const error = modal.querySelector('#recklessError');
+        const input = modal.querySelector('#shortRefreshInput');
+        const error = modal.querySelector('#shortRefreshError');
         input.value = '';
         error.style.display = 'none';
         input.focus();
 
-        // Remove previous listeners
-        const confirmBtn = modal.querySelector('#recklessConfirm');
-        const cancelBtn = modal.querySelector('#recklessCancel');
+        const confirmBtn = modal.querySelector('#shortRefreshConfirm');
+        const cancelBtn = modal.querySelector('#shortRefreshCancel');
         confirmBtn.onclick = null;
         cancelBtn.onclick = null;
 
         confirmBtn.onclick = function() {
-            if (input.value.trim().toLowerCase() === 'reckless') {
+            if (input.value.trim() === String(seconds)) {
                 bsModal.hide();
                 onConfirm && onConfirm();
             } else {
+                error.textContent = `Type ${seconds} to confirm.`;
                 error.style.display = '';
                 input.focus();
             }
@@ -494,7 +502,6 @@ export function ConfigVM(root, deps) {
             bsModal.hide();
             onCancel && onCancel();
         };
-        // Also handle modal close (X button)
         modal.querySelector('.btn-close').onclick = function() {
             bsModal.hide();
             onCancel && onCancel();
@@ -1103,6 +1110,17 @@ export function ConfigVM(root, deps) {
         return `every ${Math.round(s / 60)} min`;
     });
     self.liveUpdatesLabel = ko.pureComputed(() => (self.signalrEnabled() ? 'On' : 'Off'));
+
+    // The full refresh means different things depending on whether live updates
+    // are carrying the load -- spell it out so nobody sets it wrong.
+    self.fullRefreshHint = ko.pureComputed(() => (self.signalrEnabled()
+        ? 'A full reload from Beacon. With live updates on it is only a backstop — every 3–5 min is plenty.'
+        : 'A full reload from Beacon. With live updates off this is the only thing refreshing the board — keep it short, 1–2 min.'
+    ));
+    self.dataReadoutNote = ko.pureComputed(() => (self.signalrEnabled()
+        ? 'Live updates keep the board current; the full refresh is a backstop.'
+        : 'No live updates — the board is only as fresh as the full refresh.'
+    ));
 
     // Data pane -- one-tap presets for the values these are actually set to.
     // The number field beside each row stays as the escape hatch for odd

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1077,6 +1077,32 @@ export function ConfigVM(root, deps) {
 
     self.fetchPeriod = ko.observable(7).extend({ min: 0, max: 31, digit: true });
     self.fetchForward = ko.observable(0).extend({ min: 0, max: 31, digit: true });
+
+    // Human-readable summary of what the Data pane's knobs currently resolve
+    // to -- shown alongside the inputs so an operator can sanity-check the
+    // window they're actually loading.
+    const _fmtWindowDate = (d) => d.toLocaleDateString('en-AU', {
+        weekday: 'short', day: 'numeric', month: 'short'
+    });
+    self.fetchWindowRange = ko.pureComputed(() => {
+        const back = Math.max(0, Number(self.fetchPeriod()) || 0);
+        const fwd = Math.max(0, Number(self.fetchForward()) || 0);
+        const now = new Date();
+        const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - back);
+        const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + fwd);
+        return `${_fmtWindowDate(start)} → ${_fmtWindowDate(end)}`;
+    });
+    self.fetchWindowDays = ko.pureComputed(() => {
+        const back = Math.max(0, Number(self.fetchPeriod()) || 0);
+        const fwd = Math.max(0, Number(self.fetchForward()) || 0);
+        return back + fwd + 1;
+    });
+    self.refreshCadence = ko.pureComputed(() => {
+        const s = Math.max(0, Number(self.refreshInterval()) || 0);
+        if (s < 90) return `every ${s} sec`;
+        return `every ${Math.round(s / 60)} min`;
+    });
+    self.liveUpdatesLabel = ko.pureComputed(() => (self.signalrEnabled() ? 'On' : 'Off'));
     self.showAdvanced = ko.observable(false);
     self.darkMode = ko.observable(false);
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2074,26 +2074,44 @@
                     <!-- CONFIG -->
                     <!-- CONFIG -->
                     <div class="card config-card mt-3">
-
                         <div class="card-body">
                             <form id="configForm">
-                                <div class="accordion" id="configOtherSettingsAccordion">
-
-                                    <!-- General -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingGeneral">
-                                            <button class="accordion-button d-flex align-items-center gap-2 fw-semibold" type="button" data-bs-toggle="collapse"
-                                                data-bs-target="#collapseGeneral" aria-expanded="true"
-                                                aria-controls="collapseGeneral">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-cogs"></i></span>
-                                                <span>General Settings</span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapseGeneral" class="accordion-collapse collapse show"
-                                            aria-labelledby="headingGeneral"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
-                                                <div class="row g-3">
+                                <div class="config-settings">
+                                    <ul class="nav nav-pills config-rail flex-column" role="tablist" aria-orientation="vertical">
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link active" id="cfgTab-data" data-bs-toggle="pill" data-bs-target="#cfgPane-data" type="button" role="tab" aria-controls="cfgPane-data" aria-selected="true">
+                                            <span class="cfg-rail-ico"><i class="fa fa-database"></i></span><span>Data</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-filters" data-bs-toggle="pill" data-bs-target="#cfgPane-filters" type="button" role="tab" aria-controls="cfgPane-filters" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-filter"></i></span><span>Filters</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-map" data-bs-toggle="pill" data-bs-target="#cfgPane-map" type="button" role="tab" aria-controls="cfgPane-map" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-layer-group"></i></span><span>Map</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-sidebar" data-bs-toggle="pill" data-bs-target="#cfgPane-sidebar" type="button" role="tab" aria-controls="cfgPane-sidebar" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-table-columns"></i></span><span>Sidebar</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-appearance" data-bs-toggle="pill" data-bs-target="#cfgPane-appearance" type="button" role="tab" aria-controls="cfgPane-appearance" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-sliders"></i></span><span>Appearance</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-suggest" data-bs-toggle="pill" data-bs-target="#cfgPane-suggest" type="button" role="tab" aria-controls="cfgPane-suggest" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-robot"></i></span><span>Instant Task Suggestions</span>
+                                        </button>
+                                    </li>
+                                    </ul>
+                                    <div class="tab-content config-panes">
+                                    <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
+                                        <div class="row g-3">
                                                     <div class="col-sm-6 col-md-3">
                                                         <label for="refreshInterval" class="form-label">
                                                             <i class="fa fa-sync-alt me-1"></i>Refresh interval
@@ -2137,19 +2155,6 @@
                                                     </div>
                                                     <div class="col-sm-6 col-md-3">
                                                         <label class="form-label">
-                                                            <i class="fa fa-moon me-1"></i>Dark Mode
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="darkModeToggle"
-                                                                data-bind="checked: config.darkMode">
-                                                            <label class="form-check-label" for="darkModeToggle">
-                                                                Enable dark mode
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Reduces eye strain in low light environments.</div>
-                                                    </div>
-                                                    <div class="col-sm-6 col-md-3">
-                                                        <label class="form-label">
                                                             <i class="fa fa-bolt me-1"></i>Live Updates
                                                         </label>
                                                         <div class="form-check form-switch mt-2">
@@ -2161,91 +2166,18 @@
                                                         </div>
                                                         <div class="form-text">Receive instant incident, team and tasking updates. If enabling or disabling, restart LAD after saving.</div>
                                                     </div>                                                    
-                                                    <div class="col-sm-6 col-md-3">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-bell me-1"></i>Alerts Panel
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="alertsCollapsibleRulesToggle"
-                                                                data-bind="checked: config.alertsCollapsibleRules">
-                                                            <label class="form-check-label" for="alertsCollapsibleRulesToggle">
-                                                                Auto collapse alert popups
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Alerts will start collapsed.</div>
-                                                    </div>
-                                                    <div class="col-sm-6 col-md-3">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-hashtag me-1"></i>Incident Tasking Count
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="taskingCountActiveOnlyToggle"
-                                                                data-bind="checked: config.taskingCountActiveOnly">
-                                                            <label class="form-check-label" for="taskingCountActiveOnlyToggle">
-                                                                Count Active taskings only
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Tasking count counts only Tasked, Enroute &amp; Onsite taskings (excludes Complete, CalledOff, Untasked).</div>
-                                                    </div>
-                                                </div>
-                                            </div>
                                         </div>
                                     </div>
-
-                                    <!-- Panel Layout -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingPanelLayout">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapsePanelLayout"
-                                                aria-expanded="false" aria-controls="collapsePanelLayout">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-columns"></i></span>
-                                                <span>Panel Layout</span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapsePanelLayout" class="accordion-collapse collapse"
-                                            aria-labelledby="headingPanelLayout"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
-                                                <label class="form-label">
-                                                    <i class="fa fa-columns me-1"></i>Section Layout Preset
-                                                </label>
-                                                <div class="layout-preset-grid"
-                                                    data-bind="foreach: { data: config.layoutPresetDefs, as: 'preset' }">
-                                                    <label class="layout-preset-card"
-                                                        data-bind="css: { 'is-active': $root.config.layoutPreset() === preset.id }">
-                                                        <input class="form-check-input layout-preset-radio"
-                                                            type="radio" name="layoutPreset"
-                                                            data-bind="checked: $root.config.layoutPreset, checkedValue: preset.id">
-                                                        <div class="layout-preset-preview"
-                                                            data-bind="css: preset.previewClass">
-                                                            <div class="preview-block preview-block--teams">Teams</div>
-                                                            <div class="preview-block preview-block--tasking">Tasking</div>
-                                                            <div class="preview-block preview-block--map">Map</div>
-                                                        </div>
-                                                        <div class="layout-preset-name" data-bind="text: preset.name"></div>
-                                                        <div class="layout-preset-description small text-muted"
-                                                            data-bind="text: preset.description"></div>
-                                                    </label>
-                                                </div>
-                                                <div class="form-text">Pick a layout to instantly preview and apply section placement.</div>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <!-- Incident Status -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingIncidentStatus">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseIncidentStatus"
-                                                aria-expanded="false" aria-controls="collapseIncidentStatus">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-filter"></i></span>
-                                                <span>Incident Filters</span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapseIncidentStatus" class="accordion-collapse collapse"
-                                            aria-labelledby="headingIncidentStatus"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
+                                    <div class="tab-pane fade" id="cfgPane-filters" role="tabpanel" aria-labelledby="cfgTab-filters" tabindex="0">
+                                        <div class="accordion config-subaccordion" id="cfgFiltersAcc">
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-incidents" aria-expanded="true" aria-controls="cfgSub-incidents">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-fire"></i></span><span>Incidents</span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-incidents" class="accordion-collapse collapse show" data-bs-parent="#cfgFiltersAcc">
+                                                <div class="accordion-body">
                                                 <div class="row g-3">
                                                     <div class="col-md-6">
                                                         <label class="form-label d-block mb-2">Show Incidents With
@@ -2490,24 +2422,17 @@
                                                         </div>
                                                     </div>
                                                 </div>
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-
-                                    <!-- Team Status & Tasking -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingTeamStatus">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseTeamStatus"
-                                                aria-expanded="false" aria-controls="collapseTeamStatus">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-users"></i></span>
-                                                <span>Team &amp; Tasking Filters</span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapseTeamStatus" class="accordion-collapse collapse"
-                                            aria-labelledby="headingTeamStatus"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-teams" aria-expanded="false" aria-controls="cfgSub-teams">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-users"></i></span><span>Teams</span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-teams" class="accordion-collapse collapse" data-bs-parent="#cfgFiltersAcc">
+                                                <div class="accordion-body">
                                                 <div class="row g-3">
                                                     <div class="col-md-6 col-lg-4">
                                                         <label class="form-label d-block mb-2">Show Teams With
@@ -2644,26 +2569,17 @@
                                                         </div>
                                                     </div>
                                                 </div> <!-- /row -->
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <!-- Sectors -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingSectors">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseSectors"
-                                                aria-expanded="false" aria-controls="collapseSectors">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-th-large"></i></span>
-                                                <span>Sectors</span>
-                                                <span class="spinner-border spinner-border-sm text-muted mx-2"
-                                                    role="status" data-bind="visible: sectorsLoading"></span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapseSectors" class="accordion-collapse collapse"
-                                            aria-labelledby="headingSectors"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-
-                                            <div class="accordion-body">
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-sectors" aria-expanded="false" aria-controls="cfgSub-sectors">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-th-large"></i></span><span>Sectors</span><span class="spinner-border spinner-border-sm text-muted mx-2" role="status" data-bind="visible: sectorsLoading"></span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-sectors" class="accordion-collapse collapse" data-bs-parent="#cfgFiltersAcc">
+                                                <div class="accordion-body">
 
                                                 <div class="mb-3">
                                                     <label class="form-label d-block mb-1 fw-semibold">Apply sector filters to:</label>
@@ -2727,100 +2643,21 @@
                                                         No sectors loaded for current incident filters.
                                                     </div>
                                                 </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <!-- Starred Teams & Incidents -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingPinned">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapsePinned"
-                                                aria-expanded="false" aria-controls="collapsePinned">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-star"></i></span>
-                                                <span>Starred Teams &amp; Incidents</span>
-                                            </button>
-                                        </h2>
-
-                                        <div id="collapsePinned" class="accordion-collapse collapse"
-                                            aria-labelledby="headingPinned"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
-                                                <div
-                                                    class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
-                                                    <div class="small text-muted">
-                                                        Starred teams: <span class="badge bg-primary"
-                                                            data-bind="text: config.pinnedTeamIds().length"></span>
-                                                        &nbsp;•&nbsp;
-                                                        Starred incidents: <span class="badge bg-success"
-                                                            data-bind="text: config.pinnedIncidentIds().length"></span>
-                                                    </div>
-
-                                                    <button type="button" class="btn btn-sm btn-outline-danger"
-                                                        data-bind="click: config.clearAllPinned, enable: (config.pinnedTeamIds().length + config.pinnedIncidentIds().length) > 0">
-                                                        Clear all Starred
-                                                    </button>
-                                                </div>
-
-                                                <div class="row g-2">
-                                                    <div class="col-12 col-md-6">
-                                                        <div class="border rounded p-2">
-                                                            <div
-                                                                class="d-flex align-items-center justify-content-between">
-                                                                <div class="fw-semibold small">Starred Teams</div>
-                                                                <div class="d-flex align-items-center gap-2">
-                                                                    <span class="badge bg-primary"
-                                                                        data-bind="text: config.pinnedTeamIds().length"></span>
-                                                                    <button type="button"
-                                                                        class="btn btn-sm btn-outline-secondary"
-                                                                        data-bind="click: config.clearPinnedTeams, enable: config.pinnedTeamIds().length > 0">
-                                                                        Clear
-                                                                    </button>
-                                                                </div>
-                                                            </div>
-
-                                                        </div>
-                                                    </div>
-
-                                                    <div class="col-12 col-md-6">
-                                                        <div class="border rounded p-2">
-                                                            <div
-                                                                class="d-flex align-items-center justify-content-between">
-                                                                <div class="fw-semibold small">Starred Incidents</div>
-                                                                <div class="d-flex align-items-center gap-2">
-                                                                    <span class="badge bg-success"
-                                                                        data-bind="text: config.pinnedIncidentIds().length"></span>
-                                                                    <button type="button"
-                                                                        class="btn btn-sm btn-outline-secondary"
-                                                                        data-bind="click: config.clearPinnedIncidents, enable: config.pinnedIncidentIds().length > 0">
-                                                                        Clear
-                                                                    </button>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
+                                        </div>
                                     </div>
-                                    <!-- Map Layers -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingMapLayers">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseMapLayers"
-                                                aria-expanded="false" aria-controls="collapseMapLayers">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-layer-group"></i></span>
-                                                <span>Map Layers</span>
-                                            </button>
-                                        </h2>
-
-                                        <div id="collapseMapLayers" class="accordion-collapse collapse"
-                                            aria-labelledby="headingMapLayers"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
-
-                                                <h6 class="fw-semibold mb-2">
-                                                    <i class="fa fa-sliders me-1"></i>Display Settings
-                                                </h6>
+                                    <div class="tab-pane fade" id="cfgPane-map" role="tabpanel" aria-labelledby="cfgTab-map" tabindex="0">
+                                        <div class="accordion config-subaccordion" id="cfgMapAcc">
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-markers" aria-expanded="true" aria-controls="cfgSub-markers">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-map-marker-alt"></i></span><span>Incident markers</span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-markers" class="accordion-collapse collapse show" data-bs-parent="#cfgMapAcc">
+                                                <div class="accordion-body">
                                                 <div class="row g-3">
 
                                                     <!-- Clustering options -->
@@ -2907,9 +2744,17 @@
                                                     </div>
 
                                                 </div>
-
-                                                <hr class="my-4">
-
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-collab" aria-expanded="false" aria-controls="cfgSub-collab">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-users"></i></span><span>Collaborative layers</span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-collab" class="accordion-collapse collapse" data-bs-parent="#cfgMapAcc">
+                                                <div class="accordion-body">
                                                 <div class="d-flex align-items-center justify-content-between mb-2">
                                                     <h6 class="fw-semibold mb-0">
                                                         <i class="fa fa-users me-1"></i>Collaborative Layers
@@ -3325,25 +3170,135 @@
                                                 <div class="form-text mt-2" data-bind="visible: config.noSearchMatchMessage, text: config.noSearchMatchMessage">
                                                 </div>
 
+                                                </div>
                                             </div>
                                         </div>
+                                        </div>
                                     </div>
+                                    <div class="tab-pane fade" id="cfgPane-sidebar" role="tabpanel" aria-labelledby="cfgTab-sidebar" tabindex="0">
+                                                <label class="form-label">
+                                                    <i class="fa fa-columns me-1"></i>Section Layout Preset
+                                                </label>
+                                                <div class="layout-preset-grid"
+                                                    data-bind="foreach: { data: config.layoutPresetDefs, as: 'preset' }">
+                                                    <label class="layout-preset-card"
+                                                        data-bind="css: { 'is-active': $root.config.layoutPreset() === preset.id }">
+                                                        <input class="form-check-input layout-preset-radio"
+                                                            type="radio" name="layoutPreset"
+                                                            data-bind="checked: $root.config.layoutPreset, checkedValue: preset.id">
+                                                        <div class="layout-preset-preview"
+                                                            data-bind="css: preset.previewClass">
+                                                            <div class="preview-block preview-block--teams">Teams</div>
+                                                            <div class="preview-block preview-block--tasking">Tasking</div>
+                                                            <div class="preview-block preview-block--map">Map</div>
+                                                        </div>
+                                                        <div class="layout-preset-name" data-bind="text: preset.name"></div>
+                                                        <div class="layout-preset-description small text-muted"
+                                                            data-bind="text: preset.description"></div>
+                                                    </label>
+                                                </div>
+                                                <div class="form-text">Pick a layout to instantly preview and apply section placement.</div>
+                                        <hr class="my-4">
+                                        <h6 class="cfg-subhead"><i class="fa fa-star me-2"></i>Starred teams &amp; incidents</h6>
+                                                <div
+                                                    class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+                                                    <div class="small text-muted">
+                                                        Starred teams: <span class="badge bg-primary"
+                                                            data-bind="text: config.pinnedTeamIds().length"></span>
+                                                        &nbsp;•&nbsp;
+                                                        Starred incidents: <span class="badge bg-success"
+                                                            data-bind="text: config.pinnedIncidentIds().length"></span>
+                                                    </div>
 
-                                    <!-- Instant Task Suggestions -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingSuggestions">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseSuggestions"
-                                                aria-expanded="false" aria-controls="collapseSuggestions">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-robot"></i></span>
-                                                <span>Instant Task Suggestions</span>
-                                            </button>
-                                        </h2>
+                                                    <button type="button" class="btn btn-sm btn-outline-danger"
+                                                        data-bind="click: config.clearAllPinned, enable: (config.pinnedTeamIds().length + config.pinnedIncidentIds().length) > 0">
+                                                        Clear all Starred
+                                                    </button>
+                                                </div>
 
-                                        <div id="collapseSuggestions" class="accordion-collapse collapse"
-                                            aria-labelledby="headingSuggestions"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
+                                                <div class="row g-2">
+                                                    <div class="col-12 col-md-6">
+                                                        <div class="border rounded p-2">
+                                                            <div
+                                                                class="d-flex align-items-center justify-content-between">
+                                                                <div class="fw-semibold small">Starred Teams</div>
+                                                                <div class="d-flex align-items-center gap-2">
+                                                                    <span class="badge bg-primary"
+                                                                        data-bind="text: config.pinnedTeamIds().length"></span>
+                                                                    <button type="button"
+                                                                        class="btn btn-sm btn-outline-secondary"
+                                                                        data-bind="click: config.clearPinnedTeams, enable: config.pinnedTeamIds().length > 0">
+                                                                        Clear
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="col-12 col-md-6">
+                                                        <div class="border rounded p-2">
+                                                            <div
+                                                                class="d-flex align-items-center justify-content-between">
+                                                                <div class="fw-semibold small">Starred Incidents</div>
+                                                                <div class="d-flex align-items-center gap-2">
+                                                                    <span class="badge bg-success"
+                                                                        data-bind="text: config.pinnedIncidentIds().length"></span>
+                                                                    <button type="button"
+                                                                        class="btn btn-sm btn-outline-secondary"
+                                                                        data-bind="click: config.clearPinnedIncidents, enable: config.pinnedIncidentIds().length > 0">
+                                                                        Clear
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                    </div>
+                                    <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
+                                        <div class="row g-3">
+                                                    <div class="col-sm-6 col-md-3">
+                                                        <label class="form-label">
+                                                            <i class="fa fa-moon me-1"></i>Dark Mode
+                                                        </label>
+                                                        <div class="form-check form-switch mt-2">
+                                                            <input class="form-check-input" type="checkbox" id="darkModeToggle"
+                                                                data-bind="checked: config.darkMode">
+                                                            <label class="form-check-label" for="darkModeToggle">
+                                                                Enable dark mode
+                                                            </label>
+                                                        </div>
+                                                        <div class="form-text">Reduces eye strain in low light environments.</div>
+                                                    </div>
+                                                    <div class="col-sm-6 col-md-3">
+                                                        <label class="form-label">
+                                                            <i class="fa fa-bell me-1"></i>Alerts Panel
+                                                        </label>
+                                                        <div class="form-check form-switch mt-2">
+                                                            <input class="form-check-input" type="checkbox" id="alertsCollapsibleRulesToggle"
+                                                                data-bind="checked: config.alertsCollapsibleRules">
+                                                            <label class="form-check-label" for="alertsCollapsibleRulesToggle">
+                                                                Auto collapse alert popups
+                                                            </label>
+                                                        </div>
+                                                        <div class="form-text">Alerts will start collapsed.</div>
+                                                    </div>
+                                                    <div class="col-sm-6 col-md-3">
+                                                        <label class="form-label">
+                                                            <i class="fa fa-hashtag me-1"></i>Incident Tasking Count
+                                                        </label>
+                                                        <div class="form-check form-switch mt-2">
+                                                            <input class="form-check-input" type="checkbox" id="taskingCountActiveOnlyToggle"
+                                                                data-bind="checked: config.taskingCountActiveOnly">
+                                                            <label class="form-check-label" for="taskingCountActiveOnlyToggle">
+                                                                Count Active taskings only
+                                                            </label>
+                                                        </div>
+                                                        <div class="form-text">Tasking count counts only Tasked, Enroute &amp; Onsite taskings (excludes Complete, CalledOff, Untasked).</div>
+                                                    </div>
+                                        </div>
+                                    </div>
+                                    <div class="tab-pane fade" id="cfgPane-suggest" role="tabpanel" aria-labelledby="cfgTab-suggest" tabindex="0">
 
                                                 <p class="small text-muted mb-3">
                                                     When enabled, the instant-task dropdown will suggest a team using a
@@ -3490,13 +3445,9 @@
                                                     </div><!-- /row -->
                                                 </div><!-- /visible -->
 
-                                            </div>
-                                        </div>
                                     </div>
-
-                                </div><!-- /accordion -->
-
-
+                                    </div>
+                                </div>
                             </form>
                         </div>
                     </div>

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2121,61 +2121,52 @@
                                     </ul>
                                     <div class="tab-content config-panes">
                                     <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
-                                        <div class="row g-3">
-                                                    <div class="col-sm-6 col-md-6">
-                                                        <label for="refreshInterval" class="form-label">
-                                                            <i class="fa fa-sync-alt me-1"></i>Refresh interval
-                                                            (seconds)
-                                                        </label>
-                                                        <div class="input-group">
-                                                            <span class="input-group-text"><i
-                                                                    class="fa fa-clock"></i></span>
-                                                            <input id="refreshInterval" type="number" min="30" step="5"
-                                                                class="form-control"
-                                                                data-bind="value: config.refreshInterval">
-                                                        </div>
-                                                        <div class="form-text">How often to fully refresh data.</div>
+                                        <div class="cfg-rows">
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="refreshInterval">Refresh interval</label>
+                                                    <div class="d">How often LAD fully refreshes all data.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="input-group input-group-sm">
+                                                        <input id="refreshInterval" type="number" min="30" step="5"
+                                                            class="form-control" data-bind="value: config.refreshInterval">
+                                                        <span class="input-group-text">sec</span>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-6">
-                                                        <label for="fetchPeriod" class="form-label">
-                                                            <i class="fa fa-history me-1"></i>Fetch backwards (days)
-                                                        </label>
-                                                        <div class="input-group">
-                                                            <span class="input-group-text"><i
-                                                                    class="fa fa-calendar-minus"></i></span>
-                                                            <input id="fetchPeriod" type="number" min="0" max="31"
-                                                                step="1" class="form-control"
-                                                                data-bind="value: config.fetchPeriod">
-                                                        </div>
-                                                        <div class="form-text">How many days in the past to fetch.</div>
+                                                </div>
+                                            </div>
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="fetchPeriod">Fetch window</label>
+                                                    <div class="d">How far back and forward to load incidents &amp; teams.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="input-group input-group-sm">
+                                                        <input id="fetchPeriod" type="number" min="0" max="31" step="1"
+                                                            class="form-control" aria-label="Fetch backwards (days)"
+                                                            data-bind="value: config.fetchPeriod">
+                                                        <span class="input-group-text">d&nbsp;back</span>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-6">
-                                                        <label for="fetchForward" class="form-label">
-                                                            <i class="fa fa-calendar-plus me-1"></i>Fetch forward (days)
-                                                        </label>
-                                                        <div class="input-group">
-                                                            <span class="input-group-text"><i
-                                                                    class="fa fa-calendar-plus"></i></span>
-                                                            <input id="fetchForward" type="number" min="0" step="1"
-                                                                class="form-control"
-                                                                data-bind="value: config.fetchForward">
-                                                        </div>
-                                                        <div class="form-text">How many days into the future to fetch.
-                                                        </div>
+                                                    <div class="input-group input-group-sm">
+                                                        <input id="fetchForward" type="number" min="0" step="1"
+                                                            class="form-control" aria-label="Fetch forward (days)"
+                                                            data-bind="value: config.fetchForward">
+                                                        <span class="input-group-text">d&nbsp;fwd</span>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-6">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-bolt me-1"></i>Live Updates
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="signalrEnabledToggle"
-                                                                data-bind="checked: config.signalrEnabled">
-                                                            <label class="form-check-label" for="signalrEnabledToggle">
-                                                                Enable SignalR live updates
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Receive instant incident, team and tasking updates. If enabling or disabling, restart LAD after saving.</div>
-                                                    </div>                                                    
+                                                </div>
+                                            </div>
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="signalrEnabledToggle">Live updates</label>
+                                                    <div class="d">Instant incident, team &amp; tasking changes via SignalR. Restart LAD after changing.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="form-check form-switch">
+                                                        <input class="form-check-input" type="checkbox" role="switch"
+                                                            id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
+                                                    </div>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-filters" role="tabpanel" aria-labelledby="cfgTab-filters" tabindex="0">
@@ -3244,46 +3235,43 @@
                                                 </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
-                                        <div class="row g-3">
-                                                    <div class="col-sm-6 col-md-4">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-moon me-1"></i>Dark Mode
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="darkModeToggle"
-                                                                data-bind="checked: config.darkMode">
-                                                            <label class="form-check-label" for="darkModeToggle">
-                                                                Enable dark mode
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Reduces eye strain in low light environments.</div>
+                                        <div class="cfg-rows">
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="darkModeToggle">Dark mode</label>
+                                                    <div class="d">Reduces eye strain in low light environments.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="form-check form-switch">
+                                                        <input class="form-check-input" type="checkbox" role="switch"
+                                                            id="darkModeToggle" data-bind="checked: config.darkMode">
                                                     </div>
-                                                    <div class="col-sm-6 col-md-4">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-bell me-1"></i>Alerts Panel
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="alertsCollapsibleRulesToggle"
-                                                                data-bind="checked: config.alertsCollapsibleRules">
-                                                            <label class="form-check-label" for="alertsCollapsibleRulesToggle">
-                                                                Auto collapse alert popups
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Alerts will start collapsed.</div>
+                                                </div>
+                                            </div>
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="alertsCollapsibleRulesToggle">Auto-collapse alert popups</label>
+                                                    <div class="d">New alerts start collapsed in the Alerts panel.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="form-check form-switch">
+                                                        <input class="form-check-input" type="checkbox" role="switch"
+                                                            id="alertsCollapsibleRulesToggle" data-bind="checked: config.alertsCollapsibleRules">
                                                     </div>
-                                                    <div class="col-sm-6 col-md-4">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-hashtag me-1"></i>Incident Tasking Count
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="taskingCountActiveOnlyToggle"
-                                                                data-bind="checked: config.taskingCountActiveOnly">
-                                                            <label class="form-check-label" for="taskingCountActiveOnlyToggle">
-                                                                Count Active taskings only
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Tasking count counts only Tasked, Enroute &amp; Onsite taskings (excludes Complete, CalledOff, Untasked).</div>
+                                                </div>
+                                            </div>
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="taskingCountActiveOnlyToggle">Count active taskings only</label>
+                                                    <div class="d">Incident tasking count excludes Complete, CalledOff &amp; Untasked (counts only Tasked, Enroute &amp; Onsite).</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="form-check form-switch">
+                                                        <input class="form-check-input" type="checkbox" role="switch"
+                                                            id="taskingCountActiveOnlyToggle" data-bind="checked: config.taskingCountActiveOnly">
                                                     </div>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-suggest" role="tabpanel" aria-labelledby="cfgTab-suggest" tabindex="0">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2140,7 +2140,7 @@
                                                             <span class="input-group-text">sec</span>
                                                         </div>
                                                     </div>
-                                                    <div class="d">Full reload of every incident and team.</div>
+                                                    <div class="d">Automatically perform a full reload of every incident and team.</div>
                                                 </div>
                                                 <div class="cfg-field">
                                                     <label>History &mdash; how far back</label>
@@ -2189,7 +2189,7 @@
                                                             data-bind="text: config.liveUpdatesLabel,
                                                                        css: { on: config.signalrEnabled(), off: !config.signalrEnabled() }"></span>
                                                     </div>
-                                                    <div class="d">Instant incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
+                                                    <div class="d">Instantly update incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
                                                 </div>
                                             </div>
 
@@ -3271,39 +3271,47 @@
                                                 </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
-                                        <div class="cfg-card">
-                                            <div class="cfg-line">
+                                        <div class="cfg-data-fields cfg-fields-solo">
+                                            <div class="cfg-field">
                                                 <label for="darkModeToggle">Dark mode</label>
-                                                <div class="cfg-line-ctl">
+                                                <div class="ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="darkModeToggle" data-bind="checked: config.darkMode">
                                                     </div>
+                                                    <span class="cfg-live-pill"
+                                                        data-bind="text: config.darkModeLabel,
+                                                                   css: { on: config.darkMode(), off: !config.darkMode() }"></span>
                                                 </div>
+                                                <div class="d">Reduces eye strain on overnight LHQ shifts.</div>
                                             </div>
-                                            <div class="cfg-line">
+                                            <div class="cfg-field">
                                                 <label for="alertsCollapsibleRulesToggle">Auto-collapse alert popups</label>
-                                                <div class="cfg-line-ctl">
+                                                <div class="ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="alertsCollapsibleRulesToggle" data-bind="checked: config.alertsCollapsibleRules">
                                                     </div>
+                                                    <span class="cfg-live-pill"
+                                                        data-bind="text: config.alertsCollapseLabel,
+                                                                   css: { on: config.alertsCollapsibleRules(), off: !config.alertsCollapsibleRules() }"></span>
                                                 </div>
+                                                <div class="d">New alerts start collapsed in the Alerts panel.</div>
                                             </div>
-                                            <div class="cfg-line">
+                                            <div class="cfg-field">
                                                 <label for="taskingCountActiveOnlyToggle">Count active taskings only</label>
-                                                <div class="cfg-line-ctl">
+                                                <div class="ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="taskingCountActiveOnlyToggle" data-bind="checked: config.taskingCountActiveOnly">
                                                     </div>
+                                                    <span class="cfg-live-pill"
+                                                        data-bind="text: config.taskingCountLabel,
+                                                                   css: { on: config.taskingCountActiveOnly(), off: !config.taskingCountActiveOnly() }"></span>
                                                 </div>
+                                                <div class="d">Incident tasking count excludes Complete, CalledOff &amp; Untasked.</div>
                                             </div>
                                         </div>
-                                        <p class="cfg-card-note">
-                                            Dark mode reduces eye strain on overnight shifts. &ldquo;Count active taskings
-                                            only&rdquo; excludes Complete, CalledOff &amp; Untasked from the incident tasking count.
-                                        </p>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-suggest" role="tabpanel" aria-labelledby="cfgTab-suggest" tabindex="0">
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2121,13 +2121,10 @@
                                     </ul>
                                     <div class="tab-content config-panes">
                                     <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
-                                        <div class="cfg-rows">
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="refreshInterval">Refresh interval</label>
-                                                    <div class="d">How often LAD fully refreshes all data.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                        <div class="cfg-card">
+                                            <div class="cfg-line">
+                                                <label for="refreshInterval">Refresh interval</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="input-group input-group-sm">
                                                         <input id="refreshInterval" type="number" min="30" step="5"
                                                             class="form-control" data-bind="value: config.refreshInterval">
@@ -2135,32 +2132,26 @@
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="fetchPeriod">Fetch window</label>
-                                                    <div class="d">How far back and forward to load incidents &amp; teams.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                            <div class="cfg-line">
+                                                <label for="fetchPeriod">Fetch window</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="input-group input-group-sm">
                                                         <input id="fetchPeriod" type="number" min="0" max="31" step="1"
                                                             class="form-control" aria-label="Fetch backwards (days)"
                                                             data-bind="value: config.fetchPeriod">
-                                                        <span class="input-group-text">d&nbsp;back</span>
+                                                        <span class="input-group-text">back</span>
                                                     </div>
                                                     <div class="input-group input-group-sm">
                                                         <input id="fetchForward" type="number" min="0" step="1"
                                                             class="form-control" aria-label="Fetch forward (days)"
                                                             data-bind="value: config.fetchForward">
-                                                        <span class="input-group-text">d&nbsp;fwd</span>
+                                                        <span class="input-group-text">fwd</span>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="signalrEnabledToggle">Live updates</label>
-                                                    <div class="d">Instant incident, team &amp; tasking changes via SignalR. Restart LAD after changing.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                            <div class="cfg-line">
+                                                <label for="signalrEnabledToggle">Live updates</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
@@ -2168,6 +2159,10 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <p class="cfg-card-note">
+                                            &ldquo;Refresh interval&rdquo; is the full data-reload cycle. Between reloads,
+                                            live updates keep the board current via SignalR &mdash; restart LAD after toggling.
+                                        </p>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-filters" role="tabpanel" aria-labelledby="cfgTab-filters" tabindex="0">
                                         <div class="accordion config-subaccordion" id="cfgFiltersAcc">
@@ -3235,37 +3230,28 @@
                                                 </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
-                                        <div class="cfg-rows">
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="darkModeToggle">Dark mode</label>
-                                                    <div class="d">Reduces eye strain in low light environments.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                        <div class="cfg-card">
+                                            <div class="cfg-line">
+                                                <label for="darkModeToggle">Dark mode</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="darkModeToggle" data-bind="checked: config.darkMode">
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="alertsCollapsibleRulesToggle">Auto-collapse alert popups</label>
-                                                    <div class="d">New alerts start collapsed in the Alerts panel.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                            <div class="cfg-line">
+                                                <label for="alertsCollapsibleRulesToggle">Auto-collapse alert popups</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="alertsCollapsibleRulesToggle" data-bind="checked: config.alertsCollapsibleRules">
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="taskingCountActiveOnlyToggle">Count active taskings only</label>
-                                                    <div class="d">Incident tasking count excludes Complete, CalledOff &amp; Untasked (counts only Tasked, Enroute &amp; Onsite).</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                            <div class="cfg-line">
+                                                <label for="taskingCountActiveOnlyToggle">Count active taskings only</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="taskingCountActiveOnlyToggle" data-bind="checked: config.taskingCountActiveOnly">
@@ -3273,6 +3259,10 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <p class="cfg-card-note">
+                                            Dark mode reduces eye strain on overnight shifts. &ldquo;Count active taskings
+                                            only&rdquo; excludes Complete, CalledOff &amp; Untasked from the incident tasking count.
+                                        </p>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-suggest" role="tabpanel" aria-labelledby="cfgTab-suggest" tabindex="0">
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2121,48 +2121,60 @@
                                     </ul>
                                     <div class="tab-content config-panes">
                                     <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
-                                        <div class="cfg-card">
-                                            <div class="cfg-line">
-                                                <label for="refreshInterval">Refresh interval</label>
-                                                <div class="cfg-line-ctl">
-                                                    <div class="input-group input-group-sm">
-                                                        <input id="refreshInterval" type="number" min="30" step="5"
-                                                            class="form-control" data-bind="value: config.refreshInterval">
-                                                        <span class="input-group-text">sec</span>
+                                        <div class="cfg-data">
+                                            <div class="cfg-data-fields">
+                                                <div class="cfg-field">
+                                                    <label for="refreshInterval">Refresh interval</label>
+                                                    <div class="ctl">
+                                                        <div class="input-group input-group-sm">
+                                                            <input id="refreshInterval" type="number" min="30" step="5"
+                                                                class="form-control" data-bind="value: config.refreshInterval">
+                                                            <span class="input-group-text">sec</span>
+                                                        </div>
                                                     </div>
+                                                    <div class="d">Full reload of every incident and team.</div>
+                                                </div>
+                                                <div class="cfg-field">
+                                                    <label for="fetchPeriod">Fetch window</label>
+                                                    <div class="ctl">
+                                                        <div class="input-group input-group-sm">
+                                                            <input id="fetchPeriod" type="number" min="0" max="31" step="1"
+                                                                class="form-control" aria-label="Fetch backwards (days)"
+                                                                data-bind="value: config.fetchPeriod">
+                                                            <span class="input-group-text">d&nbsp;back</span>
+                                                        </div>
+                                                        <div class="input-group input-group-sm">
+                                                            <input id="fetchForward" type="number" min="0" step="1"
+                                                                class="form-control" aria-label="Fetch forward (days)"
+                                                                data-bind="value: config.fetchForward">
+                                                            <span class="input-group-text">d&nbsp;fwd</span>
+                                                        </div>
+                                                    </div>
+                                                    <div class="d">How much past history and lookahead to load.</div>
+                                                </div>
+                                                <div class="cfg-field">
+                                                    <label for="signalrEnabledToggle">Live updates</label>
+                                                    <div class="ctl">
+                                                        <div class="form-check form-switch">
+                                                            <input class="form-check-input" type="checkbox" role="switch"
+                                                                id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
+                                                        </div>
+                                                    </div>
+                                                    <div class="d">Instant incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-line">
-                                                <label for="fetchPeriod">Fetch window</label>
-                                                <div class="cfg-line-ctl">
-                                                    <div class="input-group input-group-sm">
-                                                        <input id="fetchPeriod" type="number" min="0" max="31" step="1"
-                                                            class="form-control" aria-label="Fetch backwards (days)"
-                                                            data-bind="value: config.fetchPeriod">
-                                                        <span class="input-group-text">back</span>
-                                                    </div>
-                                                    <div class="input-group input-group-sm">
-                                                        <input id="fetchForward" type="number" min="0" step="1"
-                                                            class="form-control" aria-label="Fetch forward (days)"
-                                                            data-bind="value: config.fetchForward">
-                                                        <span class="input-group-text">fwd</span>
-                                                    </div>
+
+                                            <div class="cfg-readout">
+                                                <div class="cfg-readout-h">Loading now</div>
+                                                <div class="cfg-readout-range" data-bind="text: config.fetchWindowRange"></div>
+                                                <div class="cfg-readout-sub"><span data-bind="text: config.fetchWindowDays"></span>-day window</div>
+                                                <div class="cfg-readout-rows">
+                                                    <div><span>Full refresh</span><span data-bind="text: config.refreshCadence"></span></div>
+                                                    <div><span>Live updates</span><span data-bind="text: config.liveUpdatesLabel"></span></div>
                                                 </div>
-                                            </div>
-                                            <div class="cfg-line">
-                                                <label for="signalrEnabledToggle">Live updates</label>
-                                                <div class="cfg-line-ctl">
-                                                    <div class="form-check form-switch">
-                                                        <input class="form-check-input" type="checkbox" role="switch"
-                                                            id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
-                                                    </div>
-                                                </div>
+                                                <div class="cfg-readout-note">Toggling live updates needs a LAD restart to take effect.</div>
                                             </div>
                                         </div>
-                                        <p class="cfg-card-note">
-                                            &ldquo;Refresh interval&rdquo; is the full data-reload cycle. Between reloads,
-                                            live updates keep the board current via SignalR &mdash; restart LAD after toggling.
-                                        </p>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-filters" role="tabpanel" aria-labelledby="cfgTab-filters" tabindex="0">
                                         <div class="accordion config-subaccordion" id="cfgFiltersAcc">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2090,17 +2090,22 @@
                                     </li>
                                     <li class="nav-item" role="presentation">
                                         <button class="nav-link" id="cfgTab-map" data-bs-toggle="pill" data-bs-target="#cfgPane-map" type="button" role="tab" aria-controls="cfgPane-map" aria-selected="false">
-                                            <span class="cfg-rail-ico"><i class="fa fa-layer-group"></i></span><span>Map</span>
+                                            <span class="cfg-rail-ico"><i class="fa fa-map-marker-alt"></i></span><span>Map markers</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-collab" data-bs-toggle="pill" data-bs-target="#cfgPane-collab" type="button" role="tab" aria-controls="cfgPane-collab" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-layer-group"></i></span><span>Collaborative layers</span>
                                         </button>
                                     </li>
                                     <li class="nav-item" role="presentation">
                                         <button class="nav-link" id="cfgTab-sidebar" data-bs-toggle="pill" data-bs-target="#cfgPane-sidebar" type="button" role="tab" aria-controls="cfgPane-sidebar" aria-selected="false">
-                                            <span class="cfg-rail-ico"><i class="fa fa-table-columns"></i></span><span>Sidebar</span>
+                                            <span class="cfg-rail-ico"><i class="fa fa-columns"></i></span><span>Sidebar</span>
                                         </button>
                                     </li>
                                     <li class="nav-item" role="presentation">
                                         <button class="nav-link" id="cfgTab-appearance" data-bs-toggle="pill" data-bs-target="#cfgPane-appearance" type="button" role="tab" aria-controls="cfgPane-appearance" aria-selected="false">
-                                            <span class="cfg-rail-ico"><i class="fa fa-sliders"></i></span><span>Appearance</span>
+                                            <span class="cfg-rail-ico"><i class="fa fa-adjust"></i></span><span>Appearance</span>
                                         </button>
                                     </li>
                                     <li class="nav-item" role="presentation">
@@ -2112,7 +2117,7 @@
                                     <div class="tab-content config-panes">
                                     <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
                                         <div class="row g-3">
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-6">
                                                         <label for="refreshInterval" class="form-label">
                                                             <i class="fa fa-sync-alt me-1"></i>Refresh interval
                                                             (seconds)
@@ -2126,7 +2131,7 @@
                                                         </div>
                                                         <div class="form-text">How often to fully refresh data.</div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-6">
                                                         <label for="fetchPeriod" class="form-label">
                                                             <i class="fa fa-history me-1"></i>Fetch backwards (days)
                                                         </label>
@@ -2139,7 +2144,7 @@
                                                         </div>
                                                         <div class="form-text">How many days in the past to fetch.</div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-6">
                                                         <label for="fetchForward" class="form-label">
                                                             <i class="fa fa-calendar-plus me-1"></i>Fetch forward (days)
                                                         </label>
@@ -2153,7 +2158,7 @@
                                                         <div class="form-text">How many days into the future to fetch.
                                                         </div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-6">
                                                         <label class="form-label">
                                                             <i class="fa fa-bolt me-1"></i>Live Updates
                                                         </label>
@@ -2649,15 +2654,6 @@
                                         </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-map" role="tabpanel" aria-labelledby="cfgTab-map" tabindex="0">
-                                        <div class="accordion config-subaccordion" id="cfgMapAcc">
-                                        <div class="accordion-item">
-                                            <h2 class="accordion-header">
-                                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-markers" aria-expanded="true" aria-controls="cfgSub-markers">
-                                                    <span class="cfg-sub-ico"><i class="fa fa-map-marker-alt"></i></span><span>Incident markers</span>
-                                                </button>
-                                            </h2>
-                                            <div id="cfgSub-markers" class="accordion-collapse collapse show" data-bs-parent="#cfgMapAcc">
-                                                <div class="accordion-body">
                                                 <div class="row g-3">
 
                                                     <!-- Clustering options -->
@@ -2744,17 +2740,8 @@
                                                     </div>
 
                                                 </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="accordion-item">
-                                            <h2 class="accordion-header">
-                                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-collab" aria-expanded="false" aria-controls="cfgSub-collab">
-                                                    <span class="cfg-sub-ico"><i class="fa fa-users"></i></span><span>Collaborative layers</span>
-                                                </button>
-                                            </h2>
-                                            <div id="cfgSub-collab" class="accordion-collapse collapse" data-bs-parent="#cfgMapAcc">
-                                                <div class="accordion-body">
+                                    </div>
+                                    <div class="tab-pane fade" id="cfgPane-collab" role="tabpanel" aria-labelledby="cfgTab-collab" tabindex="0">
                                                 <div class="d-flex align-items-center justify-content-between mb-2">
                                                     <h6 class="fw-semibold mb-0">
                                                         <i class="fa fa-users me-1"></i>Collaborative Layers
@@ -3170,10 +3157,6 @@
                                                 <div class="form-text mt-2" data-bind="visible: config.noSearchMatchMessage, text: config.noSearchMatchMessage">
                                                 </div>
 
-                                                </div>
-                                            </div>
-                                        </div>
-                                        </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-sidebar" role="tabpanel" aria-labelledby="cfgTab-sidebar" tabindex="0">
                                                 <label class="form-label">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -3257,7 +3257,7 @@
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
                                         <div class="row g-3">
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-4">
                                                         <label class="form-label">
                                                             <i class="fa fa-moon me-1"></i>Dark Mode
                                                         </label>
@@ -3270,7 +3270,7 @@
                                                         </div>
                                                         <div class="form-text">Reduces eye strain in low light environments.</div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-4">
                                                         <label class="form-label">
                                                             <i class="fa fa-bell me-1"></i>Alerts Panel
                                                         </label>
@@ -3283,7 +3283,7 @@
                                                         </div>
                                                         <div class="form-text">Alerts will start collapsed.</div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-4">
                                                         <label class="form-label">
                                                             <i class="fa fa-hashtag me-1"></i>Incident Tasking Count
                                                         </label>

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2100,7 +2100,12 @@
                                     </li>
                                     <li class="nav-item" role="presentation">
                                         <button class="nav-link" id="cfgTab-sidebar" data-bs-toggle="pill" data-bs-target="#cfgPane-sidebar" type="button" role="tab" aria-controls="cfgPane-sidebar" aria-selected="false">
-                                            <span class="cfg-rail-ico"><i class="fa fa-columns"></i></span><span>Sidebar</span>
+                                            <span class="cfg-rail-ico"><i class="fa fa-columns"></i></span><span>Layout</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-starred" data-bs-toggle="pill" data-bs-target="#cfgPane-starred" type="button" role="tab" aria-controls="cfgPane-starred" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-star"></i></span><span>Starred</span>
                                         </button>
                                     </li>
                                     <li class="nav-item" role="presentation">
@@ -3181,8 +3186,8 @@
                                                     </label>
                                                 </div>
                                                 <div class="form-text">Pick a layout to instantly preview and apply section placement.</div>
-                                        <hr class="my-4">
-                                        <h6 class="cfg-subhead"><i class="fa fa-star me-2"></i>Starred teams &amp; incidents</h6>
+                                    </div>
+                                    <div class="tab-pane fade" id="cfgPane-starred" role="tabpanel" aria-labelledby="cfgTab-starred" tabindex="0">
                                                 <div
                                                     class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
                                                     <div class="small text-muted">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2124,33 +2124,59 @@
                                         <div class="cfg-data">
                                             <div class="cfg-data-fields">
                                                 <div class="cfg-field">
-                                                    <label for="refreshInterval">Refresh interval</label>
-                                                    <div class="ctl">
-                                                        <div class="input-group input-group-sm">
-                                                            <input id="refreshInterval" type="number" min="30" step="5"
-                                                                class="form-control" data-bind="value: config.refreshInterval">
+                                                    <label>Refresh interval</label>
+                                                    <div class="cfg-preset-row">
+                                                        <div class="cfg-seg" data-bind="foreach: { data: config.refreshPresets, as: 'p' }">
+                                                            <button type="button" class="cfg-seg-btn"
+                                                                data-bind="text: p.label,
+                                                                           css: { active: $root.config.refreshInterval() == p.value },
+                                                                           click: $root.config.pickRefreshPreset"></button>
+                                                        </div>
+                                                        <span class="cfg-preset-or">or</span>
+                                                        <div class="input-group input-group-sm cfg-preset-num">
+                                                            <input type="number" min="30" step="5" class="form-control"
+                                                                aria-label="Refresh interval (seconds)"
+                                                                data-bind="value: config.refreshInterval">
                                                             <span class="input-group-text">sec</span>
                                                         </div>
                                                     </div>
                                                     <div class="d">Full reload of every incident and team.</div>
                                                 </div>
                                                 <div class="cfg-field">
-                                                    <label for="fetchPeriod">Fetch window</label>
-                                                    <div class="ctl">
-                                                        <div class="input-group input-group-sm">
-                                                            <input id="fetchPeriod" type="number" min="0" max="31" step="1"
-                                                                class="form-control" aria-label="Fetch backwards (days)"
-                                                                data-bind="value: config.fetchPeriod">
-                                                            <span class="input-group-text">d&nbsp;back</span>
+                                                    <label>History &mdash; how far back</label>
+                                                    <div class="cfg-preset-row">
+                                                        <div class="cfg-chips" data-bind="foreach: { data: config.historyPresets, as: 'p' }">
+                                                            <button type="button" class="cfg-chip"
+                                                                data-bind="text: p.label,
+                                                                           css: { active: $root.config.fetchPeriod() == p.value },
+                                                                           click: $root.config.pickHistoryPreset"></button>
                                                         </div>
-                                                        <div class="input-group input-group-sm">
-                                                            <input id="fetchForward" type="number" min="0" step="1"
-                                                                class="form-control" aria-label="Fetch forward (days)"
-                                                                data-bind="value: config.fetchForward">
-                                                            <span class="input-group-text">d&nbsp;fwd</span>
+                                                        <span class="cfg-preset-or">or</span>
+                                                        <div class="input-group input-group-sm cfg-preset-num">
+                                                            <input type="number" min="0" max="31" step="1" class="form-control"
+                                                                aria-label="Days of history"
+                                                                data-bind="value: config.fetchPeriod">
+                                                            <span class="input-group-text">d</span>
                                                         </div>
                                                     </div>
-                                                    <div class="d">How much past history and lookahead to load.</div>
+                                                </div>
+                                                <div class="cfg-field">
+                                                    <label>Lookahead &mdash; how far forward</label>
+                                                    <div class="cfg-preset-row">
+                                                        <div class="cfg-chips" data-bind="foreach: { data: config.lookaheadPresets, as: 'p' }">
+                                                            <button type="button" class="cfg-chip"
+                                                                data-bind="text: p.label,
+                                                                           css: { active: $root.config.fetchForward() == p.value },
+                                                                           click: $root.config.pickLookaheadPreset"></button>
+                                                        </div>
+                                                        <span class="cfg-preset-or">or</span>
+                                                        <div class="input-group input-group-sm cfg-preset-num">
+                                                            <input type="number" min="0" max="31" step="1" class="form-control"
+                                                                aria-label="Days of lookahead"
+                                                                data-bind="value: config.fetchForward">
+                                                            <span class="input-group-text">d</span>
+                                                        </div>
+                                                    </div>
                                                 </div>
                                                 <div class="cfg-field">
                                                     <label for="signalrEnabledToggle">Live updates</label>
@@ -2159,6 +2185,9 @@
                                                             <input class="form-check-input" type="checkbox" role="switch"
                                                                 id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
                                                         </div>
+                                                        <span class="cfg-live-pill"
+                                                            data-bind="text: config.liveUpdatesLabel,
+                                                                       css: { on: config.signalrEnabled(), off: !config.signalrEnabled() }"></span>
                                                     </div>
                                                     <div class="d">Instant incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
                                                 </div>

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2124,7 +2124,7 @@
                                         <div class="cfg-data">
                                             <div class="cfg-data-fields">
                                                 <div class="cfg-field">
-                                                    <label>Refresh interval</label>
+                                                    <label>Full refresh</label>
                                                     <div class="cfg-preset-row">
                                                         <div class="cfg-seg" data-bind="foreach: { data: config.refreshPresets, as: 'p' }">
                                                             <button type="button" class="cfg-seg-btn"
@@ -2140,10 +2140,10 @@
                                                             <span class="input-group-text">sec</span>
                                                         </div>
                                                     </div>
-                                                    <div class="d">Automatically perform a full reload of every incident and team.</div>
+                                                    <div class="d" data-bind="text: config.fullRefreshHint"></div>
                                                 </div>
                                                 <div class="cfg-field">
-                                                    <label>History &mdash; how far back</label>
+                                                    <label>History &mdash; how far back to load</label>
                                                     <div class="cfg-preset-row">
                                                         <div class="cfg-chips" data-bind="foreach: { data: config.historyPresets, as: 'p' }">
                                                             <button type="button" class="cfg-chip"
@@ -2161,7 +2161,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="cfg-field">
-                                                    <label>Lookahead &mdash; how far forward</label>
+                                                    <label>Lookahead &mdash; how far forward to load</label>
                                                     <div class="cfg-preset-row">
                                                         <div class="cfg-chips" data-bind="foreach: { data: config.lookaheadPresets, as: 'p' }">
                                                             <button type="button" class="cfg-chip"
@@ -2189,7 +2189,7 @@
                                                             data-bind="text: config.liveUpdatesLabel,
                                                                        css: { on: config.signalrEnabled(), off: !config.signalrEnabled() }"></span>
                                                     </div>
-                                                    <div class="d">Instantly update incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
+                                                    <div class="d">Beacon pushes every incident, team &amp; tasking change to the board as it happens &mdash; this is what keeps LAD current. Restart LAD after changing.</div>
                                                 </div>
                                             </div>
 
@@ -2198,10 +2198,10 @@
                                                 <div class="cfg-readout-range" data-bind="text: config.fetchWindowRange"></div>
                                                 <div class="cfg-readout-sub"><span data-bind="text: config.fetchWindowDays"></span>-day window</div>
                                                 <div class="cfg-readout-rows">
-                                                    <div><span>Full refresh</span><span data-bind="text: config.refreshCadence"></span></div>
                                                     <div><span>Live updates</span><span data-bind="text: config.liveUpdatesLabel"></span></div>
+                                                    <div><span>Full refresh</span><span data-bind="text: config.refreshCadence"></span></div>
                                                 </div>
-                                                <div class="cfg-readout-note">Toggling live updates needs a LAD restart to take effect.</div>
+                                                <div class="cfg-readout-note" data-bind="text: config.dataReadoutNote"></div>
                                             </div>
                                         </div>
                                     </div>

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1040,6 +1040,29 @@ body.dark-mode .nav-link.active {
   border-color: #0d6efd;
 }
 
+/* Config modal left rail */
+body.dark-mode .config-rail {
+  border-color: #444;
+}
+
+body.dark-mode .config-rail .nav-link {
+  color: #adb5bd;
+}
+
+body.dark-mode .config-rail .nav-link:hover {
+  background: #333;
+  color: #e0e0e0;
+}
+
+body.dark-mode .config-rail .nav-link.active {
+  background: #2b3a55;
+  color: #6ea8fe;
+}
+
+body.dark-mode .cfg-subhead {
+  color: #adb5bd;
+}
+
 /* Collapse elements */
 body.dark-mode .collapse {
   background-color: #2d2d2d;

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1064,6 +1064,15 @@ body.dark-mode .cfg-subhead {
   color: #adb5bd;
 }
 
+body.dark-mode .cfg-row,
+body.dark-mode .cfg-row:first-child {
+  border-color: #444;
+}
+
+body.dark-mode .cfg-row-main .d {
+  color: #adb5bd;
+}
+
 /* Collapse elements */
 body.dark-mode .collapse {
   background-color: #2d2d2d;

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1064,12 +1064,16 @@ body.dark-mode .cfg-subhead {
   color: #adb5bd;
 }
 
-body.dark-mode .cfg-row,
-body.dark-mode .cfg-row:first-child {
+body.dark-mode .cfg-card {
+  background: #2d2d2d;
   border-color: #444;
 }
 
-body.dark-mode .cfg-row-main .d {
+body.dark-mode .cfg-line {
+  border-color: #3d3d3d;
+}
+
+body.dark-mode .cfg-card-note {
   color: #adb5bd;
 }
 

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1073,7 +1073,22 @@ body.dark-mode .cfg-line {
   border-color: #3d3d3d;
 }
 
-body.dark-mode .cfg-card-note {
+body.dark-mode .cfg-card-note,
+body.dark-mode .cfg-field .d {
+  color: #adb5bd;
+}
+
+body.dark-mode .cfg-readout {
+  background: #262626;
+  border-color: #444;
+}
+
+body.dark-mode .cfg-readout-h,
+body.dark-mode .cfg-readout-note {
+  color: #8b929c;
+}
+
+body.dark-mode .cfg-readout-sub {
   color: #adb5bd;
 }
 

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1041,6 +1041,7 @@ body.dark-mode .nav-link.active {
 }
 
 /* Config modal left rail */
+body.dark-mode .config-panes,
 body.dark-mode .config-rail {
   border-color: #444;
 }

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1064,16 +1064,6 @@ body.dark-mode .cfg-subhead {
   color: #adb5bd;
 }
 
-body.dark-mode .cfg-card {
-  background: #2d2d2d;
-  border-color: #444;
-}
-
-body.dark-mode .cfg-line {
-  border-color: #3d3d3d;
-}
-
-body.dark-mode .cfg-card-note,
 body.dark-mode .cfg-field .d {
   color: #adb5bd;
 }

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1092,6 +1092,40 @@ body.dark-mode .cfg-readout-sub {
   color: #adb5bd;
 }
 
+body.dark-mode .cfg-seg,
+body.dark-mode .cfg-seg-btn,
+body.dark-mode .cfg-chip {
+  border-color: #495057;
+}
+
+body.dark-mode .cfg-seg-btn,
+body.dark-mode .cfg-chip {
+  background: #2d2d2d;
+  color: #e0e0e0;
+}
+
+body.dark-mode .cfg-seg-btn:hover,
+body.dark-mode .cfg-chip:hover {
+  background: #3a3a3a;
+}
+
+body.dark-mode .cfg-seg-btn.active,
+body.dark-mode .cfg-chip.active {
+  background: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+body.dark-mode .cfg-live-pill.on {
+  background: #1a2c22;
+  color: #4bbd83;
+}
+
+body.dark-mode .cfg-live-pill.off {
+  background: #333;
+  color: #adb5bd;
+}
+
 /* Collapse elements */
 body.dark-mode .collapse {
   background-color: #2d2d2d;

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2118,16 +2118,21 @@ overflow: hidden;
 .config-settings {
   display: grid;
   grid-template-columns: 210px minmax(0, 1fr);
-  gap: 1.25rem;
-  align-items: start;
+  gap: 0;
 }
 
 .config-rail {
   position: sticky;
   top: 0;
+  align-self: start;
   gap: 2px;
-  border-right: 1px solid #dee2e6;
-  padding-right: 0.75rem;
+  padding-right: 1rem;
+}
+
+.config-panes {
+  border-left: 1px solid #dee2e6;
+  padding-left: 1.25rem;
+  min-height: 340px;
 }
 
 .config-rail .nav-link {
@@ -2165,10 +2170,6 @@ overflow: hidden;
   margin-right: 0.5rem;
 }
 
-.config-panes {
-  min-height: 360px;
-}
-
 .cfg-subhead {
   font-size: 0.8rem;
   font-weight: 600;
@@ -2191,11 +2192,15 @@ overflow: hidden;
     position: static;
     flex-direction: row !important;
     flex-wrap: wrap;
-    border-right: 0;
-    border-bottom: 1px solid #dee2e6;
     padding-right: 0;
     padding-bottom: 0.5rem;
     margin-bottom: 0.75rem;
+    border-bottom: 1px solid #dee2e6;
+  }
+
+  .config-panes {
+    border-left: 0;
+    padding-left: 0;
   }
 
   .config-rail .nav-link {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2187,14 +2187,15 @@ overflow: hidden;
 .cfg-rows {
   display: flex;
   flex-direction: column;
-  max-width: 620px;
+  max-width: 540px;
 }
 
 .cfg-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1.5rem;
+  display: grid;
+  grid-template-columns: 13.5rem 1fr;
+  column-gap: 1.25rem;
+  row-gap: 0.15rem;
+  align-items: baseline;
   padding: 0.85rem 0.1rem;
   border-bottom: 1px solid #e9ecef;
 }
@@ -2204,27 +2205,30 @@ overflow: hidden;
 }
 
 .cfg-row-main {
-  min-width: 0;
+  display: contents;
 }
 
 .cfg-row-main .t {
-  display: block;
+  grid-column: 1;
+  grid-row: 1;
   font-weight: 600;
   margin: 0;
 }
 
 .cfg-row-main .d {
+  grid-column: 1 / -1;
+  grid-row: 2;
   font-size: 0.8125rem;
   color: #6c757d;
-  margin-top: 0.15rem;
 }
 
 .cfg-row-control {
-  flex: none;
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: start;
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  padding-top: 0.1rem;
 }
 
 .cfg-row-control .input-group {
@@ -2241,11 +2245,11 @@ overflow: hidden;
 .cfg-row-control .form-switch {
   min-height: auto;
   margin: 0;
-  padding-left: 2.5em;
+  padding-left: 0;
 }
 
 .cfg-row-control .form-switch .form-check-input {
-  margin-left: -2.5em;
+  margin: 0;
   cursor: pointer;
 }
 

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2183,6 +2183,72 @@ overflow: hidden;
   padding-top: 0.75rem;
 }
 
+/* Stacked settings rows (Data / Appearance panes) */
+.cfg-rows {
+  display: flex;
+  flex-direction: column;
+  max-width: 620px;
+}
+
+.cfg-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.85rem 0.1rem;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.cfg-row:first-child {
+  border-top: 1px solid #e9ecef;
+}
+
+.cfg-row-main {
+  min-width: 0;
+}
+
+.cfg-row-main .t {
+  display: block;
+  font-weight: 600;
+  margin: 0;
+}
+
+.cfg-row-main .d {
+  font-size: 0.8125rem;
+  color: #6c757d;
+  margin-top: 0.15rem;
+}
+
+.cfg-row-control {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding-top: 0.1rem;
+}
+
+.cfg-row-control .input-group {
+  width: auto;
+  flex: none;
+}
+
+.cfg-row-control .input-group .form-control {
+  width: 4rem;
+  flex: 0 0 auto;
+  text-align: right;
+}
+
+.cfg-row-control .form-switch {
+  min-height: auto;
+  margin: 0;
+  padding-left: 2.5em;
+}
+
+.cfg-row-control .form-switch .form-check-input {
+  margin-left: -2.5em;
+  cursor: pointer;
+}
+
 @media (max-width: 640px) {
   .config-settings {
     grid-template-columns: 1fr;

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2246,6 +2246,123 @@ overflow: hidden;
   color: #6c757d;
 }
 
+/* Data pane: settings + live "loading now" readout */
+.cfg-data {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 19rem;
+  gap: 2.25rem;
+  align-items: start;
+  max-width: 760px;
+}
+
+.cfg-data-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  padding-top: 0.25rem;
+}
+
+.cfg-field > label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.cfg-field .ctl {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cfg-field .ctl .input-group {
+  width: auto;
+  flex: none;
+}
+
+.cfg-field .ctl .input-group .form-control {
+  width: 3.25rem;
+  flex: 0 0 auto;
+  text-align: right;
+}
+
+.cfg-field .ctl .form-switch {
+  min-height: auto;
+  margin: 0;
+  padding-left: 0;
+}
+
+.cfg-field .ctl .form-switch .form-check-input {
+  margin: 0;
+  cursor: pointer;
+}
+
+.cfg-field .d {
+  font-size: 0.8125rem;
+  color: #6c757d;
+  margin-top: 0.35rem;
+  max-width: 34ch;
+}
+
+.cfg-readout {
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 1rem 1.1rem 1.05rem;
+}
+
+.cfg-readout-h {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a929c;
+  margin-bottom: 0.6rem;
+}
+
+.cfg-readout-range {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.cfg-readout-sub {
+  font-size: 0.8125rem;
+  color: #6c757d;
+  margin-top: 0.15rem;
+}
+
+.cfg-readout-rows {
+  margin-top: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.cfg-readout-rows > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.875rem;
+}
+
+.cfg-readout-rows > div > span:last-child {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.cfg-readout-note {
+  margin-top: 0.95rem;
+  font-size: 0.75rem;
+  color: #8a929c;
+}
+
+@media (max-width: 820px) {
+  .cfg-data {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
 @media (max-width: 640px) {
   .config-settings {
     grid-template-columns: 1fr;

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2183,69 +2183,6 @@ overflow: hidden;
   padding-top: 0.75rem;
 }
 
-/* Compact settings card (Data / Appearance panes) */
-.cfg-card {
-  max-width: 400px;
-  padding: 0 1rem;
-  border: 1px solid #e3e6ea;
-  border-radius: 8px;
-  background: #fff;
-}
-
-.cfg-line {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: center;
-  column-gap: 1rem;
-  padding: 0.72rem 0;
-  border-bottom: 1px solid #eef0f2;
-}
-
-.cfg-line:last-child {
-  border-bottom: 0;
-}
-
-.cfg-line > label {
-  font-weight: 500;
-  margin: 0;
-}
-
-.cfg-line-ctl {
-  justify-self: end;
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.cfg-line-ctl .input-group {
-  width: auto;
-  flex: none;
-}
-
-.cfg-line-ctl .input-group .form-control {
-  width: 3.25rem;
-  flex: 0 0 auto;
-  text-align: right;
-}
-
-.cfg-line-ctl .form-switch {
-  min-height: auto;
-  margin: 0;
-  padding-left: 0;
-}
-
-.cfg-line-ctl .form-switch .form-check-input {
-  margin: 0;
-  cursor: pointer;
-}
-
-.cfg-card-note {
-  max-width: 42ch;
-  margin: 0.85rem 0 0;
-  font-size: 0.8125rem;
-  color: #6c757d;
-}
-
 /* Data pane: preset controls + live "loading now" readout */
 .cfg-data {
   display: grid;
@@ -2262,6 +2199,11 @@ overflow: hidden;
   padding-top: 0.25rem;
 }
 
+/* same field stack used standalone (Appearance pane) */
+.cfg-fields-solo {
+  max-width: 460px;
+}
+
 .cfg-field > label {
   display: block;
   font-weight: 600;
@@ -2272,6 +2214,19 @@ overflow: hidden;
   display: flex;
   align-items: center;
   gap: 0.55rem;
+}
+
+.cfg-field .ctl .form-switch {
+  display: flex;
+  align-items: center;
+  min-height: auto;
+  margin: 0;
+  padding-left: 0;
+}
+
+.cfg-field .ctl .form-switch .form-check-input {
+  margin: 0;
+  cursor: pointer;
 }
 
 .cfg-field .d {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2114,6 +2114,95 @@ overflow: hidden;
   margin-top: 2.5px !important;
 }
 
+/* === Config modal: left-rail sections === */
+.config-settings {
+  display: grid;
+  grid-template-columns: 210px minmax(0, 1fr);
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.config-rail {
+  position: sticky;
+  top: 0;
+  gap: 2px;
+  border-right: 1px solid #dee2e6;
+  padding-right: 0.75rem;
+}
+
+.config-rail .nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  text-align: left;
+  color: #495057;
+  border-radius: 6px;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.9rem;
+}
+
+.config-rail .nav-link:hover {
+  background: #f1f3f5;
+  color: #212529;
+}
+
+.config-rail .nav-link.active {
+  background: #e7f1ff;
+  color: #0d6efd;
+  font-weight: 600;
+}
+
+.cfg-rail-ico,
+.cfg-sub-ico {
+  width: 1.1rem;
+  text-align: center;
+  flex: none;
+  opacity: 0.85;
+}
+
+.cfg-sub-ico {
+  margin-right: 0.5rem;
+}
+
+.config-panes {
+  min-height: 360px;
+}
+
+.cfg-subhead {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6c757d;
+  margin: 0 0 0.75rem;
+}
+
+.config-subaccordion .accordion-body {
+  padding-top: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .config-settings {
+    grid-template-columns: 1fr;
+  }
+
+  .config-rail {
+    position: static;
+    flex-direction: row !important;
+    flex-wrap: wrap;
+    border-right: 0;
+    border-bottom: 1px solid #dee2e6;
+    padding-right: 0;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .config-rail .nav-link {
+    width: auto;
+  }
+}
+
 /* === Job History / Ops Log two-lane timeline === */
 
 .job-history-timeline {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2183,74 +2183,67 @@ overflow: hidden;
   padding-top: 0.75rem;
 }
 
-/* Stacked settings rows (Data / Appearance panes) */
-.cfg-rows {
-  display: flex;
-  flex-direction: column;
-  max-width: 540px;
+/* Compact settings card (Data / Appearance panes) */
+.cfg-card {
+  max-width: 400px;
+  padding: 0 1rem;
+  border: 1px solid #e3e6ea;
+  border-radius: 8px;
+  background: #fff;
 }
 
-.cfg-row {
+.cfg-line {
   display: grid;
-  grid-template-columns: 13.5rem 1fr;
-  column-gap: 1.25rem;
-  row-gap: 0.15rem;
-  align-items: baseline;
-  padding: 0.85rem 0.1rem;
-  border-bottom: 1px solid #e9ecef;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  column-gap: 1rem;
+  padding: 0.72rem 0;
+  border-bottom: 1px solid #eef0f2;
 }
 
-.cfg-row:first-child {
-  border-top: 1px solid #e9ecef;
+.cfg-line:last-child {
+  border-bottom: 0;
 }
 
-.cfg-row-main {
-  display: contents;
-}
-
-.cfg-row-main .t {
-  grid-column: 1;
-  grid-row: 1;
-  font-weight: 600;
+.cfg-line > label {
+  font-weight: 500;
   margin: 0;
 }
 
-.cfg-row-main .d {
-  grid-column: 1 / -1;
-  grid-row: 2;
-  font-size: 0.8125rem;
-  color: #6c757d;
-}
-
-.cfg-row-control {
-  grid-column: 2;
-  grid-row: 1;
-  justify-self: start;
+.cfg-line-ctl {
+  justify-self: end;
   display: flex;
   align-items: center;
   gap: 0.4rem;
 }
 
-.cfg-row-control .input-group {
+.cfg-line-ctl .input-group {
   width: auto;
   flex: none;
 }
 
-.cfg-row-control .input-group .form-control {
-  width: 4rem;
+.cfg-line-ctl .input-group .form-control {
+  width: 3.25rem;
   flex: 0 0 auto;
   text-align: right;
 }
 
-.cfg-row-control .form-switch {
+.cfg-line-ctl .form-switch {
   min-height: auto;
   margin: 0;
   padding-left: 0;
 }
 
-.cfg-row-control .form-switch .form-check-input {
+.cfg-line-ctl .form-switch .form-check-input {
   margin: 0;
   cursor: pointer;
+}
+
+.cfg-card-note {
+  max-width: 42ch;
+  margin: 0.85rem 0 0;
+  font-size: 0.8125rem;
+  color: #6c757d;
 }
 
 @media (max-width: 640px) {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2246,61 +2246,145 @@ overflow: hidden;
   color: #6c757d;
 }
 
-/* Data pane: settings + live "loading now" readout */
+/* Data pane: preset controls + live "loading now" readout */
 .cfg-data {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 19rem;
+  grid-template-columns: minmax(0, 1fr) 17rem;
   gap: 2.25rem;
   align-items: start;
-  max-width: 760px;
+  max-width: 880px;
 }
 
 .cfg-data-fields {
   display: flex;
   flex-direction: column;
-  gap: 1.4rem;
+  gap: 1.5rem;
   padding-top: 0.25rem;
 }
 
 .cfg-field > label {
   display: block;
   font-weight: 600;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.5rem;
 }
 
 .cfg-field .ctl {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-}
-
-.cfg-field .ctl .input-group {
-  width: auto;
-  flex: none;
-}
-
-.cfg-field .ctl .input-group .form-control {
-  width: 3.25rem;
-  flex: 0 0 auto;
-  text-align: right;
-}
-
-.cfg-field .ctl .form-switch {
-  min-height: auto;
-  margin: 0;
-  padding-left: 0;
-}
-
-.cfg-field .ctl .form-switch .form-check-input {
-  margin: 0;
-  cursor: pointer;
+  gap: 0.55rem;
 }
 
 .cfg-field .d {
   font-size: 0.8125rem;
   color: #6c757d;
-  margin-top: 0.35rem;
-  max-width: 34ch;
+  margin-top: 0.4rem;
+  max-width: 44ch;
+}
+
+/* preset row: segments / chips + numeric escape hatch */
+.cfg-preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.6rem;
+}
+
+.cfg-seg {
+  display: inline-flex;
+  flex-wrap: wrap;
+  border: 1px solid var(--bs-border-color, #ced4da);
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.cfg-seg-btn {
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: 0;
+  border-right: 1px solid var(--bs-border-color, #ced4da);
+  background: #fff;
+  color: #1b2430;
+  padding: 0.4rem 0.7rem;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+.cfg-seg-btn:last-child {
+  border-right: 0;
+}
+
+.cfg-seg-btn:hover {
+  background: #f1f3f5;
+}
+
+.cfg-seg-btn.active {
+  background: #0d6efd;
+  color: #fff;
+}
+
+.cfg-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.cfg-chip {
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: 1px solid #ced4da;
+  background: #fff;
+  color: #1b2430;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+.cfg-chip:hover {
+  border-color: #8a929c;
+}
+
+.cfg-chip.active {
+  background: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+.cfg-preset-or {
+  font-size: 0.75rem;
+  color: #8a929c;
+}
+
+.cfg-preset-num {
+  width: auto !important;
+  flex: none;
+}
+
+.cfg-preset-num .form-control {
+  width: 3.5rem;
+  flex: 0 0 auto;
+  text-align: right;
+}
+
+.cfg-live-pill {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+}
+
+.cfg-live-pill.on {
+  background: #e4f1ea;
+  color: #2f8f5b;
+}
+
+.cfg-live-pill.off {
+  background: #eef0f2;
+  color: #6c757d;
 }
 
 .cfg-readout {


### PR DESCRIPTION
## What

The Page Config modal had grown to **nine flat accordion panels**, with filtering split across two floating cards plus three separate panels, and a "Map Layers" panel that mixed marker-display settings with the collaborative-layer library.

This replaces the single accordion with a **vertical pill nav + tab panes**:

| Section | Holds |
|---|---|
| **Data** | Full refresh interval (preset segments), fetch window (chip presets), live updates — plus a live "loading now" readout |
| **Filters** | sub-accordion: Incidents · Teams · Sectors |
| **Map markers** | clustering + marker layer order |
| **Collaborative layers** | the shared-layer library, on its own |
| **Layout** | section layout preset |
| **Starred** | starred teams & incidents |
| **Appearance** | dark mode, auto-collapse alerts, tasking-count mode |
| **Instant Task Suggestions** | unchanged |

All control markup and `data-bind` attributes are carried over; the HQ scope cards stay pinned above the nav.

## Data tab specifics

- **Full refresh** is now preset segments (`30s · 1–10 min`); **history** and **lookahead** are chip rows (`Today · 1 day … 1 month`). Each keeps a small `or [N]` number field as the escape hatch for off-preset values.
- A **"Loading now" readout** resolves the knobs to a real date range + day count, humanised refresh cadence and live-updates state.
- The **full-refresh help text and readout note swap with the live-updates toggle**, so it's clear the sweep can be infrequent when live updates carry the load.
- The **short-interval warning** was reworked: fires only below 60s (not on every change), explains the actual cost (this client re-querying everything from Beacon), and confirms by typing the interval rather than the word "reckless".

## New in ConfigVM

`fetchWindowRange` / `fetchWindowDays` / `refreshCadence` / `liveUpdatesLabel` / `fullRefreshHint` / `dataReadoutNote`, the preset lists + `pick*` setters, and the `darkModeLabel` / `alertsCollapseLabel` / `taskingCountLabel` pill computeds. All pure, no side effects.

## Testing

- `webpack --config webpack.dev.js` compiles
- `eslint` clean on changed files
- HTML tag balance unchanged from `master-dev` (same two pre-existing quirks)

Not visually verified against the running app by me — screenshots are in the review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)