### PR TITLE
Run Linter workflow on PRs to any branch, add build step

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,8 +1,6 @@
 name: Linter
-on: 
+on:
   pull_request:
-    branches:
-      - master
 jobs:
   lint:
     name: Lint Code Base
@@ -16,3 +14,5 @@ jobs:
         run: npm install
       - name: Lint
         run: npm run lint
+      - name: Build
+        run: npm run dev


### PR DESCRIPTION
## Summary
- The Linter workflow only triggered on PRs targeting `master`, but nearly all PRs target `master-dev`, so it was effectively never running on real PRs.
- Added a build step (`npm run dev`) so a PR that breaks webpack compilation is caught in CI, not just at manual dev/prod publish time.

## Test plan
- [x] Verified `npm run lint` still passes locally (exit 0)
- [x] Verified `npm run lint` correctly flags a deliberately introduced error (tested and reverted)
- [x] Verified `npm run dev` builds successfully locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)