### PR TITLE
Show assigned unit in job hover tooltip

### DIFF
--- a/src/pages/tasking/components/job_tooltip.js
+++ b/src/pages/tasking/components/job_tooltip.js
@@ -25,9 +25,12 @@ export function buildJobTooltipHtml(job) {
     const status = job.statusName?.() || '';
     const addr = job.addressDisplayOrGPS?.() || '';
     const received = job.jobReceived?.() ? fmtRelative(new Date(job.jobReceived())) : '';
+    // Matches the popup's own footer (job_popup.js), which shows
+    // entityAssignedTo.name for the same field.
+    const unit = job.entityAssignedTo?.name?.() || job.entityAssignedTo?.code?.() || '';
 
     const titleBits = [id ? `#${id}` : null, priority || null, type || null].filter(Boolean).map(escapeHtml);
-    const metaBits = [status || null, received || null].filter(Boolean).map(escapeHtml);
+    const metaBits = [status || null, received || null, unit || null].filter(Boolean).map(escapeHtml);
 
     return `
         <div class="job-tooltip__title">${titleBits.join(' &middot; ')}</div>


### PR DESCRIPTION
## Summary

Adds the assigned unit to the job/incident marker hover tooltip's meta line — `entityAssignedTo.name` (falling back to `.code()`), matching how the full job popup's own footer already displays this exact field.

Branched off `master-dev` independently of #441 (removes the "ago" time from the same meta line) — both touch the same array but not the same lines, so they should merge cleanly in either order.

## Testing

- `npm run lint` clean.
- `webpack --config webpack.dev.js` builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
