### PR TITLE
Add job type to incident marker hover tooltip

### DIFF
--- a/src/pages/tasking/components/job_tooltip.js
+++ b/src/pages/tasking/components/job_tooltip.js
@@ -18,11 +18,12 @@ function escapeHtml(s) {
 export function buildJobTooltipHtml(job) {
     const id = job.identifierTrimmed?.() || job.identifier?.() || '';
     const priority = job.priorityName?.() || '';
+    const type = job.typeName?.() || '';
     const status = job.statusName?.() || '';
     const addr = job.addressDisplayOrGPS?.() || '';
     const received = job.jobReceived?.() ? fmtRelative(new Date(job.jobReceived())) : '';
 
-    const titleBits = [id ? `#${id}` : null, priority || null].filter(Boolean).map(escapeHtml);
+    const titleBits = [id ? `#${id}` : null, priority || null, type || null].filter(Boolean).map(escapeHtml);
     const metaBits = [status || null, received || null].filter(Boolean).map(escapeHtml);
 
     return `


### PR DESCRIPTION
## Summary

Adds job type to the incident/job marker hover tooltip added in #437, shown in the title line alongside the identifier and priority (e.g. `#5644 · General · FR`) — matching the `typeName - statusName` pairing the full job popup already uses.

(This was briefly pushed directly to `master-dev` by mistake and has been reverted there — see `5f758e0` — this PR is the proper redo.)

## Testing

- `npm run lint` clean.
- `webpack --config webpack.dev.js` builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
