### PR TITLE
Job status on incident markers

### DIFF
--- a/src/pages/tasking/components/job_icon.js
+++ b/src/pages/tasking/components/job_icon.js
@@ -1,4 +1,4 @@
-import {jobsToUI} from "../utils/jobTypesToUI.js";
+import {jobsToUI, statusClosedMark, ACTIVE_RING_COLOUR} from "../utils/jobTypesToUI.js";
 
 // --- SVG factory (shape+style → L.divIcon) ---
 import L from "leaflet";
@@ -121,33 +121,116 @@ function shapeInnerSvg({ shape, fill, stroke, radius = 7, strokeWidth = 2 }) {
     return inner;
 }
 
-export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2 }) {
+// Diagonal strike ("/") or cross ("✕") overlaid on a closed job's marker.
+// Dark line with a thin white casing underneath so it reads on any fill.
+// Sits right across the shape — barely past its edge.
+function closedMarkSvg(kind, c, radius) {
+    const e = radius + 1;
+    const w = Math.max(1.3, radius * 0.22);
+    const seg = (x1, y1, x2, y2) =>
+        `<line x1="${(c + x1).toFixed(2)}" y1="${(c + y1).toFixed(2)}" x2="${(c + x2).toFixed(2)}" y2="${(c + y2).toFixed(2)}" />`;
+    const lines = kind === "cross"
+        ? seg(-e, -e, e, e) + seg(e, -e, -e, e)
+        : seg(-e, e, e, -e); // "/"
+    return `<g stroke="#ffffff" stroke-width="${(w + 1.1).toFixed(2)}" stroke-linecap="round">${lines}</g>` +
+           `<g stroke="#12181e" stroke-width="${w.toFixed(2)}" stroke-linecap="round">${lines}</g>`;
+}
+
+// Red "!" pip in the NE corner — a job carrying an action-required tag.
+function alertPipSvg(pad, d, radius) {
+    const pr = Math.max(3.4, radius * 0.6);
+    const halo = pr + 1.1;
+    const x = pad + d - pr * 0.35;
+    const y = pad + pr * 0.35;
+    const n = (v) => v.toFixed(2);
+    return `<circle cx="${n(x)}" cy="${n(y)}" r="${n(halo)}" fill="#ffffff" />` +
+           `<circle cx="${n(x)}" cy="${n(y)}" r="${n(pr)}" fill="#e5484d" stroke="rgba(0,0,0,0.3)" stroke-width="0.7" />` +
+           `<g fill="#ffffff">` +
+             `<rect x="${n(x - pr * 0.16)}" y="${n(y - pr * 0.55)}" width="${n(pr * 0.32)}" height="${n(pr * 0.72)}" rx="${n(pr * 0.16)}" />` +
+             `<circle cx="${n(x)}" cy="${n(y + pr * 0.52)}" r="${n(pr * 0.17)}" />` +
+           `</g>`;
+}
+
+export function makeShapeIcon({ shape, fill, stroke, radius = 7, strokeWidth = 2, closedMark = null, alert = false }) {
     const d = radius * 2;
     const inner = shapeInnerSvg({ shape, fill, stroke, radius, strokeWidth });
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${d}" height="${d}" viewBox="0 0 ${d} ${d}">
+
+    if (!closedMark && !alert) {
+        const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${d}" height="${d}" viewBox="0 0 ${d} ${d}">
               ${inner}
             </svg>`;
+
+        return L.divIcon({
+            className: "job-svg-marker",
+            html: svg,
+            iconSize: [d, d],
+            iconAnchor: [radius, radius],
+            popupAnchor: [0, -radius],
+            shapeDiameter: d
+        });
+    }
+
+    // Padded symmetrically so iconAnchor stays at the shape centre; the pulse /
+    // status rings key off `shapeDiameter` rather than this padded box.
+    // ~radius*0.55 covers the "!" pip halo and the strike's small overhang.
+    const pad = Math.ceil(radius * 0.55);
+    const box = d + pad * 2;
+    const c = pad + radius;
+
+    let overlay = `<g transform="translate(${pad}, ${pad})">${inner}</g>`;
+    if (closedMark) overlay += closedMarkSvg(closedMark, c, radius);
+    if (alert) overlay += alertPipSvg(pad, d, radius);
+
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${box}" height="${box}" viewBox="0 0 ${box} ${box}">${overlay}</svg>`;
 
     return L.divIcon({
         className: "job-svg-marker",
         html: svg,
-        iconSize: [d, d],
-        iconAnchor: [radius, radius],
-        popupAnchor: [0, -radius]
+        iconSize: [box, box],
+        iconAnchor: [c, c],
+        popupAnchor: [0, -radius],
+        shapeDiameter: d
     });
 };
 
+/**
+ * SVG for the Active "marching ring" — a dashed circle in a spinning <g>.
+ * Rotation (compositor-only) reads as marching ants at this size and is far
+ * cheaper than animating stroke-dashoffset on every marker.
+ */
+export function buildStatusRingSvg(box, ringRadius, colour = ACTIVE_RING_COLOUR) {
+    const c = box / 2;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${box}" height="${box}" viewBox="0 0 ${box} ${box}">
+              <g class="status-ring-spin" style="transform-box:fill-box;transform-origin:center">
+                <circle cx="${c}" cy="${c}" r="${ringRadius}" fill="none" stroke="${colour}"
+                        stroke-width="2.75" stroke-linecap="round" stroke-dasharray="4 3.5" />
+              </g>
+            </svg>`;
+}
+
 // Build icon style for a given job
-export function styleForJob(job) {
+export function styleForJob(job, { showStatus = false } = {}) {
 
     const style = jobsToUI(job)
 
     // // Emphasise Priority/Immediate with larger radius
     // const radius = (/^(Priority|Immediate)$/i.test(job.priorityName())) ? 8.5 : 7;
     const radius = 7
-    
-    return { shape: style.shape, fill: style.fillcolor, stroke: style.strokecolor, radius, strokeWidth: 2.25 };
+
+    const out = { shape: style.shape, fill: style.fillcolor, stroke: style.strokecolor, radius, strokeWidth: 2.25 };
     // tweak strokeWidth if you need stronger outlines
+
+    // Only attach status keys when the option is on, so JSON.stringify(style)
+    // (the change-detection key) is byte-identical to the old behaviour when off.
+    // Note: the Active marching ring is a sibling layer, not part of this icon —
+    // see upsertStatusRing() in jobMarker.js.
+    if (showStatus) {
+        const mark = statusClosedMark(job.statusName?.());
+        if (mark) out.closedMark = mark;
+        if ((job.actionRequiredTags?.() || []).length > 0) out.alert = true;
+    }
+
+    return out;
 }
 
 /**

--- a/src/pages/tasking/components/legend.js
+++ b/src/pages/tasking/components/legend.js
@@ -6,6 +6,39 @@ export const LegendControl = L.Control.extend({
 
   onAdd() {
     const div = L.DomUtil.create("div", "legend-container leaflet-bar");
+
+    // Status → marker treatment rows. Hidden until config.showJobStatusOnMarkers
+    // is on (Map.applyJobStatusOnMarkers toggles the .legend-status-block wrapper).
+    // A grey circle marker (r6 @ 9,11) with the treatment drawn over it.
+    const strikeSvg = (cross) => {
+      const cas = 'stroke="#fff" stroke-width="3.6" stroke-linecap="round"';
+      const ink = 'stroke="#12181e" stroke-width="2.2" stroke-linecap="round"';
+      const a = cross
+        ? '<line x1="3" y1="5" x2="15" y2="17"/><line x1="3" y1="17" x2="15" y2="5"/>'
+        : '<line x1="3" y1="17" x2="15" y2="5"/>';
+      return `<g ${cas}>${a}</g><g ${ink}>${a}</g>`;
+    };
+    const dot = '<circle cx="9" cy="11" r="6" fill="#9aa3ad" stroke="#000" stroke-width="2"/>';
+    const STATUS_ROWS = [
+      { label: "New",
+        svg: `<circle cx="9" cy="11" r="8.4" fill="none" stroke="#f7931d" stroke-width="2.2"/>${dot}` },
+      { label: "Active",
+        svg: `<circle cx="9" cy="11" r="8.2" fill="none" stroke="#e5399b" stroke-width="2.2" stroke-dasharray="3.4 3" stroke-linecap="round"/>${dot}` },
+      { label: "Tasked", svg: dot },
+      { label: "Complete / Referred / Finalised", svg: `${dot}${strikeSvg(false)}` },
+      { label: "Cancelled / Rejected", svg: `${dot}${strikeSvg(true)}` },
+      { label: "Action required (any status)",
+        svg: `${dot}
+              <circle cx="16.4" cy="4.4" r="4.4" fill="#fff"/>
+              <circle cx="16.4" cy="4.4" r="3.5" fill="#e5484d"/>
+              <rect x="15.8" y="2.5" width="1.2" height="2.6" rx="0.6" fill="#fff"/><circle cx="16.4" cy="6.3" r="0.7" fill="#fff"/>` },
+    ];
+    const statusPipRows = STATUS_ROWS.map((r) => `
+        <div style="display:flex;align-items:center;gap:5px;">
+          <svg width="22" height="22" viewBox="0 0 22 22" style="flex-shrink:0;overflow:visible;">${r.svg}</svg>
+          <span>${r.label}</span>
+        </div>`).join("");
+
     div.innerHTML = `
       <div class="legend-header d-flex justify-content-between align-items-center">
         <span class="fw-semibold">Legend</span><br>
@@ -47,6 +80,13 @@ export const LegendControl = L.Control.extend({
     </div>
 
 
+    <div class="legend-status-block d-none">
+      <div class="fw-semibold small mb-1 mt-2">Job Status <span class="text-muted fw-normal">(Any type)</span></div>
+      <div style="display:grid;grid-template-columns:1fr;row-gap:3px;" class="small">
+        ${statusPipRows}
+      </div>
+    </div>
+
     <div>
       <div class="fw-semibold small mb-1 mt-2">Overlays</div>
       <div style="display:grid;grid-template-columns:1fr 1fr;column-gap:12px;row-gap:4px;" class="small legend-ring">
@@ -75,10 +115,12 @@ export const LegendControl = L.Control.extend({
         </div>
         <div style="display:flex;align-items:center;gap:4px;">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 36 36" style="flex-shrink:0;overflow:visible;">
-            <polygon points="18,3 33,11.5 33,24.5 18,33 3,24.5 3,11.5" fill="#6b7280" stroke="rgba(247,147,29,0.9)" stroke-width="2"/>
+            <!-- Grey cluster badge with a solid pulsing orange hex outline,
+                 mirroring the real cluster-pulse-hex (Map.js iconCreateFunction). -->
+            <polygon points="18,0 36,10.5 36,25.5 18,36 0,25.5 0,10.5" fill="none" stroke="rgba(247,147,29,0.9)" stroke-width="2" style="transform-box:fill-box;transform-origin:center;animation:cluster-pulse-new 1.4s ease-out infinite;"/>
+            <polygon points="18,3 33,11.5 33,24.5 18,33 3,24.5 3,11.5" fill="#6b7280" stroke="#888" stroke-width="2"/>
             <polygon points="24.1,9 27.5,18 24.1,27 11.9,27 8.5,18 11.9,9" fill="#6b7280"/>
             <text x="18" y="18" text-anchor="middle" dominant-baseline="central" fill="#fff" font-size="13" font-weight="700" font-family="system-ui,sans-serif">3</text>
-            <polygon points="18,3 33,11.5 33,24.5 18,33 3,24.5 3,11.5" fill="none" stroke="#f7931d" stroke-width="2" stroke-dasharray="4 2"/>
           </svg>
           <span>Cluster Contains Unacked Incidents</span>
         </div>
@@ -86,6 +128,7 @@ export const LegendControl = L.Control.extend({
       </div>
 
 
+  <div>
   <div class="fw-semibold small mb-1 mt-2">Assets</div>
   <div style="display:grid;grid-template-columns:1fr 1fr;column-gap:12px;row-gap:2px;">
 
@@ -168,9 +211,9 @@ export const LegendControl = L.Control.extend({
     </div>
 
   </div>
+  </div>
 </div>
 
-    </div>
     `;
 
     this._container = div;

--- a/src/pages/tasking/markers/jobMarker.js
+++ b/src/pages/tasking/markers/jobMarker.js
@@ -2,7 +2,8 @@ var L = require('leaflet');
 var ko = require('knockout');
 
 import { buildJobPopupKO } from '../components/job_popup.js';
-import { makeShapeIcon, styleForJob, buildPulseRingSvg } from '../components/job_icon.js';
+import { makeShapeIcon, styleForJob, buildPulseRingSvg, buildStatusRingSvg } from '../components/job_icon.js';
+import { statusHasRing } from '../utils/jobTypesToUI.js';
 
 
 import { makePopupNode, bindKoToPopup, unbindKoFromPopup, deferPopupUpdate } from '../utils/popup_dom_utils.js';
@@ -25,7 +26,8 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
             : vm.mapVM.jobClusterGroup;          // normal clustering
     const markers = vm.mapVM.jobMarkerIndex;
     const pulseLayer = vm.mapVM.jobPulseLayer;
-    const style = styleForJob(job);
+    const showStatus = !!vm.config?.showJobStatusOnMarkers?.();
+    const style = styleForJob(job, { showStatus });
     const html = buildJobPopupKO();
     const contentEl = makePopupNode(html, 'job-pop-root')
 
@@ -59,8 +61,9 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
         m._priorityColor = style.fill || '#6b7280';
         if (!m._popupBound) { m.setPopupContent(node); wireKoForPopup(ko, m, job, vm, vm.mapVM.makeJobPopupVM(job)); }
 
-        // keep the "New" ring and _isNew flag in correct state
+        // keep the "New" pulse ring and the Active marching ring in correct state
         upsertPulseRing(pulseLayer, job, m);
+        if (showStatus) upsertStatusRing(vm.mapVM.jobStatusRingLayer, job, m);
         const wasNew = m._isNew;
         m._isNew = (job.statusName?.() || '').toLowerCase() === 'new';
         if (wasNew !== m._isNew && vm.mapVM.clusteringEnabled) {
@@ -77,6 +80,8 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
                     if (prev !== m._isNew && vm.mapVM.clusteringEnabled) {
                         vm.mapVM.jobClusterGroup.refreshClusters(m);
                     }
+                    // restyle icon (strike / X) + Active marching ring when the option is on
+                    if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(m, job, vm, pulseLayer);
                 })
             );
         }
@@ -87,6 +92,14 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
                 syncMarkerStyle(m, job, vm, pulseLayer);
             });
             (m._subs ||= []).push(m._prioritySub);
+        }
+
+        // action-required tags → "!" pip on the icon
+        if (!m._alertSub && job.actionRequiredTags) {
+            m._alertSub = job.actionRequiredTags.subscribe(() => {
+                if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(m, job, vm, pulseLayer);
+            });
+            (m._subs ||= []).push(m._alertSub);
         }
 
         job.marker = m;
@@ -108,6 +121,7 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
     job.marker = marker;
 
     upsertPulseRing(pulseLayer, job, marker);
+    if (showStatus) upsertStatusRing(vm.mapVM.jobStatusRingLayer, job, marker);
     (marker._pulseSubs ||= []).push(
         job.statusName.subscribe(() => {
             upsertPulseRing(pulseLayer, job, marker);
@@ -117,6 +131,8 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
             if (wasNew !== marker._isNew && vm.mapVM.clusteringEnabled) {
                 vm.mapVM.jobClusterGroup.refreshClusters(marker);
             }
+            // restyle icon (strike / X) + Active marching ring when the option is on
+            if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(marker, job, vm, pulseLayer);
         })
     );
 
@@ -129,14 +145,22 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
         syncMarkerStyle(marker, job, vm, pulseLayer);
     });
 
+    // action-required tags → "!" pip on the icon
+    marker._alertSub = job.actionRequiredTags
+        ? job.actionRequiredTags.subscribe(() => {
+            if (vm.config?.showJobStatusOnMarkers?.()) syncMarkerStyle(marker, job, vm, pulseLayer);
+        })
+        : null;
+
     // live position updates from KO observables
     marker._subs = [
         job.address.latitude.subscribe(() => safeMove(marker, job)),
         job.address.longitude.subscribe(() => safeMove(marker, job)),
         marker._prioritySub,
-    ];
+        marker._alertSub,
+    ].filter(Boolean);
 
-    // Sync pulse ring visibility after adding
+    // Sync pulse / status ring visibility after adding
     vm.mapVM._syncPulseRings?.();
 
     return marker;
@@ -167,12 +191,20 @@ export function removeJobMarker(vm, jobOrId) {
     const popupEl = m.getPopup()?.getElement?.();
     if (popupEl && popupEl.__ko_bound__) { try { ko.cleanNode(popupEl); } catch { /* empty */ } delete popupEl.__ko_bound__; }
 
+    // statusName subscription drives both the pulse ring and the Active ring
+    (m._pulseSubs || []).forEach(s => { try { s.dispose?.(); } catch { /* empty */ } });
+    m._pulseSubs = [];
+
     if (m._pulseRing) {
         m._pulseRing._detach?.();
-        (m._pulseSubs || []).forEach(s => { try { s.dispose?.(); } catch { /* empty */ } });
-        m._pulseSubs = [];
         pulseLayer.removeLayer(m._pulseRing);
         m._pulseRing = null;
+    }
+
+    if (m._statusRing) {
+        m._statusRing._detach?.();
+        vm.mapVM.jobStatusRingLayer?.removeLayer(m._statusRing);
+        m._statusRing = null;
     }
 
     // Remove from whichever layer it's in
@@ -184,17 +216,58 @@ export function removeJobMarker(vm, jobOrId) {
     if (job) job.marker = null;
 }
 
+/**
+ * Re-evaluate every existing job marker — used when the `showJobStatusOnMarkers`
+ * config option is toggled, so the strike / X / "!" pip and the Active marching
+ * ring are added to / removed from markers already on the map.
+ */
+export function restyleAllJobMarkers(vm) {
+    const showStatus = !!vm.config?.showJobStatusOnMarkers?.();
+    const pulseLayer = vm.mapVM?.jobPulseLayer;
+    const statusRingLayer = vm.mapVM?.jobStatusRingLayer;
+    vm.jobsById?.forEach((job) => {
+        const m = job.marker;
+        if (!m) return;
+
+        const newStyle = styleForJob(job, { showStatus });
+        const key = JSON.stringify(newStyle);
+        if (m._styleKey !== key) {
+            m.setIcon(makeShapeIcon(newStyle));
+            m._styleKey = key;
+            m._priorityColor = newStyle.fill || '#6b7280';
+            // icon box may have resized — rebuild the pulse ring against it
+            if (m._pulseRing && pulseLayer) {
+                m._pulseRing._detach?.();
+                pulseLayer.removeLayer(m._pulseRing);
+                m._pulseRing = null;
+                upsertPulseRing(pulseLayer, job, m);
+            }
+        }
+
+        // Active marching ring: rebuild if on, tear down if the option is off
+        if (m._statusRing && statusRingLayer) {
+            m._statusRing._detach?.();
+            statusRingLayer.removeLayer(m._statusRing);
+            m._statusRing = null;
+        }
+        if (showStatus) upsertStatusRing(statusRingLayer, job, m);
+    });
+    vm.mapVM?._syncPulseRings?.();
+}
+
 //complicated for some reason. has to support different icons sizes and anchors
 function upsertPulseRing(layerGroup, job, marker) {
     const isNew = (job.statusName?.() || '').toLowerCase() === 'new';
     const base = marker.options.icon?.options || {};
-    const baseSize = base.iconSize || [14, 14];
-    const baseAnchor = base.iconAnchor || [baseSize[0] / 2, baseSize[1] / 2];
+    const iconSize = base.iconSize || [14, 14];
+    // Ring is sized to the actual shape, not the (possibly pip-padded) icon box.
+    const shapeD = base.shapeDiameter || Math.min(iconSize[0], iconSize[1]);
+    const baseSize = [shapeD, shapeD];
 
     if (isNew && !marker._pulseRing) {
         const k = 3;
         const ringSize = [Math.round(baseSize[0] * k), Math.round(baseSize[1] * k)];
-        const ringAnchor = [Math.round(baseAnchor[0] * k), Math.round(baseAnchor[1] * k)];
+        const ringAnchor = [Math.round(ringSize[0] / 2), Math.round(ringSize[1] / 2)];
 
         const shape = styleForJob(job).shape || 'circle';
         const pulseSvg = buildPulseRingSvg(shape, ringSize[0], ringSize[1]);
@@ -227,6 +300,63 @@ function upsertPulseRing(layerGroup, job, marker) {
     }
 }
 
+/**
+ * Active jobs get a magenta "marching ring" — a sibling non-interactive marker
+ * on jobStatusRingLayer, following the main marker, sized to the real shape.
+ * Same lifecycle model as the pulse ring.  Callers gate on the config option.
+ */
+function upsertStatusRing(layerGroup, job, marker) {
+    if (!layerGroup) return;
+    const want = statusHasRing(job.statusName?.());
+
+    if (want && !marker._statusRing) {
+        const base = marker.options.icon?.options || {};
+        const iconSize = base.iconSize || [14, 14];
+        const shapeD = base.shapeDiameter || Math.min(iconSize[0], iconSize[1]);
+        const ringR = shapeD / 2 + 4;                 // clear of the shape edge
+        const size = Math.ceil((ringR + 3) * 2);
+        const anchor = [Math.round(size / 2), Math.round(size / 2)];
+
+        const ring = L.marker(marker.getLatLng(), {
+            pane: 'pane-tippy-top',
+            icon: L.divIcon({
+                className: 'status-ring-icon',
+                html: buildStatusRingSvg(size, ringR),
+                iconSize: [size, size],
+                iconAnchor: anchor
+            }),
+            interactive: false,
+            keyboard: false
+        });
+
+        const follow = () => ring.setLatLng(marker.getLatLng());
+        marker.on('move', follow);
+        ring._detach = () => marker.off('move', follow);
+
+        // Sit behind the marker so the shape and the "!" pip always win their
+        // pixels — the ring is a background accent, not an overlay.
+        ring.setZIndexOffset((marker.options?.zIndexOffset || 0) - 100);
+        ring.addTo(layerGroup);
+        marker._statusRing = ring;
+    }
+
+    if (!want && marker._statusRing) {
+        marker._statusRing._detach?.();
+        layerGroup.removeLayer(marker._statusRing);
+        marker._statusRing = null;
+    }
+}
+
+/** Tear down and (if still wanted) rebuild the status ring against the current icon. */
+function rebuildStatusRing(layerGroup, job, marker) {
+    if (marker._statusRing && layerGroup) {
+        marker._statusRing._detach?.();
+        layerGroup.removeLayer(marker._statusRing);
+        marker._statusRing = null;
+    }
+    upsertStatusRing(layerGroup, job, marker);
+}
+
 // --- internals ---
 
 /**
@@ -235,7 +365,8 @@ function upsertPulseRing(layerGroup, job, marker) {
  * reassignment + cluster refresh as needed.
  */
 function syncMarkerStyle(marker, job, vm, pulseLayer) {
-    const newStyle = styleForJob(job);
+    const showStatus = !!vm.config?.showJobStatusOnMarkers?.();
+    const newStyle = styleForJob(job, { showStatus });
     const newKey = JSON.stringify(newStyle);
 
     // Update icon if the visual style actually changed
@@ -244,6 +375,15 @@ function syncMarkerStyle(marker, job, vm, pulseLayer) {
         marker._styleKey = newKey;
     }
     marker._priorityColor = newStyle.fill || '#6b7280';
+
+    // Active marching ring — rebuild against the (possibly resized) icon
+    if (showStatus) {
+        rebuildStatusRing(vm.mapVM.jobStatusRingLayer, job, marker);
+    } else if (marker._statusRing) {
+        marker._statusRing._detach?.();
+        vm.mapVM.jobStatusRingLayer?.removeLayer(marker._statusRing);
+        marker._statusRing = null;
+    }
 
     // Check whether rescue status flipped
     const wasRescue = marker._isRescue;

--- a/src/pages/tasking/utils/jobTypesToUI.js
+++ b/src/pages/tasking/utils/jobTypesToUI.js
@@ -20,6 +20,30 @@ export function jobsToUI(job) {
     return result;
 }
 
+// ── Status on markers (config.showJobStatusOnMarkers) ─────────────────────
+// New       → orange pulse ring (existing, unchanged)
+// Active    → magenta marching ring (drawn as a spinning dashed <g>)
+// Tasked    → nothing (a job someone is on shouldn't compete for attention)
+// Complete / Referred / Finalised → struck through  "/"
+// Cancelled / Rejected            → crossed out      "✕"
+// Any status with an action-required tag → red "!" pip, NE corner
+export const ACTIVE_RING_COLOUR = "#e5399b"; // magenta — clear of orange + priority fills
+
+const CLOSED_RESOLVED = new Set(["Complete", "Referred", "Finalised"]);
+const CLOSED_DEAD = new Set(["Cancelled", "Rejected"]);
+
+// "strike" (resolved) | "cross" (dead) | null
+export function statusClosedMark(statusName) {
+    if (CLOSED_RESOLVED.has(statusName)) return "strike";
+    if (CLOSED_DEAD.has(statusName)) return "cross";
+    return null;
+}
+
+// Does this status get the marching ring?
+export function statusHasRing(statusName) {
+    return statusName === "Active";
+}
+
 // Priority → stroke color
 const priorityStroke = {
     "Priority": "#FFA500",  // goldy yellow

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1216,6 +1216,11 @@ export function ConfigVM(root, deps) {
     self.alertsCollapsibleRules = ko.observable(true);
     self.taskingCountActiveOnly = ko.observable(false);
 
+    // On/Off pill labels for the Appearance pane switches
+    self.darkModeLabel = ko.pureComputed(() => (self.darkMode() ? 'On' : 'Off'));
+    self.alertsCollapseLabel = ko.pureComputed(() => (self.alertsCollapsibleRules() ? 'On' : 'Off'));
+    self.taskingCountLabel = ko.pureComputed(() => (self.taskingCountActiveOnly() ? 'On' : 'Off'));
+
     // pinned rows
     self.pinnedTeamIds = ko.observableArray([]);
     self.pinnedIncidentIds = ko.observableArray([]);

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1231,6 +1231,7 @@ export function ConfigVM(root, deps) {
     self.clusterEnabled = ko.observable(true);
     self.clusterRadius = ko.observable(60);   // maxClusterRadius in px (10–80)
     self.clusterRescueJobs = ko.observable(true);
+    self.showJobStatusOnMarkers = ko.observable(true);
     self.alertsCollapsibleRules = ko.observable(true);
     self.taskingCountActiveOnly = ko.observable(false);
 
@@ -1378,6 +1379,7 @@ export function ConfigVM(root, deps) {
         clusterEnabled: !!self.clusterEnabled(),
         clusterRadius: Number(self.clusterRadius()) || 60,
         clusterRescueJobs: !!self.clusterRescueJobs(),
+        showJobStatusOnMarkers: !!self.showJobStatusOnMarkers(),
         alertsCollapsibleRules: !!self.alertsCollapsibleRules(),
         taskingCountActiveOnly: !!self.taskingCountActiveOnly(),
         suggestionEnabled: !!self.suggestionEnabled(),
@@ -1708,6 +1710,9 @@ export function ConfigVM(root, deps) {
         if (typeof cfg.clusterRescueJobs === 'boolean') {
             self.clusterRescueJobs(cfg.clusterRescueJobs);
         }
+        if (typeof cfg.showJobStatusOnMarkers === 'boolean') {
+            self.showJobStatusOnMarkers(cfg.showJobStatusOnMarkers);
+        }
         if (typeof cfg.alertsCollapsibleRules === 'boolean') {
             self.alertsCollapsibleRules(cfg.alertsCollapsibleRules);
         }
@@ -1853,6 +1858,7 @@ export function ConfigVM(root, deps) {
         root.mapVM?.applyPaneOrder?.(self.paneOrder().map(p => p.id));
         root.mapVM?.applyClusterRadius?.(Number(self.clusterRadius()) || 60);
         root.mapVM?.applyClusterEnabled?.(!!self.clusterEnabled());
+        root.mapVM?.applyJobStatusOnMarkers?.(!!self.showJobStatusOnMarkers());
         applyLayoutPresetClass(normalizeLayoutPreset(self.layoutPreset()));
         // Apply dark mode
         self._applyDarkMode();
@@ -1901,6 +1907,11 @@ export function ConfigVM(root, deps) {
 
     self.clusterRescueJobs.subscribe((v) => {
         root.mapVM?.applyRescueClusterSetting?.(!!v);
+        self.save();
+    })
+
+    self.showJobStatusOnMarkers.subscribe((v) => {
+        root.mapVM?.applyJobStatusOnMarkers?.(!!v);
         self.save();
     })
 

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1103,6 +1103,36 @@ export function ConfigVM(root, deps) {
         return `every ${Math.round(s / 60)} min`;
     });
     self.liveUpdatesLabel = ko.pureComputed(() => (self.signalrEnabled() ? 'On' : 'Off'));
+
+    // Data pane -- one-tap presets for the values these are actually set to.
+    // The number field beside each row stays as the escape hatch for odd
+    // values; an off-preset value simply leaves no preset highlighted.
+    self.refreshPresets = [
+        { value: 30, label: '30s' },
+        { value: 60, label: '1 min' },
+        { value: 120, label: '2 min' },
+        { value: 180, label: '3 min' },
+        { value: 300, label: '5 min' },
+        { value: 600, label: '10 min' }
+    ];
+    self.historyPresets = [
+        { value: 0, label: 'Today' },
+        { value: 1, label: '1 day' },
+        { value: 3, label: '3 days' },
+        { value: 7, label: '1 week' },
+        { value: 14, label: '2 weeks' },
+        { value: 31, label: '1 month' }
+    ];
+    self.lookaheadPresets = [
+        { value: 0, label: 'None' },
+        { value: 1, label: '1 day' },
+        { value: 3, label: '3 days' },
+        { value: 7, label: '1 week' }
+    ];
+    self.pickRefreshPreset = (p) => self.refreshInterval(p.value);
+    self.pickHistoryPreset = (p) => self.fetchPeriod(p.value);
+    self.pickLookaheadPreset = (p) => self.fetchForward(p.value);
+
     self.showAdvanced = ko.observable(false);
     self.darkMode = ko.observable(false);
 

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -411,7 +411,10 @@ export function ConfigVM(root, deps) {
     // Other settings
     self.signalrEnabled = ko.observable(true);
     self.refreshInterval = ko.observable(180);
-    // Guard for reckless refresh interval changes
+    // Guard for an aggressively short full-refresh interval. Slower is always
+    // safe, so only prompt when the new value drops below this many seconds --
+    // that's where every open copy of LAD starts hammering Beacon.
+    const REFRESH_GATE_SECONDS = 60;
     let lastRefreshInterval = self.refreshInterval();
     let suppressRecklessModal = false;
     self.refreshInterval.subscribe(function(newVal) {
@@ -419,9 +422,9 @@ export function ConfigVM(root, deps) {
             lastRefreshInterval = newVal;
             return;
         }
-        // Only trigger if the value is being changed to something different
-        if (Number(newVal) !== Number(lastRefreshInterval)) {
-            showRecklessModal({
+        const n = Number(newVal);
+        if (Number.isFinite(n) && n < REFRESH_GATE_SECONDS && n !== Number(lastRefreshInterval)) {
+            showShortRefreshModal(n, {
                 onConfirm: () => {
                     lastRefreshInterval = newVal;
                 },
@@ -432,60 +435,65 @@ export function ConfigVM(root, deps) {
                     suppressRecklessModal = false;
                 }
             });
+        } else {
+            lastRefreshInterval = newVal;
         }
     });
 
-    // Modal logic for reckless confirmation
-    function showRecklessModal({ onConfirm, onCancel }) {
-        // Create modal HTML if not present
-        let modal = document.getElementById('recklessModal');
+    // Confirm dialog for a very short full-refresh interval.
+    function showShortRefreshModal(seconds, { onConfirm, onCancel }) {
+        let modal = document.getElementById('shortRefreshModal');
         if (!modal) {
             modal = document.createElement('div');
-            modal.id = 'recklessModal';
+            modal.id = 'shortRefreshModal';
             modal.className = 'modal fade';
             modal.tabIndex = -1;
             modal.innerHTML = `
                 <div class="modal-dialog modal-dialog-centered">
                   <div class="modal-content">
-                    <div class="modal-header bg-danger text-white">
-                      <h5 class="modal-title">Are you sure?</h5>
+                    <div class="modal-header bg-warning text-dark">
+                      <h5 class="modal-title" id="shortRefreshTitle"></h5>
                       <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                      <p>Changing the refresh interval can have unintended consequences. To proceed, type <b>reckless</b> below and press Confirm.</p>
-                      <input id="recklessInput" type="text" class="form-control" placeholder="Type 'reckless' to confirm">
-                      <div id="recklessError" class="text-danger mt-2" style="display:none;">You must type 'reckless' to confirm.</div>
+                      <p>This will re-query <b>every</b> incident, team and tasking in your window from Beacon, on your machine, this often. Each sweep is a heavy set of calls and the board churns while it runs.</p>
+                      <p class="mb-3">Live updates already keep your board current between sweeps &mdash; you rarely need the full refresh this frequent.</p>
+                      <label class="form-label mb-1" for="shortRefreshInput">Type <b id="shortRefreshNum"></b> to confirm.</label>
+                      <input id="shortRefreshInput" type="text" class="form-control" autocomplete="off" inputmode="numeric">
+                      <div id="shortRefreshError" class="text-danger small mt-2" style="display:none;"></div>
                     </div>
                     <div class="modal-footer">
-                      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="recklessCancel">Cancel</button>
-                      <button type="button" class="btn btn-danger" id="recklessConfirm">Confirm</button>
+                      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="shortRefreshCancel">Keep previous</button>
+                      <button type="button" class="btn btn-warning" id="shortRefreshConfirm">Use this interval</button>
                     </div>
                   </div>
                 </div>
             `;
             document.body.appendChild(modal);
         }
+        modal.querySelector('#shortRefreshTitle').textContent = `Full refresh every ${seconds} seconds?`;
+        modal.querySelector('#shortRefreshNum').textContent = String(seconds);
+
         const bsModal = bootstrap.Modal.getOrCreateInstance(modal);
         bsModal.show();
 
-        // Reset input and error
-        const input = modal.querySelector('#recklessInput');
-        const error = modal.querySelector('#recklessError');
+        const input = modal.querySelector('#shortRefreshInput');
+        const error = modal.querySelector('#shortRefreshError');
         input.value = '';
         error.style.display = 'none';
         input.focus();
 
-        // Remove previous listeners
-        const confirmBtn = modal.querySelector('#recklessConfirm');
-        const cancelBtn = modal.querySelector('#recklessCancel');
+        const confirmBtn = modal.querySelector('#shortRefreshConfirm');
+        const cancelBtn = modal.querySelector('#shortRefreshCancel');
         confirmBtn.onclick = null;
         cancelBtn.onclick = null;
 
         confirmBtn.onclick = function() {
-            if (input.value.trim().toLowerCase() === 'reckless') {
+            if (input.value.trim() === String(seconds)) {
                 bsModal.hide();
                 onConfirm && onConfirm();
             } else {
+                error.textContent = `Type ${seconds} to confirm.`;
                 error.style.display = '';
                 input.focus();
             }
@@ -494,7 +502,6 @@ export function ConfigVM(root, deps) {
             bsModal.hide();
             onCancel && onCancel();
         };
-        // Also handle modal close (X button)
         modal.querySelector('.btn-close').onclick = function() {
             bsModal.hide();
             onCancel && onCancel();
@@ -1103,6 +1110,17 @@ export function ConfigVM(root, deps) {
         return `every ${Math.round(s / 60)} min`;
     });
     self.liveUpdatesLabel = ko.pureComputed(() => (self.signalrEnabled() ? 'On' : 'Off'));
+
+    // The full refresh means different things depending on whether live updates
+    // are carrying the load -- spell it out so nobody sets it wrong.
+    self.fullRefreshHint = ko.pureComputed(() => (self.signalrEnabled()
+        ? 'A full reload from Beacon. With live updates on it is only a backstop — every 3–5 min is plenty.'
+        : 'A full reload from Beacon. With live updates off this is the only thing refreshing the board — keep it short, 1–2 min.'
+    ));
+    self.dataReadoutNote = ko.pureComputed(() => (self.signalrEnabled()
+        ? 'Live updates keep the board current; the full refresh is a backstop.'
+        : 'No live updates — the board is only as fresh as the full refresh.'
+    ));
 
     // Data pane -- one-tap presets for the values these are actually set to.
     // The number field beside each row stays as the escape hatch for odd

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1077,6 +1077,32 @@ export function ConfigVM(root, deps) {
 
     self.fetchPeriod = ko.observable(7).extend({ min: 0, max: 31, digit: true });
     self.fetchForward = ko.observable(0).extend({ min: 0, max: 31, digit: true });
+
+    // Human-readable summary of what the Data pane's knobs currently resolve
+    // to -- shown alongside the inputs so an operator can sanity-check the
+    // window they're actually loading.
+    const _fmtWindowDate = (d) => d.toLocaleDateString('en-AU', {
+        weekday: 'short', day: 'numeric', month: 'short'
+    });
+    self.fetchWindowRange = ko.pureComputed(() => {
+        const back = Math.max(0, Number(self.fetchPeriod()) || 0);
+        const fwd = Math.max(0, Number(self.fetchForward()) || 0);
+        const now = new Date();
+        const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - back);
+        const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + fwd);
+        return `${_fmtWindowDate(start)} → ${_fmtWindowDate(end)}`;
+    });
+    self.fetchWindowDays = ko.pureComputed(() => {
+        const back = Math.max(0, Number(self.fetchPeriod()) || 0);
+        const fwd = Math.max(0, Number(self.fetchForward()) || 0);
+        return back + fwd + 1;
+    });
+    self.refreshCadence = ko.pureComputed(() => {
+        const s = Math.max(0, Number(self.refreshInterval()) || 0);
+        if (s < 90) return `every ${s} sec`;
+        return `every ${Math.round(s / 60)} min`;
+    });
+    self.liveUpdatesLabel = ko.pureComputed(() => (self.signalrEnabled() ? 'On' : 'Off'));
     self.showAdvanced = ko.observable(false);
     self.darkMode = ko.observable(false);
 

--- a/src/pages/tasking/viewmodels/Map.js
+++ b/src/pages/tasking/viewmodels/Map.js
@@ -5,6 +5,7 @@ import 'leaflet.markercluster';
 
 import { AssetPopupViewModel } from './AssetPopUp';
 import { JobPopupViewModel } from './JobPopUp';
+import { restyleAllJobMarkers } from '../markers/jobMarker.js';
 
 export function MapVM(Lmap, root) {
   const self = this;
@@ -240,8 +241,11 @@ export function MapVM(Lmap, root) {
   // Track whether clustering is currently active
   self.clusteringEnabled = true;
 
-  // Separate plain layer for pulse rings – not clustered
+  // Separate plain layers for the pulse ring (New) and the marching ring
+  // (Active) – not clustered, follow their marker, visibility kept in sync
+  // by _syncPulseRings.
   self.jobPulseLayer = L.layerGroup().addTo(self.map);
+  self.jobStatusRingLayer = L.layerGroup().addTo(self.map);
 
   // id → marker lookup (flat, no per-type groups)
   self.jobMarkerIndex = new Map();
@@ -279,6 +283,19 @@ export function MapVM(Lmap, root) {
       }
     });
     self._syncPulseRings();
+  };
+
+  /**
+   * Re-render all job marker icons — called when the "show status on markers"
+   * config option is toggled.
+   */
+  self.applyJobStatusOnMarkers = function (on) {
+    // `on` is passed explicitly by Config (root.config isn't wired yet when
+    // this first runs from afterConfigLoad); fall back to reading it live.
+    const enabled = (on === undefined) ? !!root.config?.showJobStatusOnMarkers?.() : !!on;
+    document.querySelectorAll('.legend-status-block')
+      .forEach((el) => el.classList.toggle('d-none', !enabled));
+    restyleAllJobMarkers(root);
   };
 
   /**
@@ -991,52 +1008,36 @@ export function MapVM(Lmap, root) {
     self.clearJobAssetBullseye();
   };
 
-  // Pulse ring visibility management for clustering
-  // When markers get clustered, hide their pulse rings.
-  // When unclustered or spiderfied, show them again.
+  // Ring visibility management for clustering.  The pulse ring (New) and the
+  // marching ring (Active) are only shown while their marker is individually
+  // visible — hidden while it's inside a cluster, shown again on spiderfy /
+  // unclustered / zoom-in.  Both rings follow the same rule.
   self._syncPulseRings = function () {
+    const setVisible = (ring, layer, visible) => {
+      if (!ring) return;
+      const has = layer.hasLayer(ring);
+      if (visible && !has) layer.addLayer(ring);
+      else if (!visible && has) layer.removeLayer(ring);
+    };
+
     self.jobMarkerIndex.forEach((marker) => {
-      if (!marker._pulseRing) return;
+      if (!marker._pulseRing && !marker._statusRing) return;
 
-      // Markers on the standalone rescue layer (not in the cluster group)
-      // are always individually visible – skip cluster logic for them.
+      let visible;
       if (self.rescueJobLayer.hasLayer(marker)) {
-        if (!self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.addLayer(marker._pulseRing);
-        }
-        return;
-      }
-
-      // When clustering is disabled, all markers are individually visible.
-      if (!self.clusteringEnabled || self.unclusteredJobLayer.hasLayer(marker)) {
-        if (!self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.addLayer(marker._pulseRing);
-        }
-        return;
-      }
-
-      let visibleParent;
-      try {
-        visibleParent = self.jobClusterGroup.getVisibleParent(marker);
-      } catch (err) {
-        // On error, hide the pulse ring to be safe
-        if (self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.removeLayer(marker._pulseRing);
-        }
-        return;
-      }
-
-      if (visibleParent === marker) {
-        // Marker is individually visible – show pulse ring
-        if (!self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.addLayer(marker._pulseRing);
-        }
+        visible = true;
+      } else if (!self.clusteringEnabled || self.unclusteredJobLayer.hasLayer(marker)) {
+        visible = true;
       } else {
-        // Marker is inside a cluster – hide pulse ring
-        if (self.jobPulseLayer.hasLayer(marker._pulseRing)) {
-          self.jobPulseLayer.removeLayer(marker._pulseRing);
+        try {
+          visible = self.jobClusterGroup.getVisibleParent(marker) === marker;
+        } catch (err) {
+          visible = false; // on error, hide to be safe
         }
       }
+
+      setVisible(marker._pulseRing, self.jobPulseLayer, visible);
+      setVisible(marker._statusRing, self.jobStatusRingLayer, visible);
     });
   };
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2074,26 +2074,44 @@
                     <!-- CONFIG -->
                     <!-- CONFIG -->
                     <div class="card config-card mt-3">
-
                         <div class="card-body">
                             <form id="configForm">
-                                <div class="accordion" id="configOtherSettingsAccordion">
-
-                                    <!-- General -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingGeneral">
-                                            <button class="accordion-button d-flex align-items-center gap-2 fw-semibold" type="button" data-bs-toggle="collapse"
-                                                data-bs-target="#collapseGeneral" aria-expanded="true"
-                                                aria-controls="collapseGeneral">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-cogs"></i></span>
-                                                <span>General Settings</span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapseGeneral" class="accordion-collapse collapse show"
-                                            aria-labelledby="headingGeneral"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
-                                                <div class="row g-3">
+                                <div class="config-settings">
+                                    <ul class="nav nav-pills config-rail flex-column" role="tablist" aria-orientation="vertical">
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link active" id="cfgTab-data" data-bs-toggle="pill" data-bs-target="#cfgPane-data" type="button" role="tab" aria-controls="cfgPane-data" aria-selected="true">
+                                            <span class="cfg-rail-ico"><i class="fa fa-database"></i></span><span>Data</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-filters" data-bs-toggle="pill" data-bs-target="#cfgPane-filters" type="button" role="tab" aria-controls="cfgPane-filters" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-filter"></i></span><span>Filters</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-map" data-bs-toggle="pill" data-bs-target="#cfgPane-map" type="button" role="tab" aria-controls="cfgPane-map" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-layer-group"></i></span><span>Map</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-sidebar" data-bs-toggle="pill" data-bs-target="#cfgPane-sidebar" type="button" role="tab" aria-controls="cfgPane-sidebar" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-table-columns"></i></span><span>Sidebar</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-appearance" data-bs-toggle="pill" data-bs-target="#cfgPane-appearance" type="button" role="tab" aria-controls="cfgPane-appearance" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-sliders"></i></span><span>Appearance</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-suggest" data-bs-toggle="pill" data-bs-target="#cfgPane-suggest" type="button" role="tab" aria-controls="cfgPane-suggest" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-robot"></i></span><span>Instant Task Suggestions</span>
+                                        </button>
+                                    </li>
+                                    </ul>
+                                    <div class="tab-content config-panes">
+                                    <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
+                                        <div class="row g-3">
                                                     <div class="col-sm-6 col-md-3">
                                                         <label for="refreshInterval" class="form-label">
                                                             <i class="fa fa-sync-alt me-1"></i>Refresh interval
@@ -2137,19 +2155,6 @@
                                                     </div>
                                                     <div class="col-sm-6 col-md-3">
                                                         <label class="form-label">
-                                                            <i class="fa fa-moon me-1"></i>Dark Mode
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="darkModeToggle"
-                                                                data-bind="checked: config.darkMode">
-                                                            <label class="form-check-label" for="darkModeToggle">
-                                                                Enable dark mode
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Reduces eye strain in low light environments.</div>
-                                                    </div>
-                                                    <div class="col-sm-6 col-md-3">
-                                                        <label class="form-label">
                                                             <i class="fa fa-bolt me-1"></i>Live Updates
                                                         </label>
                                                         <div class="form-check form-switch mt-2">
@@ -2161,91 +2166,18 @@
                                                         </div>
                                                         <div class="form-text">Receive instant incident, team and tasking updates. If enabling or disabling, restart LAD after saving.</div>
                                                     </div>                                                    
-                                                    <div class="col-sm-6 col-md-3">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-bell me-1"></i>Alerts Panel
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="alertsCollapsibleRulesToggle"
-                                                                data-bind="checked: config.alertsCollapsibleRules">
-                                                            <label class="form-check-label" for="alertsCollapsibleRulesToggle">
-                                                                Auto collapse alert popups
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Alerts will start collapsed.</div>
-                                                    </div>
-                                                    <div class="col-sm-6 col-md-3">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-hashtag me-1"></i>Incident Tasking Count
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="taskingCountActiveOnlyToggle"
-                                                                data-bind="checked: config.taskingCountActiveOnly">
-                                                            <label class="form-check-label" for="taskingCountActiveOnlyToggle">
-                                                                Count Active taskings only
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Tasking count counts only Tasked, Enroute &amp; Onsite taskings (excludes Complete, CalledOff, Untasked).</div>
-                                                    </div>
-                                                </div>
-                                            </div>
                                         </div>
                                     </div>
-
-                                    <!-- Panel Layout -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingPanelLayout">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapsePanelLayout"
-                                                aria-expanded="false" aria-controls="collapsePanelLayout">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-columns"></i></span>
-                                                <span>Panel Layout</span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapsePanelLayout" class="accordion-collapse collapse"
-                                            aria-labelledby="headingPanelLayout"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
-                                                <label class="form-label">
-                                                    <i class="fa fa-columns me-1"></i>Section Layout Preset
-                                                </label>
-                                                <div class="layout-preset-grid"
-                                                    data-bind="foreach: { data: config.layoutPresetDefs, as: 'preset' }">
-                                                    <label class="layout-preset-card"
-                                                        data-bind="css: { 'is-active': $root.config.layoutPreset() === preset.id }">
-                                                        <input class="form-check-input layout-preset-radio"
-                                                            type="radio" name="layoutPreset"
-                                                            data-bind="checked: $root.config.layoutPreset, checkedValue: preset.id">
-                                                        <div class="layout-preset-preview"
-                                                            data-bind="css: preset.previewClass">
-                                                            <div class="preview-block preview-block--teams">Teams</div>
-                                                            <div class="preview-block preview-block--tasking">Tasking</div>
-                                                            <div class="preview-block preview-block--map">Map</div>
-                                                        </div>
-                                                        <div class="layout-preset-name" data-bind="text: preset.name"></div>
-                                                        <div class="layout-preset-description small text-muted"
-                                                            data-bind="text: preset.description"></div>
-                                                    </label>
-                                                </div>
-                                                <div class="form-text">Pick a layout to instantly preview and apply section placement.</div>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <!-- Incident Status -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingIncidentStatus">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseIncidentStatus"
-                                                aria-expanded="false" aria-controls="collapseIncidentStatus">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-filter"></i></span>
-                                                <span>Incident Filters</span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapseIncidentStatus" class="accordion-collapse collapse"
-                                            aria-labelledby="headingIncidentStatus"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
+                                    <div class="tab-pane fade" id="cfgPane-filters" role="tabpanel" aria-labelledby="cfgTab-filters" tabindex="0">
+                                        <div class="accordion config-subaccordion" id="cfgFiltersAcc">
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-incidents" aria-expanded="true" aria-controls="cfgSub-incidents">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-fire"></i></span><span>Incidents</span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-incidents" class="accordion-collapse collapse show" data-bs-parent="#cfgFiltersAcc">
+                                                <div class="accordion-body">
                                                 <div class="row g-3">
                                                     <div class="col-md-6">
                                                         <label class="form-label d-block mb-2">Show Incidents With
@@ -2490,24 +2422,17 @@
                                                         </div>
                                                     </div>
                                                 </div>
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-
-                                    <!-- Team Status & Tasking -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingTeamStatus">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseTeamStatus"
-                                                aria-expanded="false" aria-controls="collapseTeamStatus">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-users"></i></span>
-                                                <span>Team &amp; Tasking Filters</span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapseTeamStatus" class="accordion-collapse collapse"
-                                            aria-labelledby="headingTeamStatus"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-teams" aria-expanded="false" aria-controls="cfgSub-teams">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-users"></i></span><span>Teams</span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-teams" class="accordion-collapse collapse" data-bs-parent="#cfgFiltersAcc">
+                                                <div class="accordion-body">
                                                 <div class="row g-3">
                                                     <div class="col-md-6 col-lg-4">
                                                         <label class="form-label d-block mb-2">Show Teams With
@@ -2644,26 +2569,17 @@
                                                         </div>
                                                     </div>
                                                 </div> <!-- /row -->
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <!-- Sectors -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingSectors">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseSectors"
-                                                aria-expanded="false" aria-controls="collapseSectors">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-th-large"></i></span>
-                                                <span>Sectors</span>
-                                                <span class="spinner-border spinner-border-sm text-muted mx-2"
-                                                    role="status" data-bind="visible: sectorsLoading"></span>
-                                            </button>
-                                        </h2>
-                                        <div id="collapseSectors" class="accordion-collapse collapse"
-                                            aria-labelledby="headingSectors"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-
-                                            <div class="accordion-body">
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-sectors" aria-expanded="false" aria-controls="cfgSub-sectors">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-th-large"></i></span><span>Sectors</span><span class="spinner-border spinner-border-sm text-muted mx-2" role="status" data-bind="visible: sectorsLoading"></span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-sectors" class="accordion-collapse collapse" data-bs-parent="#cfgFiltersAcc">
+                                                <div class="accordion-body">
 
                                                 <div class="mb-3">
                                                     <label class="form-label d-block mb-1 fw-semibold">Apply sector filters to:</label>
@@ -2727,100 +2643,21 @@
                                                         No sectors loaded for current incident filters.
                                                     </div>
                                                 </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <!-- Starred Teams & Incidents -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingPinned">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapsePinned"
-                                                aria-expanded="false" aria-controls="collapsePinned">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-star"></i></span>
-                                                <span>Starred Teams &amp; Incidents</span>
-                                            </button>
-                                        </h2>
-
-                                        <div id="collapsePinned" class="accordion-collapse collapse"
-                                            aria-labelledby="headingPinned"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
-                                                <div
-                                                    class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
-                                                    <div class="small text-muted">
-                                                        Starred teams: <span class="badge bg-primary"
-                                                            data-bind="text: config.pinnedTeamIds().length"></span>
-                                                        &nbsp;•&nbsp;
-                                                        Starred incidents: <span class="badge bg-success"
-                                                            data-bind="text: config.pinnedIncidentIds().length"></span>
-                                                    </div>
-
-                                                    <button type="button" class="btn btn-sm btn-outline-danger"
-                                                        data-bind="click: config.clearAllPinned, enable: (config.pinnedTeamIds().length + config.pinnedIncidentIds().length) > 0">
-                                                        Clear all Starred
-                                                    </button>
-                                                </div>
-
-                                                <div class="row g-2">
-                                                    <div class="col-12 col-md-6">
-                                                        <div class="border rounded p-2">
-                                                            <div
-                                                                class="d-flex align-items-center justify-content-between">
-                                                                <div class="fw-semibold small">Starred Teams</div>
-                                                                <div class="d-flex align-items-center gap-2">
-                                                                    <span class="badge bg-primary"
-                                                                        data-bind="text: config.pinnedTeamIds().length"></span>
-                                                                    <button type="button"
-                                                                        class="btn btn-sm btn-outline-secondary"
-                                                                        data-bind="click: config.clearPinnedTeams, enable: config.pinnedTeamIds().length > 0">
-                                                                        Clear
-                                                                    </button>
-                                                                </div>
-                                                            </div>
-
-                                                        </div>
-                                                    </div>
-
-                                                    <div class="col-12 col-md-6">
-                                                        <div class="border rounded p-2">
-                                                            <div
-                                                                class="d-flex align-items-center justify-content-between">
-                                                                <div class="fw-semibold small">Starred Incidents</div>
-                                                                <div class="d-flex align-items-center gap-2">
-                                                                    <span class="badge bg-success"
-                                                                        data-bind="text: config.pinnedIncidentIds().length"></span>
-                                                                    <button type="button"
-                                                                        class="btn btn-sm btn-outline-secondary"
-                                                                        data-bind="click: config.clearPinnedIncidents, enable: config.pinnedIncidentIds().length > 0">
-                                                                        Clear
-                                                                    </button>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
+                                        </div>
                                     </div>
-                                    <!-- Map Layers -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingMapLayers">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseMapLayers"
-                                                aria-expanded="false" aria-controls="collapseMapLayers">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-layer-group"></i></span>
-                                                <span>Map Layers</span>
-                                            </button>
-                                        </h2>
-
-                                        <div id="collapseMapLayers" class="accordion-collapse collapse"
-                                            aria-labelledby="headingMapLayers"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
-
-                                                <h6 class="fw-semibold mb-2">
-                                                    <i class="fa fa-sliders me-1"></i>Display Settings
-                                                </h6>
+                                    <div class="tab-pane fade" id="cfgPane-map" role="tabpanel" aria-labelledby="cfgTab-map" tabindex="0">
+                                        <div class="accordion config-subaccordion" id="cfgMapAcc">
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-markers" aria-expanded="true" aria-controls="cfgSub-markers">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-map-marker-alt"></i></span><span>Incident markers</span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-markers" class="accordion-collapse collapse show" data-bs-parent="#cfgMapAcc">
+                                                <div class="accordion-body">
                                                 <div class="row g-3">
 
                                                     <!-- Clustering options -->
@@ -2907,9 +2744,17 @@
                                                     </div>
 
                                                 </div>
-
-                                                <hr class="my-4">
-
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="accordion-item">
+                                            <h2 class="accordion-header">
+                                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-collab" aria-expanded="false" aria-controls="cfgSub-collab">
+                                                    <span class="cfg-sub-ico"><i class="fa fa-users"></i></span><span>Collaborative layers</span>
+                                                </button>
+                                            </h2>
+                                            <div id="cfgSub-collab" class="accordion-collapse collapse" data-bs-parent="#cfgMapAcc">
+                                                <div class="accordion-body">
                                                 <div class="d-flex align-items-center justify-content-between mb-2">
                                                     <h6 class="fw-semibold mb-0">
                                                         <i class="fa fa-users me-1"></i>Collaborative Layers
@@ -3325,25 +3170,135 @@
                                                 <div class="form-text mt-2" data-bind="visible: config.noSearchMatchMessage, text: config.noSearchMatchMessage">
                                                 </div>
 
+                                                </div>
                                             </div>
                                         </div>
+                                        </div>
                                     </div>
+                                    <div class="tab-pane fade" id="cfgPane-sidebar" role="tabpanel" aria-labelledby="cfgTab-sidebar" tabindex="0">
+                                                <label class="form-label">
+                                                    <i class="fa fa-columns me-1"></i>Section Layout Preset
+                                                </label>
+                                                <div class="layout-preset-grid"
+                                                    data-bind="foreach: { data: config.layoutPresetDefs, as: 'preset' }">
+                                                    <label class="layout-preset-card"
+                                                        data-bind="css: { 'is-active': $root.config.layoutPreset() === preset.id }">
+                                                        <input class="form-check-input layout-preset-radio"
+                                                            type="radio" name="layoutPreset"
+                                                            data-bind="checked: $root.config.layoutPreset, checkedValue: preset.id">
+                                                        <div class="layout-preset-preview"
+                                                            data-bind="css: preset.previewClass">
+                                                            <div class="preview-block preview-block--teams">Teams</div>
+                                                            <div class="preview-block preview-block--tasking">Tasking</div>
+                                                            <div class="preview-block preview-block--map">Map</div>
+                                                        </div>
+                                                        <div class="layout-preset-name" data-bind="text: preset.name"></div>
+                                                        <div class="layout-preset-description small text-muted"
+                                                            data-bind="text: preset.description"></div>
+                                                    </label>
+                                                </div>
+                                                <div class="form-text">Pick a layout to instantly preview and apply section placement.</div>
+                                        <hr class="my-4">
+                                        <h6 class="cfg-subhead"><i class="fa fa-star me-2"></i>Starred teams &amp; incidents</h6>
+                                                <div
+                                                    class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+                                                    <div class="small text-muted">
+                                                        Starred teams: <span class="badge bg-primary"
+                                                            data-bind="text: config.pinnedTeamIds().length"></span>
+                                                        &nbsp;•&nbsp;
+                                                        Starred incidents: <span class="badge bg-success"
+                                                            data-bind="text: config.pinnedIncidentIds().length"></span>
+                                                    </div>
 
-                                    <!-- Instant Task Suggestions -->
-                                    <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingSuggestions">
-                                            <button class="accordion-button gap-2 collapsed" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseSuggestions"
-                                                aria-expanded="false" aria-controls="collapseSuggestions">
-                                                <span style="display:inline-block;width:24px;text-align:center;"><i class="fa fa-robot"></i></span>
-                                                <span>Instant Task Suggestions</span>
-                                            </button>
-                                        </h2>
+                                                    <button type="button" class="btn btn-sm btn-outline-danger"
+                                                        data-bind="click: config.clearAllPinned, enable: (config.pinnedTeamIds().length + config.pinnedIncidentIds().length) > 0">
+                                                        Clear all Starred
+                                                    </button>
+                                                </div>
 
-                                        <div id="collapseSuggestions" class="accordion-collapse collapse"
-                                            aria-labelledby="headingSuggestions"
-                                            data-bs-parent="#configOtherSettingsAccordion">
-                                            <div class="accordion-body">
+                                                <div class="row g-2">
+                                                    <div class="col-12 col-md-6">
+                                                        <div class="border rounded p-2">
+                                                            <div
+                                                                class="d-flex align-items-center justify-content-between">
+                                                                <div class="fw-semibold small">Starred Teams</div>
+                                                                <div class="d-flex align-items-center gap-2">
+                                                                    <span class="badge bg-primary"
+                                                                        data-bind="text: config.pinnedTeamIds().length"></span>
+                                                                    <button type="button"
+                                                                        class="btn btn-sm btn-outline-secondary"
+                                                                        data-bind="click: config.clearPinnedTeams, enable: config.pinnedTeamIds().length > 0">
+                                                                        Clear
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="col-12 col-md-6">
+                                                        <div class="border rounded p-2">
+                                                            <div
+                                                                class="d-flex align-items-center justify-content-between">
+                                                                <div class="fw-semibold small">Starred Incidents</div>
+                                                                <div class="d-flex align-items-center gap-2">
+                                                                    <span class="badge bg-success"
+                                                                        data-bind="text: config.pinnedIncidentIds().length"></span>
+                                                                    <button type="button"
+                                                                        class="btn btn-sm btn-outline-secondary"
+                                                                        data-bind="click: config.clearPinnedIncidents, enable: config.pinnedIncidentIds().length > 0">
+                                                                        Clear
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                    </div>
+                                    <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
+                                        <div class="row g-3">
+                                                    <div class="col-sm-6 col-md-3">
+                                                        <label class="form-label">
+                                                            <i class="fa fa-moon me-1"></i>Dark Mode
+                                                        </label>
+                                                        <div class="form-check form-switch mt-2">
+                                                            <input class="form-check-input" type="checkbox" id="darkModeToggle"
+                                                                data-bind="checked: config.darkMode">
+                                                            <label class="form-check-label" for="darkModeToggle">
+                                                                Enable dark mode
+                                                            </label>
+                                                        </div>
+                                                        <div class="form-text">Reduces eye strain in low light environments.</div>
+                                                    </div>
+                                                    <div class="col-sm-6 col-md-3">
+                                                        <label class="form-label">
+                                                            <i class="fa fa-bell me-1"></i>Alerts Panel
+                                                        </label>
+                                                        <div class="form-check form-switch mt-2">
+                                                            <input class="form-check-input" type="checkbox" id="alertsCollapsibleRulesToggle"
+                                                                data-bind="checked: config.alertsCollapsibleRules">
+                                                            <label class="form-check-label" for="alertsCollapsibleRulesToggle">
+                                                                Auto collapse alert popups
+                                                            </label>
+                                                        </div>
+                                                        <div class="form-text">Alerts will start collapsed.</div>
+                                                    </div>
+                                                    <div class="col-sm-6 col-md-3">
+                                                        <label class="form-label">
+                                                            <i class="fa fa-hashtag me-1"></i>Incident Tasking Count
+                                                        </label>
+                                                        <div class="form-check form-switch mt-2">
+                                                            <input class="form-check-input" type="checkbox" id="taskingCountActiveOnlyToggle"
+                                                                data-bind="checked: config.taskingCountActiveOnly">
+                                                            <label class="form-check-label" for="taskingCountActiveOnlyToggle">
+                                                                Count Active taskings only
+                                                            </label>
+                                                        </div>
+                                                        <div class="form-text">Tasking count counts only Tasked, Enroute &amp; Onsite taskings (excludes Complete, CalledOff, Untasked).</div>
+                                                    </div>
+                                        </div>
+                                    </div>
+                                    <div class="tab-pane fade" id="cfgPane-suggest" role="tabpanel" aria-labelledby="cfgTab-suggest" tabindex="0">
 
                                                 <p class="small text-muted mb-3">
                                                     When enabled, the instant-task dropdown will suggest a team using a
@@ -3490,13 +3445,9 @@
                                                     </div><!-- /row -->
                                                 </div><!-- /visible -->
 
-                                            </div>
-                                        </div>
                                     </div>
-
-                                </div><!-- /accordion -->
-
-
+                                    </div>
+                                </div>
                             </form>
                         </div>
                     </div>

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2121,61 +2121,52 @@
                                     </ul>
                                     <div class="tab-content config-panes">
                                     <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
-                                        <div class="row g-3">
-                                                    <div class="col-sm-6 col-md-6">
-                                                        <label for="refreshInterval" class="form-label">
-                                                            <i class="fa fa-sync-alt me-1"></i>Refresh interval
-                                                            (seconds)
-                                                        </label>
-                                                        <div class="input-group">
-                                                            <span class="input-group-text"><i
-                                                                    class="fa fa-clock"></i></span>
-                                                            <input id="refreshInterval" type="number" min="30" step="5"
-                                                                class="form-control"
-                                                                data-bind="value: config.refreshInterval">
-                                                        </div>
-                                                        <div class="form-text">How often to fully refresh data.</div>
+                                        <div class="cfg-rows">
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="refreshInterval">Refresh interval</label>
+                                                    <div class="d">How often LAD fully refreshes all data.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="input-group input-group-sm">
+                                                        <input id="refreshInterval" type="number" min="30" step="5"
+                                                            class="form-control" data-bind="value: config.refreshInterval">
+                                                        <span class="input-group-text">sec</span>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-6">
-                                                        <label for="fetchPeriod" class="form-label">
-                                                            <i class="fa fa-history me-1"></i>Fetch backwards (days)
-                                                        </label>
-                                                        <div class="input-group">
-                                                            <span class="input-group-text"><i
-                                                                    class="fa fa-calendar-minus"></i></span>
-                                                            <input id="fetchPeriod" type="number" min="0" max="31"
-                                                                step="1" class="form-control"
-                                                                data-bind="value: config.fetchPeriod">
-                                                        </div>
-                                                        <div class="form-text">How many days in the past to fetch.</div>
+                                                </div>
+                                            </div>
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="fetchPeriod">Fetch window</label>
+                                                    <div class="d">How far back and forward to load incidents &amp; teams.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="input-group input-group-sm">
+                                                        <input id="fetchPeriod" type="number" min="0" max="31" step="1"
+                                                            class="form-control" aria-label="Fetch backwards (days)"
+                                                            data-bind="value: config.fetchPeriod">
+                                                        <span class="input-group-text">d&nbsp;back</span>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-6">
-                                                        <label for="fetchForward" class="form-label">
-                                                            <i class="fa fa-calendar-plus me-1"></i>Fetch forward (days)
-                                                        </label>
-                                                        <div class="input-group">
-                                                            <span class="input-group-text"><i
-                                                                    class="fa fa-calendar-plus"></i></span>
-                                                            <input id="fetchForward" type="number" min="0" step="1"
-                                                                class="form-control"
-                                                                data-bind="value: config.fetchForward">
-                                                        </div>
-                                                        <div class="form-text">How many days into the future to fetch.
-                                                        </div>
+                                                    <div class="input-group input-group-sm">
+                                                        <input id="fetchForward" type="number" min="0" step="1"
+                                                            class="form-control" aria-label="Fetch forward (days)"
+                                                            data-bind="value: config.fetchForward">
+                                                        <span class="input-group-text">d&nbsp;fwd</span>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-6">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-bolt me-1"></i>Live Updates
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="signalrEnabledToggle"
-                                                                data-bind="checked: config.signalrEnabled">
-                                                            <label class="form-check-label" for="signalrEnabledToggle">
-                                                                Enable SignalR live updates
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Receive instant incident, team and tasking updates. If enabling or disabling, restart LAD after saving.</div>
-                                                    </div>                                                    
+                                                </div>
+                                            </div>
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="signalrEnabledToggle">Live updates</label>
+                                                    <div class="d">Instant incident, team &amp; tasking changes via SignalR. Restart LAD after changing.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="form-check form-switch">
+                                                        <input class="form-check-input" type="checkbox" role="switch"
+                                                            id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
+                                                    </div>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-filters" role="tabpanel" aria-labelledby="cfgTab-filters" tabindex="0">
@@ -3244,46 +3235,43 @@
                                                 </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
-                                        <div class="row g-3">
-                                                    <div class="col-sm-6 col-md-4">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-moon me-1"></i>Dark Mode
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="darkModeToggle"
-                                                                data-bind="checked: config.darkMode">
-                                                            <label class="form-check-label" for="darkModeToggle">
-                                                                Enable dark mode
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Reduces eye strain in low light environments.</div>
+                                        <div class="cfg-rows">
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="darkModeToggle">Dark mode</label>
+                                                    <div class="d">Reduces eye strain in low light environments.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="form-check form-switch">
+                                                        <input class="form-check-input" type="checkbox" role="switch"
+                                                            id="darkModeToggle" data-bind="checked: config.darkMode">
                                                     </div>
-                                                    <div class="col-sm-6 col-md-4">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-bell me-1"></i>Alerts Panel
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="alertsCollapsibleRulesToggle"
-                                                                data-bind="checked: config.alertsCollapsibleRules">
-                                                            <label class="form-check-label" for="alertsCollapsibleRulesToggle">
-                                                                Auto collapse alert popups
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Alerts will start collapsed.</div>
+                                                </div>
+                                            </div>
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="alertsCollapsibleRulesToggle">Auto-collapse alert popups</label>
+                                                    <div class="d">New alerts start collapsed in the Alerts panel.</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="form-check form-switch">
+                                                        <input class="form-check-input" type="checkbox" role="switch"
+                                                            id="alertsCollapsibleRulesToggle" data-bind="checked: config.alertsCollapsibleRules">
                                                     </div>
-                                                    <div class="col-sm-6 col-md-4">
-                                                        <label class="form-label">
-                                                            <i class="fa fa-hashtag me-1"></i>Incident Tasking Count
-                                                        </label>
-                                                        <div class="form-check form-switch mt-2">
-                                                            <input class="form-check-input" type="checkbox" id="taskingCountActiveOnlyToggle"
-                                                                data-bind="checked: config.taskingCountActiveOnly">
-                                                            <label class="form-check-label" for="taskingCountActiveOnlyToggle">
-                                                                Count Active taskings only
-                                                            </label>
-                                                        </div>
-                                                        <div class="form-text">Tasking count counts only Tasked, Enroute &amp; Onsite taskings (excludes Complete, CalledOff, Untasked).</div>
+                                                </div>
+                                            </div>
+                                            <div class="cfg-row">
+                                                <div class="cfg-row-main">
+                                                    <label class="t" for="taskingCountActiveOnlyToggle">Count active taskings only</label>
+                                                    <div class="d">Incident tasking count excludes Complete, CalledOff &amp; Untasked (counts only Tasked, Enroute &amp; Onsite).</div>
+                                                </div>
+                                                <div class="cfg-row-control">
+                                                    <div class="form-check form-switch">
+                                                        <input class="form-check-input" type="checkbox" role="switch"
+                                                            id="taskingCountActiveOnlyToggle" data-bind="checked: config.taskingCountActiveOnly">
                                                     </div>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-suggest" role="tabpanel" aria-labelledby="cfgTab-suggest" tabindex="0">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2140,7 +2140,7 @@
                                                             <span class="input-group-text">sec</span>
                                                         </div>
                                                     </div>
-                                                    <div class="d">Full reload of every incident and team.</div>
+                                                    <div class="d">Automatically perform a full reload of every incident and team.</div>
                                                 </div>
                                                 <div class="cfg-field">
                                                     <label>History &mdash; how far back</label>
@@ -2189,7 +2189,7 @@
                                                             data-bind="text: config.liveUpdatesLabel,
                                                                        css: { on: config.signalrEnabled(), off: !config.signalrEnabled() }"></span>
                                                     </div>
-                                                    <div class="d">Instant incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
+                                                    <div class="d">Instantly update incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
                                                 </div>
                                             </div>
 
@@ -3271,39 +3271,47 @@
                                                 </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
-                                        <div class="cfg-card">
-                                            <div class="cfg-line">
+                                        <div class="cfg-data-fields cfg-fields-solo">
+                                            <div class="cfg-field">
                                                 <label for="darkModeToggle">Dark mode</label>
-                                                <div class="cfg-line-ctl">
+                                                <div class="ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="darkModeToggle" data-bind="checked: config.darkMode">
                                                     </div>
+                                                    <span class="cfg-live-pill"
+                                                        data-bind="text: config.darkModeLabel,
+                                                                   css: { on: config.darkMode(), off: !config.darkMode() }"></span>
                                                 </div>
+                                                <div class="d">Reduces eye strain on overnight LHQ shifts.</div>
                                             </div>
-                                            <div class="cfg-line">
+                                            <div class="cfg-field">
                                                 <label for="alertsCollapsibleRulesToggle">Auto-collapse alert popups</label>
-                                                <div class="cfg-line-ctl">
+                                                <div class="ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="alertsCollapsibleRulesToggle" data-bind="checked: config.alertsCollapsibleRules">
                                                     </div>
+                                                    <span class="cfg-live-pill"
+                                                        data-bind="text: config.alertsCollapseLabel,
+                                                                   css: { on: config.alertsCollapsibleRules(), off: !config.alertsCollapsibleRules() }"></span>
                                                 </div>
+                                                <div class="d">New alerts start collapsed in the Alerts panel.</div>
                                             </div>
-                                            <div class="cfg-line">
+                                            <div class="cfg-field">
                                                 <label for="taskingCountActiveOnlyToggle">Count active taskings only</label>
-                                                <div class="cfg-line-ctl">
+                                                <div class="ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="taskingCountActiveOnlyToggle" data-bind="checked: config.taskingCountActiveOnly">
                                                     </div>
+                                                    <span class="cfg-live-pill"
+                                                        data-bind="text: config.taskingCountLabel,
+                                                                   css: { on: config.taskingCountActiveOnly(), off: !config.taskingCountActiveOnly() }"></span>
                                                 </div>
+                                                <div class="d">Incident tasking count excludes Complete, CalledOff &amp; Untasked.</div>
                                             </div>
                                         </div>
-                                        <p class="cfg-card-note">
-                                            Dark mode reduces eye strain on overnight shifts. &ldquo;Count active taskings
-                                            only&rdquo; excludes Complete, CalledOff &amp; Untasked from the incident tasking count.
-                                        </p>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-suggest" role="tabpanel" aria-labelledby="cfgTab-suggest" tabindex="0">
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2121,13 +2121,10 @@
                                     </ul>
                                     <div class="tab-content config-panes">
                                     <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
-                                        <div class="cfg-rows">
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="refreshInterval">Refresh interval</label>
-                                                    <div class="d">How often LAD fully refreshes all data.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                        <div class="cfg-card">
+                                            <div class="cfg-line">
+                                                <label for="refreshInterval">Refresh interval</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="input-group input-group-sm">
                                                         <input id="refreshInterval" type="number" min="30" step="5"
                                                             class="form-control" data-bind="value: config.refreshInterval">
@@ -2135,32 +2132,26 @@
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="fetchPeriod">Fetch window</label>
-                                                    <div class="d">How far back and forward to load incidents &amp; teams.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                            <div class="cfg-line">
+                                                <label for="fetchPeriod">Fetch window</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="input-group input-group-sm">
                                                         <input id="fetchPeriod" type="number" min="0" max="31" step="1"
                                                             class="form-control" aria-label="Fetch backwards (days)"
                                                             data-bind="value: config.fetchPeriod">
-                                                        <span class="input-group-text">d&nbsp;back</span>
+                                                        <span class="input-group-text">back</span>
                                                     </div>
                                                     <div class="input-group input-group-sm">
                                                         <input id="fetchForward" type="number" min="0" step="1"
                                                             class="form-control" aria-label="Fetch forward (days)"
                                                             data-bind="value: config.fetchForward">
-                                                        <span class="input-group-text">d&nbsp;fwd</span>
+                                                        <span class="input-group-text">fwd</span>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="signalrEnabledToggle">Live updates</label>
-                                                    <div class="d">Instant incident, team &amp; tasking changes via SignalR. Restart LAD after changing.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                            <div class="cfg-line">
+                                                <label for="signalrEnabledToggle">Live updates</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
@@ -2168,6 +2159,10 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <p class="cfg-card-note">
+                                            &ldquo;Refresh interval&rdquo; is the full data-reload cycle. Between reloads,
+                                            live updates keep the board current via SignalR &mdash; restart LAD after toggling.
+                                        </p>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-filters" role="tabpanel" aria-labelledby="cfgTab-filters" tabindex="0">
                                         <div class="accordion config-subaccordion" id="cfgFiltersAcc">
@@ -3235,37 +3230,28 @@
                                                 </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
-                                        <div class="cfg-rows">
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="darkModeToggle">Dark mode</label>
-                                                    <div class="d">Reduces eye strain in low light environments.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                        <div class="cfg-card">
+                                            <div class="cfg-line">
+                                                <label for="darkModeToggle">Dark mode</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="darkModeToggle" data-bind="checked: config.darkMode">
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="alertsCollapsibleRulesToggle">Auto-collapse alert popups</label>
-                                                    <div class="d">New alerts start collapsed in the Alerts panel.</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                            <div class="cfg-line">
+                                                <label for="alertsCollapsibleRulesToggle">Auto-collapse alert popups</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="alertsCollapsibleRulesToggle" data-bind="checked: config.alertsCollapsibleRules">
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-row">
-                                                <div class="cfg-row-main">
-                                                    <label class="t" for="taskingCountActiveOnlyToggle">Count active taskings only</label>
-                                                    <div class="d">Incident tasking count excludes Complete, CalledOff &amp; Untasked (counts only Tasked, Enroute &amp; Onsite).</div>
-                                                </div>
-                                                <div class="cfg-row-control">
+                                            <div class="cfg-line">
+                                                <label for="taskingCountActiveOnlyToggle">Count active taskings only</label>
+                                                <div class="cfg-line-ctl">
                                                     <div class="form-check form-switch">
                                                         <input class="form-check-input" type="checkbox" role="switch"
                                                             id="taskingCountActiveOnlyToggle" data-bind="checked: config.taskingCountActiveOnly">
@@ -3273,6 +3259,10 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <p class="cfg-card-note">
+                                            Dark mode reduces eye strain on overnight shifts. &ldquo;Count active taskings
+                                            only&rdquo; excludes Complete, CalledOff &amp; Untasked from the incident tasking count.
+                                        </p>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-suggest" role="tabpanel" aria-labelledby="cfgTab-suggest" tabindex="0">
 

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2121,48 +2121,60 @@
                                     </ul>
                                     <div class="tab-content config-panes">
                                     <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
-                                        <div class="cfg-card">
-                                            <div class="cfg-line">
-                                                <label for="refreshInterval">Refresh interval</label>
-                                                <div class="cfg-line-ctl">
-                                                    <div class="input-group input-group-sm">
-                                                        <input id="refreshInterval" type="number" min="30" step="5"
-                                                            class="form-control" data-bind="value: config.refreshInterval">
-                                                        <span class="input-group-text">sec</span>
+                                        <div class="cfg-data">
+                                            <div class="cfg-data-fields">
+                                                <div class="cfg-field">
+                                                    <label for="refreshInterval">Refresh interval</label>
+                                                    <div class="ctl">
+                                                        <div class="input-group input-group-sm">
+                                                            <input id="refreshInterval" type="number" min="30" step="5"
+                                                                class="form-control" data-bind="value: config.refreshInterval">
+                                                            <span class="input-group-text">sec</span>
+                                                        </div>
                                                     </div>
+                                                    <div class="d">Full reload of every incident and team.</div>
+                                                </div>
+                                                <div class="cfg-field">
+                                                    <label for="fetchPeriod">Fetch window</label>
+                                                    <div class="ctl">
+                                                        <div class="input-group input-group-sm">
+                                                            <input id="fetchPeriod" type="number" min="0" max="31" step="1"
+                                                                class="form-control" aria-label="Fetch backwards (days)"
+                                                                data-bind="value: config.fetchPeriod">
+                                                            <span class="input-group-text">d&nbsp;back</span>
+                                                        </div>
+                                                        <div class="input-group input-group-sm">
+                                                            <input id="fetchForward" type="number" min="0" step="1"
+                                                                class="form-control" aria-label="Fetch forward (days)"
+                                                                data-bind="value: config.fetchForward">
+                                                            <span class="input-group-text">d&nbsp;fwd</span>
+                                                        </div>
+                                                    </div>
+                                                    <div class="d">How much past history and lookahead to load.</div>
+                                                </div>
+                                                <div class="cfg-field">
+                                                    <label for="signalrEnabledToggle">Live updates</label>
+                                                    <div class="ctl">
+                                                        <div class="form-check form-switch">
+                                                            <input class="form-check-input" type="checkbox" role="switch"
+                                                                id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
+                                                        </div>
+                                                    </div>
+                                                    <div class="d">Instant incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
                                                 </div>
                                             </div>
-                                            <div class="cfg-line">
-                                                <label for="fetchPeriod">Fetch window</label>
-                                                <div class="cfg-line-ctl">
-                                                    <div class="input-group input-group-sm">
-                                                        <input id="fetchPeriod" type="number" min="0" max="31" step="1"
-                                                            class="form-control" aria-label="Fetch backwards (days)"
-                                                            data-bind="value: config.fetchPeriod">
-                                                        <span class="input-group-text">back</span>
-                                                    </div>
-                                                    <div class="input-group input-group-sm">
-                                                        <input id="fetchForward" type="number" min="0" step="1"
-                                                            class="form-control" aria-label="Fetch forward (days)"
-                                                            data-bind="value: config.fetchForward">
-                                                        <span class="input-group-text">fwd</span>
-                                                    </div>
+
+                                            <div class="cfg-readout">
+                                                <div class="cfg-readout-h">Loading now</div>
+                                                <div class="cfg-readout-range" data-bind="text: config.fetchWindowRange"></div>
+                                                <div class="cfg-readout-sub"><span data-bind="text: config.fetchWindowDays"></span>-day window</div>
+                                                <div class="cfg-readout-rows">
+                                                    <div><span>Full refresh</span><span data-bind="text: config.refreshCadence"></span></div>
+                                                    <div><span>Live updates</span><span data-bind="text: config.liveUpdatesLabel"></span></div>
                                                 </div>
-                                            </div>
-                                            <div class="cfg-line">
-                                                <label for="signalrEnabledToggle">Live updates</label>
-                                                <div class="cfg-line-ctl">
-                                                    <div class="form-check form-switch">
-                                                        <input class="form-check-input" type="checkbox" role="switch"
-                                                            id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
-                                                    </div>
-                                                </div>
+                                                <div class="cfg-readout-note">Toggling live updates needs a LAD restart to take effect.</div>
                                             </div>
                                         </div>
-                                        <p class="cfg-card-note">
-                                            &ldquo;Refresh interval&rdquo; is the full data-reload cycle. Between reloads,
-                                            live updates keep the board current via SignalR &mdash; restart LAD after toggling.
-                                        </p>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-filters" role="tabpanel" aria-labelledby="cfgTab-filters" tabindex="0">
                                         <div class="accordion config-subaccordion" id="cfgFiltersAcc">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2090,17 +2090,22 @@
                                     </li>
                                     <li class="nav-item" role="presentation">
                                         <button class="nav-link" id="cfgTab-map" data-bs-toggle="pill" data-bs-target="#cfgPane-map" type="button" role="tab" aria-controls="cfgPane-map" aria-selected="false">
-                                            <span class="cfg-rail-ico"><i class="fa fa-layer-group"></i></span><span>Map</span>
+                                            <span class="cfg-rail-ico"><i class="fa fa-map-marker-alt"></i></span><span>Map markers</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-collab" data-bs-toggle="pill" data-bs-target="#cfgPane-collab" type="button" role="tab" aria-controls="cfgPane-collab" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-layer-group"></i></span><span>Collaborative layers</span>
                                         </button>
                                     </li>
                                     <li class="nav-item" role="presentation">
                                         <button class="nav-link" id="cfgTab-sidebar" data-bs-toggle="pill" data-bs-target="#cfgPane-sidebar" type="button" role="tab" aria-controls="cfgPane-sidebar" aria-selected="false">
-                                            <span class="cfg-rail-ico"><i class="fa fa-table-columns"></i></span><span>Sidebar</span>
+                                            <span class="cfg-rail-ico"><i class="fa fa-columns"></i></span><span>Sidebar</span>
                                         </button>
                                     </li>
                                     <li class="nav-item" role="presentation">
                                         <button class="nav-link" id="cfgTab-appearance" data-bs-toggle="pill" data-bs-target="#cfgPane-appearance" type="button" role="tab" aria-controls="cfgPane-appearance" aria-selected="false">
-                                            <span class="cfg-rail-ico"><i class="fa fa-sliders"></i></span><span>Appearance</span>
+                                            <span class="cfg-rail-ico"><i class="fa fa-adjust"></i></span><span>Appearance</span>
                                         </button>
                                     </li>
                                     <li class="nav-item" role="presentation">
@@ -2112,7 +2117,7 @@
                                     <div class="tab-content config-panes">
                                     <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
                                         <div class="row g-3">
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-6">
                                                         <label for="refreshInterval" class="form-label">
                                                             <i class="fa fa-sync-alt me-1"></i>Refresh interval
                                                             (seconds)
@@ -2126,7 +2131,7 @@
                                                         </div>
                                                         <div class="form-text">How often to fully refresh data.</div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-6">
                                                         <label for="fetchPeriod" class="form-label">
                                                             <i class="fa fa-history me-1"></i>Fetch backwards (days)
                                                         </label>
@@ -2139,7 +2144,7 @@
                                                         </div>
                                                         <div class="form-text">How many days in the past to fetch.</div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-6">
                                                         <label for="fetchForward" class="form-label">
                                                             <i class="fa fa-calendar-plus me-1"></i>Fetch forward (days)
                                                         </label>
@@ -2153,7 +2158,7 @@
                                                         <div class="form-text">How many days into the future to fetch.
                                                         </div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-6">
                                                         <label class="form-label">
                                                             <i class="fa fa-bolt me-1"></i>Live Updates
                                                         </label>
@@ -2649,15 +2654,6 @@
                                         </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-map" role="tabpanel" aria-labelledby="cfgTab-map" tabindex="0">
-                                        <div class="accordion config-subaccordion" id="cfgMapAcc">
-                                        <div class="accordion-item">
-                                            <h2 class="accordion-header">
-                                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-markers" aria-expanded="true" aria-controls="cfgSub-markers">
-                                                    <span class="cfg-sub-ico"><i class="fa fa-map-marker-alt"></i></span><span>Incident markers</span>
-                                                </button>
-                                            </h2>
-                                            <div id="cfgSub-markers" class="accordion-collapse collapse show" data-bs-parent="#cfgMapAcc">
-                                                <div class="accordion-body">
                                                 <div class="row g-3">
 
                                                     <!-- Clustering options -->
@@ -2744,17 +2740,8 @@
                                                     </div>
 
                                                 </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="accordion-item">
-                                            <h2 class="accordion-header">
-                                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cfgSub-collab" aria-expanded="false" aria-controls="cfgSub-collab">
-                                                    <span class="cfg-sub-ico"><i class="fa fa-users"></i></span><span>Collaborative layers</span>
-                                                </button>
-                                            </h2>
-                                            <div id="cfgSub-collab" class="accordion-collapse collapse" data-bs-parent="#cfgMapAcc">
-                                                <div class="accordion-body">
+                                    </div>
+                                    <div class="tab-pane fade" id="cfgPane-collab" role="tabpanel" aria-labelledby="cfgTab-collab" tabindex="0">
                                                 <div class="d-flex align-items-center justify-content-between mb-2">
                                                     <h6 class="fw-semibold mb-0">
                                                         <i class="fa fa-users me-1"></i>Collaborative Layers
@@ -3170,10 +3157,6 @@
                                                 <div class="form-text mt-2" data-bind="visible: config.noSearchMatchMessage, text: config.noSearchMatchMessage">
                                                 </div>
 
-                                                </div>
-                                            </div>
-                                        </div>
-                                        </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-sidebar" role="tabpanel" aria-labelledby="cfgTab-sidebar" tabindex="0">
                                                 <label class="form-label">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -3257,7 +3257,7 @@
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
                                         <div class="row g-3">
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-4">
                                                         <label class="form-label">
                                                             <i class="fa fa-moon me-1"></i>Dark Mode
                                                         </label>
@@ -3270,7 +3270,7 @@
                                                         </div>
                                                         <div class="form-text">Reduces eye strain in low light environments.</div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-4">
                                                         <label class="form-label">
                                                             <i class="fa fa-bell me-1"></i>Alerts Panel
                                                         </label>
@@ -3283,7 +3283,7 @@
                                                         </div>
                                                         <div class="form-text">Alerts will start collapsed.</div>
                                                     </div>
-                                                    <div class="col-sm-6 col-md-3">
+                                                    <div class="col-sm-6 col-md-4">
                                                         <label class="form-label">
                                                             <i class="fa fa-hashtag me-1"></i>Incident Tasking Count
                                                         </label>

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2100,7 +2100,12 @@
                                     </li>
                                     <li class="nav-item" role="presentation">
                                         <button class="nav-link" id="cfgTab-sidebar" data-bs-toggle="pill" data-bs-target="#cfgPane-sidebar" type="button" role="tab" aria-controls="cfgPane-sidebar" aria-selected="false">
-                                            <span class="cfg-rail-ico"><i class="fa fa-columns"></i></span><span>Sidebar</span>
+                                            <span class="cfg-rail-ico"><i class="fa fa-columns"></i></span><span>Layout</span>
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="cfgTab-starred" data-bs-toggle="pill" data-bs-target="#cfgPane-starred" type="button" role="tab" aria-controls="cfgPane-starred" aria-selected="false">
+                                            <span class="cfg-rail-ico"><i class="fa fa-star"></i></span><span>Starred</span>
                                         </button>
                                     </li>
                                     <li class="nav-item" role="presentation">
@@ -3181,8 +3186,8 @@
                                                     </label>
                                                 </div>
                                                 <div class="form-text">Pick a layout to instantly preview and apply section placement.</div>
-                                        <hr class="my-4">
-                                        <h6 class="cfg-subhead"><i class="fa fa-star me-2"></i>Starred teams &amp; incidents</h6>
+                                    </div>
+                                    <div class="tab-pane fade" id="cfgPane-starred" role="tabpanel" aria-labelledby="cfgTab-starred" tabindex="0">
                                                 <div
                                                     class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
                                                     <div class="small text-muted">

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2124,33 +2124,59 @@
                                         <div class="cfg-data">
                                             <div class="cfg-data-fields">
                                                 <div class="cfg-field">
-                                                    <label for="refreshInterval">Refresh interval</label>
-                                                    <div class="ctl">
-                                                        <div class="input-group input-group-sm">
-                                                            <input id="refreshInterval" type="number" min="30" step="5"
-                                                                class="form-control" data-bind="value: config.refreshInterval">
+                                                    <label>Refresh interval</label>
+                                                    <div class="cfg-preset-row">
+                                                        <div class="cfg-seg" data-bind="foreach: { data: config.refreshPresets, as: 'p' }">
+                                                            <button type="button" class="cfg-seg-btn"
+                                                                data-bind="text: p.label,
+                                                                           css: { active: $root.config.refreshInterval() == p.value },
+                                                                           click: $root.config.pickRefreshPreset"></button>
+                                                        </div>
+                                                        <span class="cfg-preset-or">or</span>
+                                                        <div class="input-group input-group-sm cfg-preset-num">
+                                                            <input type="number" min="30" step="5" class="form-control"
+                                                                aria-label="Refresh interval (seconds)"
+                                                                data-bind="value: config.refreshInterval">
                                                             <span class="input-group-text">sec</span>
                                                         </div>
                                                     </div>
                                                     <div class="d">Full reload of every incident and team.</div>
                                                 </div>
                                                 <div class="cfg-field">
-                                                    <label for="fetchPeriod">Fetch window</label>
-                                                    <div class="ctl">
-                                                        <div class="input-group input-group-sm">
-                                                            <input id="fetchPeriod" type="number" min="0" max="31" step="1"
-                                                                class="form-control" aria-label="Fetch backwards (days)"
-                                                                data-bind="value: config.fetchPeriod">
-                                                            <span class="input-group-text">d&nbsp;back</span>
+                                                    <label>History &mdash; how far back</label>
+                                                    <div class="cfg-preset-row">
+                                                        <div class="cfg-chips" data-bind="foreach: { data: config.historyPresets, as: 'p' }">
+                                                            <button type="button" class="cfg-chip"
+                                                                data-bind="text: p.label,
+                                                                           css: { active: $root.config.fetchPeriod() == p.value },
+                                                                           click: $root.config.pickHistoryPreset"></button>
                                                         </div>
-                                                        <div class="input-group input-group-sm">
-                                                            <input id="fetchForward" type="number" min="0" step="1"
-                                                                class="form-control" aria-label="Fetch forward (days)"
-                                                                data-bind="value: config.fetchForward">
-                                                            <span class="input-group-text">d&nbsp;fwd</span>
+                                                        <span class="cfg-preset-or">or</span>
+                                                        <div class="input-group input-group-sm cfg-preset-num">
+                                                            <input type="number" min="0" max="31" step="1" class="form-control"
+                                                                aria-label="Days of history"
+                                                                data-bind="value: config.fetchPeriod">
+                                                            <span class="input-group-text">d</span>
                                                         </div>
                                                     </div>
-                                                    <div class="d">How much past history and lookahead to load.</div>
+                                                </div>
+                                                <div class="cfg-field">
+                                                    <label>Lookahead &mdash; how far forward</label>
+                                                    <div class="cfg-preset-row">
+                                                        <div class="cfg-chips" data-bind="foreach: { data: config.lookaheadPresets, as: 'p' }">
+                                                            <button type="button" class="cfg-chip"
+                                                                data-bind="text: p.label,
+                                                                           css: { active: $root.config.fetchForward() == p.value },
+                                                                           click: $root.config.pickLookaheadPreset"></button>
+                                                        </div>
+                                                        <span class="cfg-preset-or">or</span>
+                                                        <div class="input-group input-group-sm cfg-preset-num">
+                                                            <input type="number" min="0" max="31" step="1" class="form-control"
+                                                                aria-label="Days of lookahead"
+                                                                data-bind="value: config.fetchForward">
+                                                            <span class="input-group-text">d</span>
+                                                        </div>
+                                                    </div>
                                                 </div>
                                                 <div class="cfg-field">
                                                     <label for="signalrEnabledToggle">Live updates</label>
@@ -2159,6 +2185,9 @@
                                                             <input class="form-check-input" type="checkbox" role="switch"
                                                                 id="signalrEnabledToggle" data-bind="checked: config.signalrEnabled">
                                                         </div>
+                                                        <span class="cfg-live-pill"
+                                                            data-bind="text: config.liveUpdatesLabel,
+                                                                       css: { on: config.signalrEnabled(), off: !config.signalrEnabled() }"></span>
                                                     </div>
                                                     <div class="d">Instant incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
                                                 </div>

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2124,7 +2124,7 @@
                                         <div class="cfg-data">
                                             <div class="cfg-data-fields">
                                                 <div class="cfg-field">
-                                                    <label>Refresh interval</label>
+                                                    <label>Full refresh</label>
                                                     <div class="cfg-preset-row">
                                                         <div class="cfg-seg" data-bind="foreach: { data: config.refreshPresets, as: 'p' }">
                                                             <button type="button" class="cfg-seg-btn"
@@ -2140,10 +2140,10 @@
                                                             <span class="input-group-text">sec</span>
                                                         </div>
                                                     </div>
-                                                    <div class="d">Automatically perform a full reload of every incident and team.</div>
+                                                    <div class="d" data-bind="text: config.fullRefreshHint"></div>
                                                 </div>
                                                 <div class="cfg-field">
-                                                    <label>History &mdash; how far back</label>
+                                                    <label>History &mdash; how far back to load</label>
                                                     <div class="cfg-preset-row">
                                                         <div class="cfg-chips" data-bind="foreach: { data: config.historyPresets, as: 'p' }">
                                                             <button type="button" class="cfg-chip"
@@ -2161,7 +2161,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="cfg-field">
-                                                    <label>Lookahead &mdash; how far forward</label>
+                                                    <label>Lookahead &mdash; how far forward to load</label>
                                                     <div class="cfg-preset-row">
                                                         <div class="cfg-chips" data-bind="foreach: { data: config.lookaheadPresets, as: 'p' }">
                                                             <button type="button" class="cfg-chip"
@@ -2189,7 +2189,7 @@
                                                             data-bind="text: config.liveUpdatesLabel,
                                                                        css: { on: config.signalrEnabled(), off: !config.signalrEnabled() }"></span>
                                                     </div>
-                                                    <div class="d">Instantly update incident, team &amp; tasking changes via SignalR, between full refreshes.</div>
+                                                    <div class="d">Beacon pushes every incident, team &amp; tasking change to the board as it happens &mdash; this is what keeps LAD current. Restart LAD after changing.</div>
                                                 </div>
                                             </div>
 
@@ -2198,10 +2198,10 @@
                                                 <div class="cfg-readout-range" data-bind="text: config.fetchWindowRange"></div>
                                                 <div class="cfg-readout-sub"><span data-bind="text: config.fetchWindowDays"></span>-day window</div>
                                                 <div class="cfg-readout-rows">
-                                                    <div><span>Full refresh</span><span data-bind="text: config.refreshCadence"></span></div>
                                                     <div><span>Live updates</span><span data-bind="text: config.liveUpdatesLabel"></span></div>
+                                                    <div><span>Full refresh</span><span data-bind="text: config.refreshCadence"></span></div>
                                                 </div>
-                                                <div class="cfg-readout-note">Toggling live updates needs a LAD restart to take effect.</div>
+                                                <div class="cfg-readout-note" data-bind="text: config.dataReadoutNote"></div>
                                             </div>
                                         </div>
                                     </div>

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -2771,6 +2771,31 @@
                                                         </fieldset>
                                                     </div>
 
+                                                    <!-- Incident status on markers -->
+                                                    <div class="col-md-6">
+                                                        <fieldset>
+                                                            <legend class="form-label fw-semibold mb-2">
+                                                                <i class="fa fa-circle-info me-1"></i>Incident Status on Markers
+                                                            </legend>
+                                                            <div class="form-check form-switch mb-2">
+                                                                <input class="form-check-input" type="checkbox"
+                                                                    role="switch" id="jobStatusOnMarkersToggle"
+                                                                    data-bind="checked: config.showJobStatusOnMarkers">
+                                                                <label class="form-check-label"
+                                                                    for="jobStatusOnMarkersToggle">
+                                                                    Show job status on incident markers
+                                                                </label>
+                                                            </div>
+                                                            <div class="form-text">
+                                                                Styles incident markers by job status: Active gets a
+                                                                magenta ring, Complete / Referred / Finalised are struck
+                                                                through, Cancelled / Rejected are crossed out, and jobs
+                                                                with an action-required tag get a red exclamation dot.
+                                                                See the map legend for the full key.
+                                                            </div>
+                                                        </fieldset>
+                                                    </div>
+
                                                 </div>
                                     </div>
                                     <div class="tab-pane fade" id="cfgPane-collab" role="tabpanel" aria-labelledby="cfgTab-collab" tabindex="0">

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1040,6 +1040,29 @@ body.dark-mode .nav-link.active {
   border-color: #0d6efd;
 }
 
+/* Config modal left rail */
+body.dark-mode .config-rail {
+  border-color: #444;
+}
+
+body.dark-mode .config-rail .nav-link {
+  color: #adb5bd;
+}
+
+body.dark-mode .config-rail .nav-link:hover {
+  background: #333;
+  color: #e0e0e0;
+}
+
+body.dark-mode .config-rail .nav-link.active {
+  background: #2b3a55;
+  color: #6ea8fe;
+}
+
+body.dark-mode .cfg-subhead {
+  color: #adb5bd;
+}
+
 /* Collapse elements */
 body.dark-mode .collapse {
   background-color: #2d2d2d;

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1064,6 +1064,15 @@ body.dark-mode .cfg-subhead {
   color: #adb5bd;
 }
 
+body.dark-mode .cfg-row,
+body.dark-mode .cfg-row:first-child {
+  border-color: #444;
+}
+
+body.dark-mode .cfg-row-main .d {
+  color: #adb5bd;
+}
+
 /* Collapse elements */
 body.dark-mode .collapse {
   background-color: #2d2d2d;

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1064,12 +1064,16 @@ body.dark-mode .cfg-subhead {
   color: #adb5bd;
 }
 
-body.dark-mode .cfg-row,
-body.dark-mode .cfg-row:first-child {
+body.dark-mode .cfg-card {
+  background: #2d2d2d;
   border-color: #444;
 }
 
-body.dark-mode .cfg-row-main .d {
+body.dark-mode .cfg-line {
+  border-color: #3d3d3d;
+}
+
+body.dark-mode .cfg-card-note {
   color: #adb5bd;
 }
 

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1073,7 +1073,22 @@ body.dark-mode .cfg-line {
   border-color: #3d3d3d;
 }
 
-body.dark-mode .cfg-card-note {
+body.dark-mode .cfg-card-note,
+body.dark-mode .cfg-field .d {
+  color: #adb5bd;
+}
+
+body.dark-mode .cfg-readout {
+  background: #262626;
+  border-color: #444;
+}
+
+body.dark-mode .cfg-readout-h,
+body.dark-mode .cfg-readout-note {
+  color: #8b929c;
+}
+
+body.dark-mode .cfg-readout-sub {
   color: #adb5bd;
 }
 

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1041,6 +1041,7 @@ body.dark-mode .nav-link.active {
 }
 
 /* Config modal left rail */
+body.dark-mode .config-panes,
 body.dark-mode .config-rail {
   border-color: #444;
 }

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1064,16 +1064,6 @@ body.dark-mode .cfg-subhead {
   color: #adb5bd;
 }
 
-body.dark-mode .cfg-card {
-  background: #2d2d2d;
-  border-color: #444;
-}
-
-body.dark-mode .cfg-line {
-  border-color: #3d3d3d;
-}
-
-body.dark-mode .cfg-card-note,
 body.dark-mode .cfg-field .d {
   color: #adb5bd;
 }

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1092,6 +1092,40 @@ body.dark-mode .cfg-readout-sub {
   color: #adb5bd;
 }
 
+body.dark-mode .cfg-seg,
+body.dark-mode .cfg-seg-btn,
+body.dark-mode .cfg-chip {
+  border-color: #495057;
+}
+
+body.dark-mode .cfg-seg-btn,
+body.dark-mode .cfg-chip {
+  background: #2d2d2d;
+  color: #e0e0e0;
+}
+
+body.dark-mode .cfg-seg-btn:hover,
+body.dark-mode .cfg-chip:hover {
+  background: #3a3a3a;
+}
+
+body.dark-mode .cfg-seg-btn.active,
+body.dark-mode .cfg-chip.active {
+  background: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+body.dark-mode .cfg-live-pill.on {
+  background: #1a2c22;
+  color: #4bbd83;
+}
+
+body.dark-mode .cfg-live-pill.off {
+  background: #333;
+  color: #adb5bd;
+}
+
 /* Collapse elements */
 body.dark-mode .collapse {
   background-color: #2d2d2d;

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2118,16 +2118,21 @@ overflow: hidden;
 .config-settings {
   display: grid;
   grid-template-columns: 210px minmax(0, 1fr);
-  gap: 1.25rem;
-  align-items: start;
+  gap: 0;
 }
 
 .config-rail {
   position: sticky;
   top: 0;
+  align-self: start;
   gap: 2px;
-  border-right: 1px solid #dee2e6;
-  padding-right: 0.75rem;
+  padding-right: 1rem;
+}
+
+.config-panes {
+  border-left: 1px solid #dee2e6;
+  padding-left: 1.25rem;
+  min-height: 340px;
 }
 
 .config-rail .nav-link {
@@ -2165,10 +2170,6 @@ overflow: hidden;
   margin-right: 0.5rem;
 }
 
-.config-panes {
-  min-height: 360px;
-}
-
 .cfg-subhead {
   font-size: 0.8rem;
   font-weight: 600;
@@ -2191,11 +2192,15 @@ overflow: hidden;
     position: static;
     flex-direction: row !important;
     flex-wrap: wrap;
-    border-right: 0;
-    border-bottom: 1px solid #dee2e6;
     padding-right: 0;
     padding-bottom: 0.5rem;
     margin-bottom: 0.75rem;
+    border-bottom: 1px solid #dee2e6;
+  }
+
+  .config-panes {
+    border-left: 0;
+    padding-left: 0;
   }
 
   .config-rail .nav-link {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2187,14 +2187,15 @@ overflow: hidden;
 .cfg-rows {
   display: flex;
   flex-direction: column;
-  max-width: 620px;
+  max-width: 540px;
 }
 
 .cfg-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1.5rem;
+  display: grid;
+  grid-template-columns: 13.5rem 1fr;
+  column-gap: 1.25rem;
+  row-gap: 0.15rem;
+  align-items: baseline;
   padding: 0.85rem 0.1rem;
   border-bottom: 1px solid #e9ecef;
 }
@@ -2204,27 +2205,30 @@ overflow: hidden;
 }
 
 .cfg-row-main {
-  min-width: 0;
+  display: contents;
 }
 
 .cfg-row-main .t {
-  display: block;
+  grid-column: 1;
+  grid-row: 1;
   font-weight: 600;
   margin: 0;
 }
 
 .cfg-row-main .d {
+  grid-column: 1 / -1;
+  grid-row: 2;
   font-size: 0.8125rem;
   color: #6c757d;
-  margin-top: 0.15rem;
 }
 
 .cfg-row-control {
-  flex: none;
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: start;
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  padding-top: 0.1rem;
 }
 
 .cfg-row-control .input-group {
@@ -2241,11 +2245,11 @@ overflow: hidden;
 .cfg-row-control .form-switch {
   min-height: auto;
   margin: 0;
-  padding-left: 2.5em;
+  padding-left: 0;
 }
 
 .cfg-row-control .form-switch .form-check-input {
-  margin-left: -2.5em;
+  margin: 0;
   cursor: pointer;
 }
 

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2183,6 +2183,72 @@ overflow: hidden;
   padding-top: 0.75rem;
 }
 
+/* Stacked settings rows (Data / Appearance panes) */
+.cfg-rows {
+  display: flex;
+  flex-direction: column;
+  max-width: 620px;
+}
+
+.cfg-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.85rem 0.1rem;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.cfg-row:first-child {
+  border-top: 1px solid #e9ecef;
+}
+
+.cfg-row-main {
+  min-width: 0;
+}
+
+.cfg-row-main .t {
+  display: block;
+  font-weight: 600;
+  margin: 0;
+}
+
+.cfg-row-main .d {
+  font-size: 0.8125rem;
+  color: #6c757d;
+  margin-top: 0.15rem;
+}
+
+.cfg-row-control {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding-top: 0.1rem;
+}
+
+.cfg-row-control .input-group {
+  width: auto;
+  flex: none;
+}
+
+.cfg-row-control .input-group .form-control {
+  width: 4rem;
+  flex: 0 0 auto;
+  text-align: right;
+}
+
+.cfg-row-control .form-switch {
+  min-height: auto;
+  margin: 0;
+  padding-left: 2.5em;
+}
+
+.cfg-row-control .form-switch .form-check-input {
+  margin-left: -2.5em;
+  cursor: pointer;
+}
+
 @media (max-width: 640px) {
   .config-settings {
     grid-template-columns: 1fr;

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2246,6 +2246,123 @@ overflow: hidden;
   color: #6c757d;
 }
 
+/* Data pane: settings + live "loading now" readout */
+.cfg-data {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 19rem;
+  gap: 2.25rem;
+  align-items: start;
+  max-width: 760px;
+}
+
+.cfg-data-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  padding-top: 0.25rem;
+}
+
+.cfg-field > label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.cfg-field .ctl {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cfg-field .ctl .input-group {
+  width: auto;
+  flex: none;
+}
+
+.cfg-field .ctl .input-group .form-control {
+  width: 3.25rem;
+  flex: 0 0 auto;
+  text-align: right;
+}
+
+.cfg-field .ctl .form-switch {
+  min-height: auto;
+  margin: 0;
+  padding-left: 0;
+}
+
+.cfg-field .ctl .form-switch .form-check-input {
+  margin: 0;
+  cursor: pointer;
+}
+
+.cfg-field .d {
+  font-size: 0.8125rem;
+  color: #6c757d;
+  margin-top: 0.35rem;
+  max-width: 34ch;
+}
+
+.cfg-readout {
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 1rem 1.1rem 1.05rem;
+}
+
+.cfg-readout-h {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a929c;
+  margin-bottom: 0.6rem;
+}
+
+.cfg-readout-range {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.cfg-readout-sub {
+  font-size: 0.8125rem;
+  color: #6c757d;
+  margin-top: 0.15rem;
+}
+
+.cfg-readout-rows {
+  margin-top: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.cfg-readout-rows > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.875rem;
+}
+
+.cfg-readout-rows > div > span:last-child {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.cfg-readout-note {
+  margin-top: 0.95rem;
+  font-size: 0.75rem;
+  color: #8a929c;
+}
+
+@media (max-width: 820px) {
+  .cfg-data {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
 @media (max-width: 640px) {
   .config-settings {
     grid-template-columns: 1fr;

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -1445,6 +1445,35 @@ tr.job:hover {
   }
 }
 
+/* STATUS RING — the Active "marching ring" (separate follower marker).
+   A dashed circle whose <g> rotates, which reads as marching ants and is
+   compositor-only (cheap) unlike animating stroke-dashoffset. */
+.status-ring-icon {
+  pointer-events: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  line-height: 0;
+  font-size: 0;
+}
+
+.status-ring-spin {
+  animation: status-ring-spin 9s linear infinite;
+}
+
+@keyframes status-ring-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-ring-spin {
+    animation: none;
+  }
+}
+
 .no-drag {
   user-select: text !important;
   cursor: text !important;
@@ -1707,7 +1736,12 @@ overflow: hidden;
   border-radius: 8px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
   min-width: 120px;
-  max-width: 80vw;
+  /* cap the spread (~3 narrow columns) so it can't sheet across the map;
+     anything past this scrolls inside the box */
+  max-width: min(88vw, 620px);
+  max-height: calc(100vh - 24px);
+  max-height: calc(100dvh - 24px);
+  overflow: auto;
   font-size: 13px;
 }
 
@@ -1715,13 +1749,19 @@ overflow: hidden;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  max-height: calc(100vh - 120px);
-  gap: 0 20px;
+  /* keep wrapped columns packed to the left rather than spread across */
+  align-content: flex-start;
+  /* Wrap into a new column (rightwards) before the stack climbs into the
+     zoom / tool buttons running down the left edge of the map. The 180px
+     floor stops it collapsing to slivers on very short windows. */
+  max-height: max(180px, calc(100vh - 300px));
+  max-height: max(180px, calc(100dvh - 300px));
+  gap: 0 18px;
 }
 
 .legend-body > div {
-  min-width: 190px;
-  max-width: 300px;
+  min-width: 165px;
+  max-width: 260px;
 }
 
 .legend-container i {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2183,69 +2183,6 @@ overflow: hidden;
   padding-top: 0.75rem;
 }
 
-/* Compact settings card (Data / Appearance panes) */
-.cfg-card {
-  max-width: 400px;
-  padding: 0 1rem;
-  border: 1px solid #e3e6ea;
-  border-radius: 8px;
-  background: #fff;
-}
-
-.cfg-line {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: center;
-  column-gap: 1rem;
-  padding: 0.72rem 0;
-  border-bottom: 1px solid #eef0f2;
-}
-
-.cfg-line:last-child {
-  border-bottom: 0;
-}
-
-.cfg-line > label {
-  font-weight: 500;
-  margin: 0;
-}
-
-.cfg-line-ctl {
-  justify-self: end;
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.cfg-line-ctl .input-group {
-  width: auto;
-  flex: none;
-}
-
-.cfg-line-ctl .input-group .form-control {
-  width: 3.25rem;
-  flex: 0 0 auto;
-  text-align: right;
-}
-
-.cfg-line-ctl .form-switch {
-  min-height: auto;
-  margin: 0;
-  padding-left: 0;
-}
-
-.cfg-line-ctl .form-switch .form-check-input {
-  margin: 0;
-  cursor: pointer;
-}
-
-.cfg-card-note {
-  max-width: 42ch;
-  margin: 0.85rem 0 0;
-  font-size: 0.8125rem;
-  color: #6c757d;
-}
-
 /* Data pane: preset controls + live "loading now" readout */
 .cfg-data {
   display: grid;
@@ -2262,6 +2199,11 @@ overflow: hidden;
   padding-top: 0.25rem;
 }
 
+/* same field stack used standalone (Appearance pane) */
+.cfg-fields-solo {
+  max-width: 460px;
+}
+
 .cfg-field > label {
   display: block;
   font-weight: 600;
@@ -2272,6 +2214,19 @@ overflow: hidden;
   display: flex;
   align-items: center;
   gap: 0.55rem;
+}
+
+.cfg-field .ctl .form-switch {
+  display: flex;
+  align-items: center;
+  min-height: auto;
+  margin: 0;
+  padding-left: 0;
+}
+
+.cfg-field .ctl .form-switch .form-check-input {
+  margin: 0;
+  cursor: pointer;
 }
 
 .cfg-field .d {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2114,6 +2114,95 @@ overflow: hidden;
   margin-top: 2.5px !important;
 }
 
+/* === Config modal: left-rail sections === */
+.config-settings {
+  display: grid;
+  grid-template-columns: 210px minmax(0, 1fr);
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.config-rail {
+  position: sticky;
+  top: 0;
+  gap: 2px;
+  border-right: 1px solid #dee2e6;
+  padding-right: 0.75rem;
+}
+
+.config-rail .nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  text-align: left;
+  color: #495057;
+  border-radius: 6px;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.9rem;
+}
+
+.config-rail .nav-link:hover {
+  background: #f1f3f5;
+  color: #212529;
+}
+
+.config-rail .nav-link.active {
+  background: #e7f1ff;
+  color: #0d6efd;
+  font-weight: 600;
+}
+
+.cfg-rail-ico,
+.cfg-sub-ico {
+  width: 1.1rem;
+  text-align: center;
+  flex: none;
+  opacity: 0.85;
+}
+
+.cfg-sub-ico {
+  margin-right: 0.5rem;
+}
+
+.config-panes {
+  min-height: 360px;
+}
+
+.cfg-subhead {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6c757d;
+  margin: 0 0 0.75rem;
+}
+
+.config-subaccordion .accordion-body {
+  padding-top: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .config-settings {
+    grid-template-columns: 1fr;
+  }
+
+  .config-rail {
+    position: static;
+    flex-direction: row !important;
+    flex-wrap: wrap;
+    border-right: 0;
+    border-bottom: 1px solid #dee2e6;
+    padding-right: 0;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .config-rail .nav-link {
+    width: auto;
+  }
+}
+
 /* === Job History / Ops Log two-lane timeline === */
 
 .job-history-timeline {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2183,74 +2183,67 @@ overflow: hidden;
   padding-top: 0.75rem;
 }
 
-/* Stacked settings rows (Data / Appearance panes) */
-.cfg-rows {
-  display: flex;
-  flex-direction: column;
-  max-width: 540px;
+/* Compact settings card (Data / Appearance panes) */
+.cfg-card {
+  max-width: 400px;
+  padding: 0 1rem;
+  border: 1px solid #e3e6ea;
+  border-radius: 8px;
+  background: #fff;
 }
 
-.cfg-row {
+.cfg-line {
   display: grid;
-  grid-template-columns: 13.5rem 1fr;
-  column-gap: 1.25rem;
-  row-gap: 0.15rem;
-  align-items: baseline;
-  padding: 0.85rem 0.1rem;
-  border-bottom: 1px solid #e9ecef;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  column-gap: 1rem;
+  padding: 0.72rem 0;
+  border-bottom: 1px solid #eef0f2;
 }
 
-.cfg-row:first-child {
-  border-top: 1px solid #e9ecef;
+.cfg-line:last-child {
+  border-bottom: 0;
 }
 
-.cfg-row-main {
-  display: contents;
-}
-
-.cfg-row-main .t {
-  grid-column: 1;
-  grid-row: 1;
-  font-weight: 600;
+.cfg-line > label {
+  font-weight: 500;
   margin: 0;
 }
 
-.cfg-row-main .d {
-  grid-column: 1 / -1;
-  grid-row: 2;
-  font-size: 0.8125rem;
-  color: #6c757d;
-}
-
-.cfg-row-control {
-  grid-column: 2;
-  grid-row: 1;
-  justify-self: start;
+.cfg-line-ctl {
+  justify-self: end;
   display: flex;
   align-items: center;
   gap: 0.4rem;
 }
 
-.cfg-row-control .input-group {
+.cfg-line-ctl .input-group {
   width: auto;
   flex: none;
 }
 
-.cfg-row-control .input-group .form-control {
-  width: 4rem;
+.cfg-line-ctl .input-group .form-control {
+  width: 3.25rem;
   flex: 0 0 auto;
   text-align: right;
 }
 
-.cfg-row-control .form-switch {
+.cfg-line-ctl .form-switch {
   min-height: auto;
   margin: 0;
   padding-left: 0;
 }
 
-.cfg-row-control .form-switch .form-check-input {
+.cfg-line-ctl .form-switch .form-check-input {
   margin: 0;
   cursor: pointer;
+}
+
+.cfg-card-note {
+  max-width: 42ch;
+  margin: 0.85rem 0 0;
+  font-size: 0.8125rem;
+  color: #6c757d;
 }
 
 @media (max-width: 640px) {

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -2246,61 +2246,145 @@ overflow: hidden;
   color: #6c757d;
 }
 
-/* Data pane: settings + live "loading now" readout */
+/* Data pane: preset controls + live "loading now" readout */
 .cfg-data {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 19rem;
+  grid-template-columns: minmax(0, 1fr) 17rem;
   gap: 2.25rem;
   align-items: start;
-  max-width: 760px;
+  max-width: 880px;
 }
 
 .cfg-data-fields {
   display: flex;
   flex-direction: column;
-  gap: 1.4rem;
+  gap: 1.5rem;
   padding-top: 0.25rem;
 }
 
 .cfg-field > label {
   display: block;
   font-weight: 600;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.5rem;
 }
 
 .cfg-field .ctl {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-}
-
-.cfg-field .ctl .input-group {
-  width: auto;
-  flex: none;
-}
-
-.cfg-field .ctl .input-group .form-control {
-  width: 3.25rem;
-  flex: 0 0 auto;
-  text-align: right;
-}
-
-.cfg-field .ctl .form-switch {
-  min-height: auto;
-  margin: 0;
-  padding-left: 0;
-}
-
-.cfg-field .ctl .form-switch .form-check-input {
-  margin: 0;
-  cursor: pointer;
+  gap: 0.55rem;
 }
 
 .cfg-field .d {
   font-size: 0.8125rem;
   color: #6c757d;
-  margin-top: 0.35rem;
-  max-width: 34ch;
+  margin-top: 0.4rem;
+  max-width: 44ch;
+}
+
+/* preset row: segments / chips + numeric escape hatch */
+.cfg-preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.6rem;
+}
+
+.cfg-seg {
+  display: inline-flex;
+  flex-wrap: wrap;
+  border: 1px solid var(--bs-border-color, #ced4da);
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.cfg-seg-btn {
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: 0;
+  border-right: 1px solid var(--bs-border-color, #ced4da);
+  background: #fff;
+  color: #1b2430;
+  padding: 0.4rem 0.7rem;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+.cfg-seg-btn:last-child {
+  border-right: 0;
+}
+
+.cfg-seg-btn:hover {
+  background: #f1f3f5;
+}
+
+.cfg-seg-btn.active {
+  background: #0d6efd;
+  color: #fff;
+}
+
+.cfg-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.cfg-chip {
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: 1px solid #ced4da;
+  background: #fff;
+  color: #1b2430;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+.cfg-chip:hover {
+  border-color: #8a929c;
+}
+
+.cfg-chip.active {
+  background: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+.cfg-preset-or {
+  font-size: 0.75rem;
+  color: #8a929c;
+}
+
+.cfg-preset-num {
+  width: auto !important;
+  flex: none;
+}
+
+.cfg-preset-num .form-control {
+  width: 3.5rem;
+  flex: 0 0 auto;
+  text-align: right;
+}
+
+.cfg-live-pill {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+}
+
+.cfg-live-pill.on {
+  background: #e4f1ea;
+  color: #2f8f5b;
+}
+
+.cfg-live-pill.off {
+  background: #eef0f2;
+  color: #6c757d;
 }
 
 .cfg-readout {


### PR DESCRIPTION
> **Stacked on #432** (config modal reorg). Review/merge that first — this PR's diff will only make sense on top of it, and GitHub will retarget it to `master-dev` once #432 lands.

## What

An optional per-marker treatment that encodes each incident's job status into its map marker, driven by `config.showJobStatusOnMarkers` (**default on**):

- **Active** jobs get a magenta *marching ring* — a separate follower marker (dashed circle, compositor-only rotation, honours `prefers-reduced-motion`)
- **Complete / Referred / Finalised** are struck through; **Cancelled / Rejected** crossed out
- a red **"!"** corner dot marks any job carrying an action-required tag
- **New** keeps its orange pulse ring; **Tasked** is left unmarked

`Map.applyJobStatusOnMarkers` re-evaluates every existing marker when the toggle flips; `jobMarker.syncMarkerStyle` applies the per-status style on create/update. The map legend gains a status-key block, hidden until the toggle is on. The toggle lives in the **Map markers** tab of the config modal.

Also tightens `.legend-container` / `.legend-body` sizing so a long legend wraps into columns instead of sheeting across the map.

## Provenance

Squashed from the `wip/job-marker-status-pip` spike (3 WIP commits + a stashed default-on / wording tweak), restacked cleanly onto the config-modal reorg. `wip/job-marker-status-pip` is retained as-is as a backup.

## Testing

- `webpack --config webpack.dev.js` compiles
- `eslint` clean on `src/pages/tasking/`
- HTML tag balance unchanged

Not visually verified against the running app by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)