### PR TITLE
Remove misleading "ago" time from job hover tooltip

### DIFF
--- a/src/pages/tasking/components/job_tooltip.js
+++ b/src/pages/tasking/components/job_tooltip.js
@@ -1,5 +1,3 @@
-import { fmtRelative } from '../utils/common.js';
-
 function escapeHtml(s) {
     return String(s ?? '')
         .replace(/&/g, '&amp;')
@@ -24,10 +22,9 @@ export function buildJobTooltipHtml(job) {
     const type = (job.typeShort?.() || '') + (job.categoriesNameNumberDash?.() || '');
     const status = job.statusName?.() || '';
     const addr = job.addressDisplayOrGPS?.() || '';
-    const received = job.jobReceived?.() ? fmtRelative(new Date(job.jobReceived())) : '';
 
     const titleBits = [id ? `#${id}` : null, priority || null, type || null].filter(Boolean).map(escapeHtml);
-    const metaBits = [status || null, received || null].filter(Boolean).map(escapeHtml);
+    const metaBits = [status || null].filter(Boolean).map(escapeHtml);
 
     return `
         <div class="job-tooltip__title">${titleBits.join(' &middot; ')}</div>


### PR DESCRIPTION
## Summary

Removes the "X ago" time from the job/incident marker hover tooltip's meta line. It was showing `job.jobReceived` (the incident's original received time), sitting right next to status, which reads as if it's the time of the status change but isn't — no such timestamp exists on the job model or from the API (checked in a prior conversation). Meta line is just status now.

## Testing

- `npm run lint` clean.
- `webpack --config webpack.dev.js` builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
