### PR TITLE
Widen job hover tooltip to fit its title text

### DIFF
--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -396,8 +396,8 @@ body.sidebar-collapsed .vsplit {
      guess for this absolutely-positioned box, which can land far smaller
      than the content needs (near one-word-per-line). min-width floors it
      to something legible regardless; max-width still caps long content. */
-  min-width: 190px;
-  max-width: 240px;
+  min-width: 220px;
+  max-width: 280px;
   white-space: normal;
 }
 .job-tooltip__title {


### PR DESCRIPTION
## Summary

Widens the job/incident marker hover tooltip from 190–240px to 220–280px. The title line can now carry three or four segments (identifier, priority, type + category from #439), and the narrower box was wrapping mid-phrase.

## Testing

- `webpack --config webpack.dev.js` builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
