### PR TITLE
Job hover tooltip: drop "ago" time, add assigned unit

### DIFF
--- a/src/pages/tasking/components/job_tooltip.js
+++ b/src/pages/tasking/components/job_tooltip.js
@@ -1,5 +1,3 @@
-import { fmtRelative } from '../utils/common.js';
-
 function escapeHtml(s) {
     return String(s ?? '')
         .replace(/&/g, '&amp;')
@@ -24,10 +22,12 @@ export function buildJobTooltipHtml(job) {
     const type = (job.typeShort?.() || '') + (job.categoriesNameNumberDash?.() || '');
     const status = job.statusName?.() || '';
     const addr = job.addressDisplayOrGPS?.() || '';
-    const received = job.jobReceived?.() ? fmtRelative(new Date(job.jobReceived())) : '';
+    // Matches the popup's own footer (job_popup.js), which shows
+    // entityAssignedTo.name for the same field.
+    const unit = job.entityAssignedTo?.name?.() || job.entityAssignedTo?.code?.() || '';
 
     const titleBits = [id ? `#${id}` : null, priority || null, type || null].filter(Boolean).map(escapeHtml);
-    const metaBits = [status || null, received || null].filter(Boolean).map(escapeHtml);
+    const metaBits = [status || null, unit || null].filter(Boolean).map(escapeHtml);
 
     return `
         <div class="job-tooltip__title">${titleBits.join(' &middot; ')}</div>


### PR DESCRIPTION
## Summary

Two job/incident marker hover tooltip meta-line changes, combined into one PR (supersedes #441 and #442, both closed in favour of this):

- Removes the "X ago" time (`job.jobReceived`'s relative time), which sat next to status and read as if it were the time of the status change — no such timestamp exists on the job model or from the API.
- Adds the assigned unit (`entityAssignedTo.name`, falling back to `.code()`) in its place, matching how the full job popup's own footer already displays this exact field.

## Testing

- `npm run lint` clean.
- `webpack --config webpack.dev.js` builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
