### PR TITLE
Config modal: Light / Dark / Auto theme

### DIFF
--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1153,9 +1153,9 @@ export function ConfigVM(root, deps) {
 
     self.showAdvanced = ko.observable(false);
 
-    // Theme: 'light' | 'dark' | 'auto'. 'auto' follows the OS/browser
-    // prefers-color-scheme and re-applies live when the user changes it.
-    self.darkModeMode = ko.observable('light');
+    // Theme: 'light' | 'dark' | 'auto'. 'auto' (the default) follows the
+    // OS/browser prefers-color-scheme and re-applies live when it changes.
+    self.darkModeMode = ko.observable('auto');
     const _darkMq = (typeof window !== 'undefined' && window.matchMedia)
         ? window.matchMedia('(prefers-color-scheme: dark)')
         : null;
@@ -1672,9 +1672,11 @@ export function ConfigVM(root, deps) {
         }
         if (cfg.darkModeMode === 'light' || cfg.darkModeMode === 'dark' || cfg.darkModeMode === 'auto') {
             self.darkModeMode(cfg.darkModeMode);
-        } else if (typeof cfg.darkMode === 'boolean') {
-            // migrate configs saved before the 3-way theme setting
-            self.darkModeMode(cfg.darkMode ? 'dark' : 'light');
+        } else if (cfg.darkMode === true) {
+            // configs saved before the 3-way setting: an explicit `true` was a
+            // deliberate choice -> keep them on Dark. `false` was just the old
+            // default, so let it fall through to 'auto'.
+            self.darkModeMode('dark');
         }
         self.layoutPreset(normalizeLayoutPreset(cfg.layoutPreset || localStorage.getItem('lh.layoutPreset')));
         if (typeof cfg.includeIncidentsWithoutSector === 'boolean') {

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -1152,7 +1152,37 @@ export function ConfigVM(root, deps) {
     self.pickLookaheadPreset = (p) => self.fetchForward(p.value);
 
     self.showAdvanced = ko.observable(false);
-    self.darkMode = ko.observable(false);
+
+    // Theme: 'light' | 'dark' | 'auto'. 'auto' follows the OS/browser
+    // prefers-color-scheme and re-applies live when the user changes it.
+    self.darkModeMode = ko.observable('light');
+    const _darkMq = (typeof window !== 'undefined' && window.matchMedia)
+        ? window.matchMedia('(prefers-color-scheme: dark)')
+        : null;
+    self.systemPrefersDark = ko.observable(!!(_darkMq && _darkMq.matches));
+    if (_darkMq) {
+        const _onSchemeChange = (e) => self.systemPrefersDark(!!e.matches);
+        if (_darkMq.addEventListener) _darkMq.addEventListener('change', _onSchemeChange);
+        else if (_darkMq.addListener) _darkMq.addListener(_onSchemeChange); // older Safari
+    }
+    // Effective boolean -- what the rest of the app reads. Reactive to both
+    // the chosen mode and (in 'auto') the live OS setting.
+    self.darkMode = ko.pureComputed(() => {
+        const m = self.darkModeMode();
+        return m === 'dark' || (m === 'auto' && self.systemPrefersDark());
+    });
+    self.themeModes = [
+        { value: 'light', label: 'Light' },
+        { value: 'dark', label: 'Dark' },
+        { value: 'auto', label: 'Auto' }
+    ];
+    self.pickThemeMode = (m) => self.darkModeMode(m.value);
+    self.themeHint = ko.pureComputed(() => {
+        if (self.darkModeMode() === 'auto') {
+            return `Follows your device's light / dark setting — currently ${self.darkMode() ? 'dark' : 'light'}.`;
+        }
+        return 'A low-glare dark colour scheme for the whole board and map.';
+    });
 
     self.layoutPresetDefs = [
         {
@@ -1236,7 +1266,6 @@ export function ConfigVM(root, deps) {
     self.taskingCountActiveOnly = ko.observable(false);
 
     // On/Off pill labels for the Appearance pane switches
-    self.darkModeLabel = ko.pureComputed(() => (self.darkMode() ? 'On' : 'Off'));
     self.alertsCollapseLabel = ko.pureComputed(() => (self.alertsCollapsibleRules() ? 'On' : 'Off'));
     self.taskingCountLabel = ko.pureComputed(() => (self.taskingCountActiveOnly() ? 'On' : 'Off'));
 
@@ -1287,11 +1316,7 @@ export function ConfigVM(root, deps) {
 
     // Dark mode helper (defined early so it can be called in afterConfigLoad)
     self._applyDarkMode = () => {
-        if (self.darkMode()) {
-            document.body.classList.add('dark-mode');
-        } else {
-            document.body.classList.remove('dark-mode');
-        }
+        document.body.classList.toggle('dark-mode', self.darkMode());
     };
 
 
@@ -1357,7 +1382,9 @@ export function ConfigVM(root, deps) {
         fetchPeriod: Number(self.fetchPeriod()),
         fetchForward: Number(self.fetchForward()),
         showAdvanced: !!self.showAdvanced(),
-        darkMode: !!self.darkMode(),
+        darkModeMode: self.darkModeMode(),
+        // kept so a config saved here still reads sensibly on an older build
+        darkMode: self.darkModeMode() === 'dark',
         layoutPreset: normalizeLayoutPreset(self.layoutPreset()),
         locationFilters: {
             teams: ko.toJS(self.teamFilters),
@@ -1643,8 +1670,11 @@ export function ConfigVM(root, deps) {
         if (typeof cfg.showAdvanced === 'boolean') {
             self.showAdvanced(cfg.showAdvanced);
         }
-        if (typeof cfg.darkMode === 'boolean') {
-            self.darkMode(cfg.darkMode);
+        if (cfg.darkModeMode === 'light' || cfg.darkModeMode === 'dark' || cfg.darkModeMode === 'auto') {
+            self.darkModeMode(cfg.darkModeMode);
+        } else if (typeof cfg.darkMode === 'boolean') {
+            // migrate configs saved before the 3-way theme setting
+            self.darkModeMode(cfg.darkMode ? 'dark' : 'light');
         }
         self.layoutPreset(normalizeLayoutPreset(cfg.layoutPreset || localStorage.getItem('lh.layoutPreset')));
         if (typeof cfg.includeIncidentsWithoutSector === 'boolean') {
@@ -1931,17 +1961,17 @@ export function ConfigVM(root, deps) {
     self.normalTaskingWeight.subscribe(() => { self.save(); });
     self.suggestionUseRouting.subscribe(() => { self.save(); });
 
+    // Effective theme changed -- a mode switch, or the OS setting flipping
+    // while in 'auto'. Repaint; don't persist (the OS isn't ours to save).
     self.darkMode.subscribe((isDark) => {
         self._applyDarkMode();
-        
-        // Switch basemap when dark mode changes
         if (root.mapVM?.changeBasemap) {
-            const targetBasemap = isDark ? "DarkGray" : "Topographic";
-            root.mapVM.changeBasemap(targetBasemap);
+            root.mapVM.changeBasemap(isDark ? "DarkGray" : "Topographic");
         }
-        
-        self.save();
     });
+
+    // The user picked Light / Dark / Auto -- persist that choice.
+    self.darkModeMode.subscribe(() => self.save());
 
     self.layoutPreset.subscribe((preset) => {
         const normalized = normalizeLayoutPreset(preset);

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -3298,17 +3298,16 @@
                                     <div class="tab-pane fade" id="cfgPane-appearance" role="tabpanel" aria-labelledby="cfgTab-appearance" tabindex="0">
                                         <div class="cfg-data-fields cfg-fields-solo">
                                             <div class="cfg-field">
-                                                <label for="darkModeToggle">Dark mode</label>
-                                                <div class="ctl">
-                                                    <div class="form-check form-switch">
-                                                        <input class="form-check-input" type="checkbox" role="switch"
-                                                            id="darkModeToggle" data-bind="checked: config.darkMode">
+                                                <label>Theme</label>
+                                                <div class="cfg-preset-row">
+                                                    <div class="cfg-seg" data-bind="foreach: { data: config.themeModes, as: 'm' }">
+                                                        <button type="button" class="cfg-seg-btn"
+                                                            data-bind="text: m.label,
+                                                                       css: { active: $root.config.darkModeMode() === m.value },
+                                                                       click: $root.config.pickThemeMode"></button>
                                                     </div>
-                                                    <span class="cfg-live-pill"
-                                                        data-bind="text: config.darkModeLabel,
-                                                                   css: { on: config.darkMode(), off: !config.darkMode() }"></span>
                                                 </div>
-                                                <div class="d">Reduces eye strain on overnight LHQ shifts.</div>
+                                                <div class="d" data-bind="text: config.themeHint"></div>
                                             </div>
                                             <div class="cfg-field">
                                                 <label for="alertsCollapsibleRulesToggle">Auto-collapse alert popups</label>


### PR DESCRIPTION
## What

The Appearance tab's dark-mode switch becomes a **three-way Theme control** — Light · Dark · **Auto**, and **Auto is the default**.

**Auto** follows the device's `prefers-color-scheme` (OS appearance setting, or the browser's own theme) and re-applies **live** when it changes — e.g. macOS switching to dark at sunset flips LAD too, no reload.

## How it works

| | |
|---|---|
| **`darkModeMode`** (`'light' \| 'dark' \| 'auto'`) | the stored choice — binds to the segmented control. Constructor default `'auto'`. |
| **`darkMode`** | now a `pureComputed` of the *effective* boolean: `mode === 'dark' \|\| (mode === 'auto' && systemPrefersDark())`. Every existing `self.darkMode()` read (`_applyDarkMode`, basemap swap, `afterConfigLoad`) works unchanged. |
| **`systemPrefersDark`** | an observable fed by a `matchMedia('(prefers-color-scheme: dark)')` `change` listener (with the `addListener` fallback for old Safari) — makes Auto reactive |

- `body.dark-mode` toggle and the Topographic ↔ DarkGray basemap swap move behind the effective `darkMode` computed. Only a deliberate mode change calls `save()`.
- **No `darkmode.css` changes** — the `body.dark-mode` class mechanism (~1100 rules) is untouched.
- **No FOUC** — `<body>` is `opacity: 0` until bindings apply (`main.js` reveal), long after the theme class is set.

## Migration / rollout

- New installs: **Auto**.
- Configs saved before this: `darkModeMode` if present wins; otherwise an explicit **`darkMode: true` → Dark** (a deliberate choice worth keeping). `darkMode: false` was just the old constructor default, so those **fall through to Auto** — i.e. an existing user on a dark-set OS who never touched the setting will now see LAD in dark. They can pick "Light" once if they'd rather.
- `buildConfig` still writes a `darkMode` boolean (`mode === 'dark'`) so a config opened on an older build still behaves.

## Testing

- `webpack --config webpack.dev.js` compiles
- `eslint` clean on `Config.js`
- HTML tag balance unchanged

Not visually verified against the running app.

> ⚠️ #434 also edits the dark-mode help-text line (replaced here by `themeHint`) — whichever of #434 / #435 merges second needs a one-line fixup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)