### PR TITLE
Tasking: fix Assigned Sector dropdown (unassign, refresh, empty state)

### DIFF
--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -4076,11 +4076,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
         // Refresh the sector list whenever a per-incident "Assigned Sector"
         // dropdown opens. Delegated on document so it covers every job card
-        // without a per-element binding; Bootstrap's show.bs.dropdown fires
-        // on the .dropdown container and bubbles here.
+        // without a per-element binding. Bootstrap 5 fires show.bs.dropdown
+        // on the toggle *button*, which bubbles to document — walk up to the
+        // enclosing .dropdown and check it's a sector one.
         document.addEventListener('show.bs.dropdown', function (e) {
-            const el = e.target;
-            if (el && el.querySelector && el.querySelector('.sectorDropdown')) {
+            const scope = e.target && e.target.closest && e.target.closest('.dropdown');
+            if (scope && scope.querySelector('.sectorDropdown')) {
                 myViewModel.refreshSectorsForDropdown();
             }
         });

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -1532,6 +1532,35 @@ function VM() {
 
     };
 
+    // Explicit "unassign" action from the per-incident sector dropdown.
+    // sectorSelectorClick can only toggle a sector off if that sector is
+    // still in the fetched list; when the assigned sector belongs to an HQ
+    // that isn't in the current filters it won't be, so this gives a way
+    // out regardless.
+    self.sectorUnassignClick = function (_data, event) {
+        var ctx = ko.contextFor(event.currentTarget || event.target);
+        var jobCtx = ctx;
+        while (jobCtx && !jobCtx.j) {
+            jobCtx = jobCtx.$parentContext;
+        }
+        if (!jobCtx || !jobCtx.j) return;
+
+        var jobId = jobCtx.j.id();
+        if (!jobCtx.j.sector().id()) return;   // nothing assigned
+
+        self.unSetSectorForJob(jobId);
+        console.log("Unassigning sector from job", jobId);
+    };
+
+    // Refresh the sector list each time an "Assigned Sector" dropdown is
+    // opened, so sectors created since page load (or since the last HQ
+    // filter change) show up without a full reload.
+    self.refreshSectorsForDropdown = function () {
+        const ids = self.config._sectorHqIds();
+        if (!ids || ids.length === 0) return;   // no HQs selected — nothing to search
+        self.fetchAllSectors(ids);
+    };
+
     self.attachJobTimelineModal = function (job) {
         const modalEl = document.getElementById('jobTimelineModal');
         const modal = new bootstrap.Modal(modalEl);
@@ -4036,6 +4065,17 @@ document.addEventListener('DOMContentLoaded', function () {
         })();
 
         ko.applyBindings(myViewModel);
+
+        // Refresh the sector list whenever a per-incident "Assigned Sector"
+        // dropdown opens. Delegated on document so it covers every job card
+        // without a per-element binding; Bootstrap's show.bs.dropdown fires
+        // on the .dropdown container and bubbles here.
+        document.addEventListener('show.bs.dropdown', function (e) {
+            const el = e.target;
+            if (el && el.querySelector && el.querySelector('.sectorDropdown')) {
+                myViewModel.refreshSectorsForDropdown();
+            }
+        });
 
         // Alerts overlay
         installAlerts(map, myViewModel);

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -1266,6 +1266,14 @@ function VM() {
         try {
             await BeaconClient.sectors.unSetSector(job, beaconCtx(t));
             showAlert('Incident removed from sector successfully.', 'success', 3000);
+            // The job GET payload omits Sector entirely when none is
+            // assigned, so Job.updateFromJson can't distinguish "cleared"
+            // from "unchanged" and the stale sector sticks. Clear it
+            // locally, then let fetchJobById reconcile everything else.
+            const jobModel = self.jobsById.get(job);
+            if (jobModel && jobModel.sector().id()) {
+                jobModel.sector(new Sector({}));
+            }
             self.fetchJobById(job, null);
         } catch (err) {
             console.error(err);

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -1294,12 +1294,32 @@
                                                                                 <span class="caret"></span>
                                                                             </button>
                                                                             <ul class="dropdown-menu sectorDropdown">
+                                                                                <!-- ko if: j.sector().id() -->
+                                                                                <li>
+                                                                                    <button type="button"
+                                                                                        class="dropdown-item text-danger"
+                                                                                        data-bind="click: $root.sectorUnassignClick">
+                                                                                        Unassign sector
+                                                                                    </button>
+                                                                                </li>
+                                                                                <li><hr class="dropdown-divider"></li>
+                                                                                <!-- /ko -->
                                                                                 <!-- ko foreach: $root.sectors -->
                                                                                 <li>
                                                                                     <button type="button"
                                                                                         class="dropdown-item"
                                                                                         data-bind=" text: name, css: { active: id() == j.sector().id() }, click: $root.sectorSelectorClick">
                                                                                     </button>
+                                                                                </li>
+                                                                                <!-- /ko -->
+                                                                                <!-- ko if: $root.sectorsLoading() -->
+                                                                                <li>
+                                                                                    <span class="dropdown-item-text text-muted small">Loading sectors…</span>
+                                                                                </li>
+                                                                                <!-- /ko -->
+                                                                                <!-- ko if: !$root.sectorsLoading() && !$root.sectors().length -->
+                                                                                <li>
+                                                                                    <span class="dropdown-item-text text-muted small">No sectors available</span>
                                                                                 </li>
                                                                                 <!-- /ko -->
                                                                             </ul>


### PR DESCRIPTION
Stacked on `refactor/beaconclient-core`.

Fixes for the per-incident **Assigned Sector** dropdown in tasking.

## Changes

- **Unassign a sector.** Added an explicit "Unassign sector" item (shown only when a sector is assigned). Previously the only way to clear a sector was to re-click it in the list, which is impossible when the assigned sector belongs to an HQ outside the current filters — so it never appears in the list.
- **Clear actually sticks.** The job GET payload omits `Sector` entirely when none is assigned, so `Job.updateFromJson` couldn't tell "cleared" from "unchanged" and the stale sector remained on the card. Now cleared locally right after a successful `RemoveJobFromSector`, then reconciled by `fetchJobById`.
- **Refresh on open.** A delegated `show.bs.dropdown` listener refreshes the sector list (scope-aware HQ ids) each time an Assigned Sector dropdown opens, so sectors created since page load show up.
- **Empty / loading states.** The menu now shows "Loading sectors…" while fetching and "No sectors available" when nothing comes back.

## Testing

- `npm run lint` passes.
- Not verified in a running app — no browser automation available here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)