### PR TITLE
Fix tasking map popup pan/zoom conflicts + add incident marker hover tooltip

### DIFF
--- a/src/pages/tasking/components/job_tooltip.js
+++ b/src/pages/tasking/components/job_tooltip.js
@@ -1,0 +1,33 @@
+import { fmtRelative } from '../utils/common.js';
+
+function escapeHtml(s) {
+    return String(s ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+/**
+ * Compact hover-tooltip content for a job/incident marker -- a quick
+ * "what is this" glance, not a substitute for the full popup. Kept to a
+ * handful of the most identifying fields on purpose: a tooltip that grows
+ * as tall as the popup defeats the point of having a lighter-weight hover.
+ */
+export function buildJobTooltipHtml(job) {
+    const id = job.identifierTrimmed?.() || job.identifier?.() || '';
+    const priority = job.priorityName?.() || '';
+    const status = job.statusName?.() || '';
+    const addr = job.addressDisplayOrGPS?.() || '';
+    const received = job.jobReceived?.() ? fmtRelative(new Date(job.jobReceived())) : '';
+
+    const titleBits = [id ? `#${id}` : null, priority || null].filter(Boolean).map(escapeHtml);
+    const metaBits = [status || null, received || null].filter(Boolean).map(escapeHtml);
+
+    return `
+        <div class="job-tooltip__title">${titleBits.join(' &middot; ')}</div>
+        ${addr ? `<div class="job-tooltip__addr">${escapeHtml(addr)}</div>` : ''}
+        ${metaBits.length ? `<div class="job-tooltip__meta">${metaBits.join(' &middot; ')}</div>` : ''}
+    `;
+}

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -1315,10 +1315,10 @@ function VM() {
                         // moving the map, and the two visibly fight (a
                         // camera move, then an abrupt extra snap).
                         map.once('moveend', () => m.openPopup());
-                        map.flyTo([lat, lng], 16, { animate: true, duration: 0.10 });
+                        map.flyTo([lat, lng], 16, { animate: true, duration: 0.5 });
                     } else {
                         // Doesn't exist yet -- nothing to open a popup on.
-                        map.flyTo([lat, lng], 16, { animate: true, duration: 0.10 });
+                        map.flyTo([lat, lng], 16, { animate: true, duration: 0.5 });
                     }
                 }
             },
@@ -1428,7 +1428,7 @@ function VM() {
                     // -- see the matching comment in flyToJob above.
                     const m = asset.marker;
                     if (m) map.once('moveend', () => m.openPopup());
-                    map.flyTo([lat, lng], 14, { animate: true, duration: 0.10 });
+                    map.flyTo([lat, lng], 14, { animate: true, duration: 0.5 });
                 }
             },
 

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -13,6 +13,7 @@ require('../lib/shared_chrome_code.js'); // side-effect
 import { showAlert } from './components/windowAlert.js';
 
 import { ResizeDividers } from './resize.js';
+import { initPopupAutoPan } from './utils/popupAutoPan.js';
 import { addOrUpdateJobMarker, removeJobMarker } from './markers/jobMarker.js';
 import { attachAssetMarker, detachAssetMarker } from './markers/assetMarker.js';
 import { attachUnmatchedAssetMarker, detachUnmatchedAssetMarker } from './markers/assetMarker.js';
@@ -264,6 +265,11 @@ const map = L.map('map', {
     // Faster debounce time while zooming
     wheelDebounceTime: 50
 }).setView([-33.8688, 151.2093], 11);
+
+// Keep popup auto-pan padding aware of whatever's actually docked in the
+// map's corners (alerts banners, zoom/measure tools, legend, ...) so
+// popups can't open underneath that floating chrome.
+initPopupAutoPan(map);
 
 
 installMapContextMenu({

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -1306,11 +1306,19 @@ function VM() {
                         cg.zoomToShowLayer(m, () => {
                             m.openPopup();
                         });
-                    } else {
+                    } else if (m) {
                         // Marker is on a standalone layer (rescueJobLayer,
-                        // unclusteredJobLayer) or doesn't exist yet – simple flyTo.
+                        // unclusteredJobLayer) – simple flyTo. Wait for it to
+                        // settle before opening the popup: opening it
+                        // immediately starts the popup's own autoPan
+                        // correction while the flyTo animation is still
+                        // moving the map, and the two visibly fight (a
+                        // camera move, then an abrupt extra snap).
+                        map.once('moveend', () => m.openPopup());
                         map.flyTo([lat, lng], 16, { animate: true, duration: 0.10 });
-                        m?.openPopup?.();
+                    } else {
+                        // Doesn't exist yet -- nothing to open a popup on.
+                        map.flyTo([lat, lng], 16, { animate: true, duration: 0.10 });
                     }
                 }
             },
@@ -1416,8 +1424,11 @@ function VM() {
                 const asset = assetOrEntry && assetOrEntry.asset ? assetOrEntry.asset : assetOrEntry;
                 const lat = asset.latitude(), lng = asset.longitude();
                 if (Number.isFinite(lat) && Number.isFinite(lng)) {
+                    // Wait for the flyTo to settle before opening the popup
+                    // -- see the matching comment in flyToJob above.
+                    const m = asset.marker;
+                    if (m) map.once('moveend', () => m.openPopup());
                     map.flyTo([lat, lng], 14, { animate: true, duration: 0.10 });
-                    asset.marker?.openPopup?.();
                 }
             },
 

--- a/src/pages/tasking/mapLayers/collabLayer.js
+++ b/src/pages/tasking/mapLayers/collabLayer.js
@@ -829,7 +829,10 @@ function openMarkerForm(vm, apiUrl, layerId, key, actorId, marker, latlng, getTo
         });
     });
 
-    const popup = L.popup({ minWidth: 220, maxWidth: 260, closeOnClick: false, autoPanPadding: [16, 16], pane: "pane-popup-top" })
+    // autoPan / autoPanPadding come from Popup.mergeOptions in
+    // utils/popupAutoPan.js, which keeps padding in sync with the map's
+    // corner controls (alerts banners, zoom tools, legend, ...).
+    const popup = L.popup({ minWidth: 220, maxWidth: 260, closeOnClick: false, pane: "pane-popup-top" })
         .setLatLng(latlng)
         .setContent(el)
         .openOn(vm.mapVM.map);

--- a/src/pages/tasking/markers/assetMarker.js
+++ b/src/pages/tasking/markers/assetMarker.js
@@ -84,9 +84,17 @@ export function attachAssetMarker(ko, map, viewModel, asset) {
       minWidth: 360,
       maxWidth: 360,
       maxHeight: 360,
-      // autoPan / autoPanPadding come from Popup.mergeOptions in
+      // Leaflet auto-pans synchronously the instant the popup opens --
+      // before its KO-unbound (pristine, near-empty) content is replaced
+      // with the real thing in bindPopupWithKO's openHandler. Starting
+      // with autoPan off and switching it on there, once real content is
+      // bound, means autoPan only ever runs once per open, against real
+      // content, instead of once against a placeholder and again a
+      // moment later against the real (usually much bigger) popup.
+      // autoPanPadding comes from Popup.mergeOptions in
       // utils/popupAutoPan.js, which keeps padding in sync with the map's
       // corner controls (alerts banners, zoom tools, legend, ...).
+      autoPan: false,
       pane: 'pane-popup-top',
     }).setContent(contentEl);
 
@@ -167,9 +175,8 @@ export function attachUnmatchedAssetMarker(ko, map, viewModel, asset) {
       minWidth: 360,
       maxWidth: 360,
       maxHeight: 360,
-      // autoPan / autoPanPadding come from Popup.mergeOptions in
-      // utils/popupAutoPan.js, which keeps padding in sync with the map's
-      // corner controls (alerts banners, zoom tools, legend, ...).
+      // See the matching comment on the matched-asset popup above.
+      autoPan: false,
       pane: 'pane-popup-top',
     }).setContent(contentEl);
 
@@ -233,12 +240,21 @@ function bindPopupWithKO(ko, marker, vm, asset, popupVm) {
       asset.matchingTeamsInView()?.length !== 0 && asset.matchingTeamsInView()[0].onPopupOpen();
     }
     popupVm.updatePopup?.();
+
+    // Real content is bound now -- turn autoPan on (it starts off, see
+    // the popup's own options) so the resulting pan is against the real
+    // content instead of the pristine placeholder Leaflet would
+    // otherwise have already panned for the instant the popup opened.
+    e.popup.options.autoPan = true;
     deferPopupUpdate(e.popup);
   };
 
   // Unbind after popup is fully closed for visual cleanliness
   const closeHandler = (e) => {
     const el = e.popup?.getContent();
+    // Turn autoPan back off for the next open -- see the popup's own
+    // options above for why.
+    if (e.popup) e.popup.options.autoPan = false;
     // Don't clear routes/crow-flies if the popup was closed as a
     // side-effect of a flyToBounds animation (e.g. spider collapse
     // from a zoom change after drawing a route).

--- a/src/pages/tasking/markers/assetMarker.js
+++ b/src/pages/tasking/markers/assetMarker.js
@@ -84,8 +84,9 @@ export function attachAssetMarker(ko, map, viewModel, asset) {
       minWidth: 360,
       maxWidth: 360,
       maxHeight: 360,
-      autoPan: true,
-      autoPanPadding: [16, 16],
+      // autoPan / autoPanPadding come from Popup.mergeOptions in
+      // utils/popupAutoPan.js, which keeps padding in sync with the map's
+      // corner controls (alerts banners, zoom tools, legend, ...).
       pane: 'pane-popup-top',
     }).setContent(contentEl);
 
@@ -166,8 +167,9 @@ export function attachUnmatchedAssetMarker(ko, map, viewModel, asset) {
       minWidth: 360,
       maxWidth: 360,
       maxHeight: 360,
-      autoPan: true,
-      autoPanPadding: [16, 16],
+      // autoPan / autoPanPadding come from Popup.mergeOptions in
+      // utils/popupAutoPan.js, which keeps padding in sync with the map's
+      // corner controls (alerts banners, zoom tools, legend, ...).
       pane: 'pane-popup-top',
     }).setContent(contentEl);
 

--- a/src/pages/tasking/markers/jobMarker.js
+++ b/src/pages/tasking/markers/jobMarker.js
@@ -7,6 +7,7 @@ import { statusHasRing } from '../utils/jobTypesToUI.js';
 
 
 import { makePopupNode, bindKoToPopup, unbindKoFromPopup, deferPopupUpdate } from '../utils/popup_dom_utils.js';
+import { popupPadding } from '../utils/popupAutoPan.js';
 
 
 export function addOrUpdateJobMarker(ko, map, vm, job) {
@@ -458,24 +459,39 @@ function wireKoForPopup(ko, marker, job, vm, popupVM) {
         popupVM.updatePopup?.();
         deferPopupUpdate(e.popup);
 
-        // Auto-widen: if the popup overflows the viewport, switch to 2-col
+        // Auto-widen: if the popup is too tall to fit, switch to 2-col.
+        // Decide single-col vs wide *before* panning the map for this
+        // open, and pan (via the single e.popup.update() at the end) only
+        // once that's settled -- toggling the class and calling
+        // popup.update() for both a "reset" measurement and again after
+        // widening each re-runs Leaflet's pan-to-fit, and two pan passes
+        // with two different container sizes can visibly fight each
+        // other (the map appears to pan to fit, then snap to a different,
+        // worse position a moment later). Measuring via scrollHeight
+        // (which reflects the class change immediately, no repaint/pan
+        // needed to read it) avoids that entirely.
         requestAnimationFrame(() => {
             const wrapper = e.popup.getElement();
             if (!wrapper) return;
             const jp = wrapper.querySelector('.job-popup');
             if (!jp) return;
-            // reset first so we measure single-col height
+
             jp.classList.remove('job-popup--wide');
+            const singleColHeight = jp.scrollHeight;
+
+            // Available height is the map's own visible height minus
+            // whatever's docked in its corners -- the same room autoPan
+            // itself has to work with (utils/popupAutoPan.js), not the
+            // raw browser window, which knows nothing about that chrome.
+            const mapRect = e.popup._map?.getContainer()?.getBoundingClientRect();
+            const available = mapRect
+                ? mapRect.height - popupPadding.topLeft.y - popupPadding.bottomRight.y
+                : window.innerHeight - 16;
+
+            if (singleColHeight > available) {
+                jp.classList.add('job-popup--wide');
+            }
             e.popup.update();
-            requestAnimationFrame(() => {
-                const rect = wrapper.getBoundingClientRect();
-                const overflows = rect.bottom > window.innerHeight - 8
-                               || rect.top < 8;
-                if (overflows) {
-                    jp.classList.add('job-popup--wide');
-                    e.popup.update();
-                }
-            });
         });
     });
     marker.on('popupclose', e => {

--- a/src/pages/tasking/markers/jobMarker.js
+++ b/src/pages/tasking/markers/jobMarker.js
@@ -35,6 +35,13 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
         minWidth: 380,
         maxWidth: 760,
         minHeight: 300,
+        // A job with many assigned teams can make this popup grow tall
+        // enough that it no longer fits between the top/bottom autoPan
+        // padding -- Leaflet's own pan-to-fit math can't satisfy both
+        // edges at once in that case and visibly snaps between them.
+        // Capping height (Leaflet adds internal scrolling automatically)
+        // keeps it always satisfiable.
+        maxHeight: 480,
         // autoPan / autoPanPadding come from Popup.mergeOptions in
         // utils/popupAutoPan.js, which keeps padding in sync with the
         // map's corner controls (alerts banners, zoom tools, legend, ...).

--- a/src/pages/tasking/markers/jobMarker.js
+++ b/src/pages/tasking/markers/jobMarker.js
@@ -8,6 +8,7 @@ import { statusHasRing } from '../utils/jobTypesToUI.js';
 
 import { makePopupNode, bindKoToPopup, unbindKoFromPopup, deferPopupUpdate } from '../utils/popup_dom_utils.js';
 import { popupPadding } from '../utils/popupAutoPan.js';
+import { buildJobTooltipHtml } from '../components/job_tooltip.js';
 
 
 export function addOrUpdateJobMarker(ko, map, vm, job) {
@@ -64,7 +65,9 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
     const marker = L.marker([lat, lng], {
         pane: 'pane-tippy-top',
         icon: makeShapeIcon(style),
-        title: job.identifier?.()
+        // No native `title` here -- it would show the browser's own plain-
+        // text hover tooltip on top of (or racing) the richer one bound in
+        // wireJobTooltip() below, and the identifier already appears there.
     }).bindPopup(popup);
 
     if (markers.has(id)) {
@@ -159,6 +162,7 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
 
     const popupVM = vm.mapVM.makeJobPopupVM(job);
     wireKoForPopup(ko, marker, job, vm, popupVM);
+    wireJobTooltip(marker, job);
 
     // live priority updates — restyle icon when priority changes
     marker._prioritySub = job.jobPriorityType.subscribe(() => {
@@ -451,6 +455,38 @@ function safeMove(marker, job) {
 }
 
 
+
+/**
+ * A light, non-interactive hover tooltip -- a quick "what is this" glance,
+ * separate from the click-to-open popup and its autoPan machinery
+ * entirely. Leaflet tooltips never auto-pan the map (there's no such
+ * option on them), so this can't reintroduce any of the pan/snap issues
+ * the popup had -- it only ever shows/hides in place.
+ *
+ * Content is rebuilt fresh on every hover (bindTooltip's function form),
+ * so it can't go stale between opens the way a KO-bound popup can.
+ */
+function wireJobTooltip(marker, job) {
+    marker.bindTooltip(() => buildJobTooltipHtml(job), {
+        direction: 'top',
+        offset: [0, -12],
+        opacity: 0.96,
+        className: 'job-tooltip',
+        // Same pane as the popup -- guarantees the tooltip always renders
+        // above every marker/overlay layer, never Leaflet's default
+        // tooltip pane, which sits below some of this map's own panes.
+        pane: 'pane-popup-top',
+    });
+
+    // Don't show the hover tooltip while the popup for the same marker is
+    // already open -- redundant, and it can visually overlap the popup.
+    // Checking on 'tooltipopen' (rather than just closing it once when the
+    // popup opens) also covers the mouse leaving and coming back while the
+    // popup is still open, which would otherwise reopen the tooltip.
+    marker.on('tooltipopen', () => {
+        if (marker.isPopupOpen()) marker.closeTooltip();
+    });
+}
 
 function wireKoForPopup(ko, marker, job, vm, popupVM) {
     if (marker._koWired) return;

--- a/src/pages/tasking/markers/jobMarker.js
+++ b/src/pages/tasking/markers/jobMarker.js
@@ -43,9 +43,20 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
         // Capping height (Leaflet adds internal scrolling automatically)
         // keeps it always satisfiable.
         maxHeight: 480,
-        // autoPan / autoPanPadding come from Popup.mergeOptions in
+        // Leaflet auto-pans synchronously the instant a popup opens --
+        // before 'popupopen' below ever runs, so before this popup's
+        // pristine, KO-unbound content (an empty team table) is replaced
+        // with the real thing. That first pan is against a tiny
+        // placeholder, then a frame later the real, much taller content
+        // is bound and panned for again -- two visible camera moves for
+        // one click. Starting with autoPan off and switching it on right
+        // before the one deliberate update() call in 'popupopen' (once
+        // real content and the wide/narrow decision have settled) makes
+        // sure autoPan only ever runs once, against final content.
+        // autoPanPadding comes from Popup.mergeOptions in
         // utils/popupAutoPan.js, which keeps padding in sync with the
         // map's corner controls (alerts banners, zoom tools, legend, ...).
+        autoPan: false,
         pane: 'pane-popup-top'
     }).setContent(contentEl);
 
@@ -491,11 +502,22 @@ function wireKoForPopup(ko, marker, job, vm, popupVM) {
             if (singleColHeight > available) {
                 jp.classList.add('job-popup--wide');
             }
+            // Real content is bound and the final single/wide layout is
+            // decided -- turn autoPan on now (it starts off, see the
+            // popup's own options above) so this is the one and only pan
+            // for this open.
+            e.popup.options.autoPan = true;
             e.popup.update();
         });
     });
     marker.on('popupclose', e => {
         const el = e.popup.getContent();
+        // Turn autoPan back off for the next open -- it's switched on
+        // above once real content settles, and content gets reset back to
+        // its pristine (unbound) state on every open via bindKoToPopup, so
+        // leaving autoPan on here would let the premature pan-against-
+        // pristine-content bug happen again on the very next open.
+        e.popup.options.autoPan = false;
         // Defer unbinding to after the close animation completes. Tracked
         // on the marker so a fast reopen (see 'popupopen' above) can cancel
         // it -- otherwise this fires after the reopen and tears down a

--- a/src/pages/tasking/markers/jobMarker.js
+++ b/src/pages/tasking/markers/jobMarker.js
@@ -35,8 +35,9 @@ export function addOrUpdateJobMarker(ko, map, vm, job) {
         minWidth: 380,
         maxWidth: 760,
         minHeight: 300,
-        autoPan: true,
-        autoPanPadding: [16, 16],
+        // autoPan / autoPanPadding come from Popup.mergeOptions in
+        // utils/popupAutoPan.js, which keeps padding in sync with the
+        // map's corner controls (alerts banners, zoom tools, legend, ...).
         pane: 'pane-popup-top'
     }).setContent(contentEl);
 

--- a/src/pages/tasking/utils/popupAutoPan.js
+++ b/src/pages/tasking/utils/popupAutoPan.js
@@ -1,0 +1,82 @@
+import L from 'leaflet';
+
+// Floor for the padding on each edge -- matches the old hardcoded
+// `autoPanPadding: [16, 16]` that every popup used to set individually.
+const MIN_PADDING = 16;
+// Small breathing room beyond the edge of whatever control is docked there,
+// so a re-panned popup doesn't sit flush against it.
+const EXTRA_MARGIN = 8;
+
+/**
+ * Keeps popup auto-pan padding in sync with whatever Leaflet corner
+ * controls are actually on screen -- the alerts banner stack (topright),
+ * zoom/measure/search tools (topleft), the legend (bottomleft),
+ * attribution (bottomright), etc.
+ *
+ * Without this, `autoPan` only keeps a popup inside the map's pixel
+ * bounds; it has no idea those controls are floating on top of the map,
+ * so a popup can be "in bounds" and still open underneath them.
+ *
+ * This works by installing a pair of shared, mutable L.Point instances as
+ * the *default* autoPan padding for every L.Popup (via Popup.mergeOptions)
+ * and keeping them updated from the real, live-measured size of each
+ * corner. Leaflet re-reads these point objects (by reference) every time
+ * it pans a popup into view, so individual bindPopup()/L.popup() call
+ * sites don't need to know about any of this -- they just need to not set
+ * their own autoPanPaddingTopLeft/BottomRight (or autoPanPadding, which
+ * takes precedence if present).
+ *
+ * Call once, right after the map is created.
+ */
+export function initPopupAutoPan(map) {
+    const topLeft = L.point(MIN_PADDING, MIN_PADDING);
+    const bottomRight = L.point(MIN_PADDING, MIN_PADDING);
+
+    L.Popup.mergeOptions({
+        autoPan: true,
+        autoPanPaddingTopLeft: topLeft,
+        autoPanPaddingBottomRight: bottomRight,
+    });
+
+    const container = map.getContainer();
+
+    function recompute() {
+        const mapRect = container.getBoundingClientRect();
+        let left = MIN_PADDING, top = MIN_PADDING, right = MIN_PADDING, bottom = MIN_PADDING;
+
+        container.querySelectorAll('.leaflet-top, .leaflet-bottom').forEach((corner) => {
+            const rect = corner.getBoundingClientRect();
+            if (rect.width === 0 || rect.height === 0) return; // nothing docked in this corner
+
+            if (corner.classList.contains('leaflet-top')) {
+                top = Math.max(top, rect.bottom - mapRect.top + EXTRA_MARGIN);
+            } else {
+                bottom = Math.max(bottom, mapRect.bottom - rect.top + EXTRA_MARGIN);
+            }
+            if (corner.classList.contains('leaflet-left')) {
+                left = Math.max(left, rect.right - mapRect.left + EXTRA_MARGIN);
+            } else {
+                right = Math.max(right, mapRect.right - rect.left + EXTRA_MARGIN);
+            }
+        });
+
+        topLeft.x = left;
+        topLeft.y = top;
+        bottomRight.x = right;
+        bottomRight.y = bottom;
+    }
+
+    recompute();
+
+    // Corner containers resize whenever a control is added/removed, the
+    // alerts banner stack grows/shrinks, or a control collapses/expands --
+    // a ResizeObserver on the four corner divs catches all of that without
+    // polling.
+    if (typeof ResizeObserver !== 'undefined') {
+        const ro = new ResizeObserver(recompute);
+        container.querySelectorAll('.leaflet-top, .leaflet-bottom').forEach((corner) => ro.observe(corner));
+    }
+    window.addEventListener('resize', recompute);
+
+    return { topLeft, bottomRight, recompute };
+}

--- a/src/pages/tasking/utils/popupAutoPan.js
+++ b/src/pages/tasking/utils/popupAutoPan.js
@@ -6,6 +6,14 @@ const MIN_PADDING = 16;
 // Small breathing room beyond the edge of whatever control is docked there,
 // so a re-panned popup doesn't sit flush against it.
 const EXTRA_MARGIN = 8;
+// Cap how much of the map's own width/height the corner controls are
+// allowed to claim as padding, on each axis. Leaflet's autoPan can't
+// satisfy both the top and bottom (or left and right) padding at once if
+// together they leave no room for the popup -- it just snaps between
+// them, cutting the popup off. Keeping a comfortable share of the
+// viewport free of padding, no matter how much chrome piles into the
+// corners, keeps that always satisfiable.
+const MAX_PADDING_SHARE = 0.35;
 
 /**
  * Keeps popup auto-pan padding in sync with whatever Leaflet corner
@@ -60,10 +68,13 @@ export function initPopupAutoPan(map) {
             }
         });
 
-        topLeft.x = left;
-        topLeft.y = top;
-        bottomRight.x = right;
-        bottomRight.y = bottom;
+        const maxVertical = mapRect.height * MAX_PADDING_SHARE;
+        const maxHorizontal = mapRect.width * MAX_PADDING_SHARE;
+
+        topLeft.x = Math.min(left, maxHorizontal);
+        topLeft.y = Math.min(top, maxVertical);
+        bottomRight.x = Math.min(right, maxHorizontal);
+        bottomRight.y = Math.min(bottom, maxVertical);
     }
 
     recompute();

--- a/src/pages/tasking/utils/popupAutoPan.js
+++ b/src/pages/tasking/utils/popupAutoPan.js
@@ -16,6 +16,18 @@ const EXTRA_MARGIN = 8;
 const MAX_PADDING_SHARE = 0.35;
 
 /**
+ * Shared, mutable autoPan padding, kept in sync with whatever's docked in
+ * the map's corners (see initPopupAutoPan below). Exported so other code
+ * that needs to reason about how much of the map is actually free -- e.g.
+ * jobMarker's popup-widen decision -- reads the same numbers autoPan
+ * itself uses, instead of a separate, disagreeing guess.
+ */
+export const popupPadding = {
+    topLeft: L.point(MIN_PADDING, MIN_PADDING),
+    bottomRight: L.point(MIN_PADDING, MIN_PADDING),
+};
+
+/**
  * Keeps popup auto-pan padding in sync with whatever Leaflet corner
  * controls are actually on screen -- the alerts banner stack (topright),
  * zoom/measure/search tools (topleft), the legend (bottomleft),
@@ -25,20 +37,19 @@ const MAX_PADDING_SHARE = 0.35;
  * bounds; it has no idea those controls are floating on top of the map,
  * so a popup can be "in bounds" and still open underneath them.
  *
- * This works by installing a pair of shared, mutable L.Point instances as
- * the *default* autoPan padding for every L.Popup (via Popup.mergeOptions)
- * and keeping them updated from the real, live-measured size of each
- * corner. Leaflet re-reads these point objects (by reference) every time
- * it pans a popup into view, so individual bindPopup()/L.popup() call
- * sites don't need to know about any of this -- they just need to not set
- * their own autoPanPaddingTopLeft/BottomRight (or autoPanPadding, which
- * takes precedence if present).
+ * This works by installing `popupPadding`'s two points as the *default*
+ * autoPan padding for every L.Popup (via Popup.mergeOptions) and keeping
+ * them updated from the real, live-measured size of each corner. Leaflet
+ * re-reads these point objects (by reference) every time it pans a popup
+ * into view, so individual bindPopup()/L.popup() call sites don't need to
+ * know about any of this -- they just need to not set their own
+ * autoPanPaddingTopLeft/BottomRight (or autoPanPadding, which takes
+ * precedence if present).
  *
  * Call once, right after the map is created.
  */
 export function initPopupAutoPan(map) {
-    const topLeft = L.point(MIN_PADDING, MIN_PADDING);
-    const bottomRight = L.point(MIN_PADDING, MIN_PADDING);
+    const { topLeft, bottomRight } = popupPadding;
 
     L.Popup.mergeOptions({
         autoPan: true,

--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -560,6 +560,24 @@ body.dark-mode .leaflet-popup-tip {
   background-color: #2d2d2d;
 }
 
+body.dark-mode .leaflet-tooltip.job-tooltip {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
+}
+/* Only the "top" arrow exists -- wireJobTooltip() always opens this
+   tooltip with direction: 'top'. */
+body.dark-mode .leaflet-tooltip.job-tooltip.leaflet-tooltip-top:before {
+  border-top-color: #2d2d2d;
+}
+body.dark-mode .job-tooltip__addr {
+  color: #cfcfcf;
+}
+body.dark-mode .job-tooltip__meta {
+  color: #9a9a9a;
+}
+
 body.dark-mode .leaflet-control {
   background-color: transparent !important;
   border-color: transparent !important;

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -392,6 +392,11 @@ body.sidebar-collapsed .vsplit {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
   font-size: 12px;
   line-height: 1.35;
+  /* max-width alone leaves the actual width to the browser's shrink-to-fit
+     guess for this absolutely-positioned box, which can land far smaller
+     than the content needs (near one-word-per-line). min-width floors it
+     to something legible regardless; max-width still caps long content. */
+  min-width: 190px;
   max-width: 240px;
   white-space: normal;
 }

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -381,6 +381,33 @@ body.sidebar-collapsed .vsplit {
   opacity: 1;
 }
 
+/* Job/incident marker hover tooltip -- a quick glance, not a popup.
+   Non-interactive (Leaflet tooltips default to pointer-events: none), so
+   it can never intercept a click meant for the marker underneath, and it
+   never auto-pans the map -- see wireJobTooltip() in markers/jobMarker.js. */
+.leaflet-tooltip.job-tooltip {
+  padding: 6px 10px;
+  border-radius: 6px;
+  border-color: rgba(0, 0, 0, 0.12);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  font-size: 12px;
+  line-height: 1.35;
+  max-width: 240px;
+  white-space: normal;
+}
+.job-tooltip__title {
+  font-weight: 600;
+}
+.job-tooltip__addr {
+  color: #444444;
+  margin-top: 2px;
+}
+.job-tooltip__meta {
+  color: #6b6b6b;
+  font-size: 11px;
+  margin-top: 2px;
+}
+
 .pane--bottom {
   flex-grow: 1;
   flex-shrink: 1;


### PR DESCRIPTION
## Summary

Fixes map popups on the tasking page opening underneath floating chrome (alerts banners, zoom/measure tools, legend), and several distinct pan/zoom conflicts uncovered along the way. Also adds a hover tooltip on incident/job markers.

## Changes

- **Corner-aware popup auto-pan padding** (`utils/popupAutoPan.js`): popups now keep clear of whatever's actually docked in the map's corners, measured live via `ResizeObserver`, instead of a flat 16px padding that had no idea that chrome existed.
- **Job popup height cap**: `maxHeight: 480` (with Leaflet's automatic scrolling) plus a 35%-of-viewport clamp on the corner padding, guarding against Leaflet's pan-to-fit math being unable to satisfy both top and bottom padding for an unusually tall popup.
- **Job popup auto-widen fix**: the single/2-column layout decision now happens once via `scrollHeight`, then pans exactly once — previously it reset, panned, remeasured post-pan, and could pan again, producing two visibly conflicting camera moves.
- **`flyToJob` / `flyToAsset` sequencing**: opening an incident or asset from a list/alert banner now waits for the fly animation to settle (`moveend`) before opening the popup, instead of starting the popup's own pan while the fly was still moving the map. Fly duration restored from 100ms to 500ms now that there's no longer a competing animation to rush past.
- **Root cause of the double-pan on marker click**: Leaflet auto-pans a popup synchronously the instant it opens, before content is bound — so it was panning for an almost-empty placeholder, then panning again a frame later once real (Knockout-bound) content landed. Job and asset popups now start with `autoPan: false` and switch it on only after real content is bound, so there's exactly one pan per open.
- **Hover tooltip for incident/job markers**: a compact, non-interactive glance (identifier, priority, address, status, time received) built on Leaflet's plain tooltip, which has no autoPan option and so can't reintroduce any of the above. Suppressed while the marker's popup is open; replaces the marker's native `title` attribute, which would have shown a competing browser tooltip.

## Testing

- `npm run lint` clean on every touched file.
- `webpack --config webpack.dev.js` builds successfully after each change.
- Not yet click-tested against live data in a running app (no browser automation used per project constraints) — recommend a pass over: clicking a job marker directly, clicking an asset/team marker directly, opening an incident from an alert banner list, and a job with enough assigned teams to trigger the 2-column popup layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
