### PR TITLE
Use typeShort in incident marker hover tooltip

### DIFF
--- a/src/pages/tasking/components/job_tooltip.js
+++ b/src/pages/tasking/components/job_tooltip.js
@@ -18,7 +18,10 @@ function escapeHtml(s) {
 export function buildJobTooltipHtml(job) {
     const id = job.identifierTrimmed?.() || job.identifier?.() || '';
     const priority = job.priorityName?.() || '';
-    const type = job.typeName?.() || '';
+    // Matches the "type + category" combo used elsewhere (e.g. the SMS
+    // prefill in main.js) -- categoriesNameNumberDash already carries its
+    // own leading dash (e.g. "-1", "-Orange"), so no separator is added.
+    const type = (job.typeShort?.() || '') + (job.categoriesNameNumberDash?.() || '');
     const status = job.statusName?.() || '';
     const addr = job.addressDisplayOrGPS?.() || '';
     const received = job.jobReceived?.() ? fmtRelative(new Date(job.jobReceived())) : '';


### PR DESCRIPTION
## Summary

Swaps `typeName` for `typeShort` in the incident marker hover tooltip added in #437/#438. `typeShort` is the field the rest of the tasking UI already uses for compact display (`job.type()` with "Evacuation" abbreviated to "Evac"), a better fit for a tooltip that's meant to stay small.

## Testing

- `npm run lint` clean.
- `webpack --config webpack.dev.js` builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
