### PR TITLE
Tasking: widen the call-off reason popup

### DIFF
--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -3792,6 +3792,41 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     });
 
+    // The team status dropdown swaps its short status list for a taller
+    // details/reason form once you pick an option. Popper places the menu
+    // when it opens and never learns that it later grew, so a menu that
+    // opened downward low on the screen used to spill off the bottom until
+    // the next open. Re-run Popper after the first paint (initial placement
+    // is occasionally computed before the menu is at full size) and again
+    // whenever the menu resizes, keeping it inside the viewport.
+    document.addEventListener('shown.bs.dropdown', (e) => {
+        const toggle = e.target;
+        if (!toggle.classList || !toggle.classList.contains('team-status-button')) return;
+
+        const scope = toggle.closest('.dropdown');
+        const menu = scope && scope.querySelector('.tasking-dropdown-menu');
+        const instance = bootstrap.Dropdown.getInstance(toggle);
+        if (!menu || !instance) return;
+
+        let pending = false;
+        const ro = new ResizeObserver(() => {
+            if (pending) return;
+            pending = true;
+            requestAnimationFrame(() => {
+                pending = false;
+                // closeStatusDropdown() just strips the .show class without a
+                // Bootstrap hide event, so bail out once the menu is detached.
+                if (!menu.isConnected || !toggle.isConnected) {
+                    ro.disconnect();
+                    return;
+                }
+                try { instance.update(); } catch (_) { /* popper already torn down */ }
+            });
+        });
+        ro.observe(menu);
+        toggle.addEventListener('hidden.bs.dropdown', () => ro.disconnect(), { once: true });
+    });
+
     //get tokens
     BeaconToken.fetchBeaconTokenAndKeepReturningValidTokens(
         apiHost,

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -1633,7 +1633,7 @@
                                                                                                     click: ts.onStatusDropdownToggleClick">
                                                                                         </button>
                                                                                         <div
-                                                                                            class="dropdown-menu team-tasking-dropdown-menu team-tasking-dropdown-menu--wide tasking-dropdown-menu p-2 shadow">
+                                                                                            class="dropdown-menu team-tasking-dropdown-menu tasking-dropdown-menu p-2 shadow">
                                                                                             <!-- ko if: ts.statusPageVisible -->
                                                                                             <div>
                                                                                                 <!-- ko if: ts.cannotUpdateStatus -->
@@ -1656,7 +1656,7 @@
                                                                                             <!-- /ko -->
 
                                                                                             <!-- ko if: detailsPageVisible -->
-                                                                                            <div>
+                                                                                            <div class="tasking-status-details-form">
 
                                                                                                 <!-- Time override toggle (only shown if system allows time setting) -->
                                                                                                 <!-- ko if: ts.needsTimeSet -->

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -1633,7 +1633,7 @@
                                                                                                     click: ts.onStatusDropdownToggleClick">
                                                                                         </button>
                                                                                         <div
-                                                                                            class="dropdown-menu team-tasking-dropdown-menu tasking-dropdown-menu p-2 shadow">
+                                                                                            class="dropdown-menu team-tasking-dropdown-menu team-tasking-dropdown-menu--wide tasking-dropdown-menu p-2 shadow">
                                                                                             <!-- ko if: ts.statusPageVisible -->
                                                                                             <div>
                                                                                                 <!-- ko if: ts.cannotUpdateStatus -->

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -525,6 +525,7 @@
                                                                                             type="button"
                                                                                             data-bs-toggle="dropdown"
                                                                                             data-bs-auto-close="outside"
+                                                                                            data-bs-boundary="viewport"
                                                                                             data-bind="text: ts.currentStatus,
                                                                                                     css: ts.tagColorFromStatus(),
                                                                                                     flashOnChange: ts.currentStatus,
@@ -1627,6 +1628,7 @@
                                                                                             type="button"
                                                                                             data-bs-toggle="dropdown"
                                                                                             data-bs-auto-close="outside"
+                                                                                            data-bs-boundary="viewport"
                                                                                             data-bind="text: ts.currentStatus,
                                                                                                     css: ts.tagColorFromStatus(),
                                                                                                     flashOnChange: ts.currentStatus,

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -186,17 +186,16 @@ body.env-devbeacon .incidents-header {
   z-index: 2000;
 }
 
-/* The team-tasking status dropdown doubles as a details/reason form on its
-   second page; Bootstrap's 10rem .dropdown-menu min-width squashes the
-   Call-off reason label and textarea. Widen it only in the job popup
-   (--wide) -- the teams list is tight on horizontal space and keeps the
-   default width. Double class beats Bootstrap's .dropdown-menu specificity. */
-.tasking-dropdown-menu.team-tasking-dropdown-menu--wide {
-  min-width: 340px;
-  max-width: min(420px, 90vw);
+/* The job-popup team-tasking status dropdown flips to a details/reason form
+   on its second page. The status-option list itself stays narrow; only the
+   form needs room so the Call-off reason label and textarea aren't crushed.
+   Widening this inner wrapper grows the (unconstrained) fixed menu with it. */
+.tasking-status-details-form {
+  min-width: 320px;
+  max-width: min(400px, 78vw);
 }
 
-.team-tasking-dropdown-menu--wide .col-form-label {
+.tasking-status-details-form .col-form-label {
   white-space: nowrap;
 }
 

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -187,10 +187,11 @@ body.env-devbeacon .incidents-header {
 }
 
 /* The team-tasking status dropdown doubles as a details/reason form on its
-   second page; Bootstrap's 10rem min-width squashes the Call-off reason
-   label and textarea. Widen it only in the job popup (--wide) -- the teams
-   list is tight on horizontal space and keeps the default width. */
-.team-tasking-dropdown-menu--wide {
+   second page; Bootstrap's 10rem .dropdown-menu min-width squashes the
+   Call-off reason label and textarea. Widen it only in the job popup
+   (--wide) -- the teams list is tight on horizontal space and keeps the
+   default width. Double class beats Bootstrap's .dropdown-menu specificity. */
+.tasking-dropdown-menu.team-tasking-dropdown-menu--wide {
   min-width: 340px;
   max-width: min(420px, 90vw);
 }

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -188,13 +188,14 @@ body.env-devbeacon .incidents-header {
 
 /* The team-tasking status dropdown doubles as a details/reason form on its
    second page; Bootstrap's 10rem min-width squashes the Call-off reason
-   label and textarea, so give it room to lay the form out. */
-.team-tasking-dropdown-menu {
+   label and textarea. Widen it only in the job popup (--wide) -- the teams
+   list is tight on horizontal space and keeps the default width. */
+.team-tasking-dropdown-menu--wide {
   min-width: 340px;
   max-width: min(420px, 90vw);
 }
 
-.team-tasking-dropdown-menu .col-form-label {
+.team-tasking-dropdown-menu--wide .col-form-label {
   white-space: nowrap;
 }
 

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -186,6 +186,18 @@ body.env-devbeacon .incidents-header {
   z-index: 2000;
 }
 
+/* The team-tasking status dropdown doubles as a details/reason form on its
+   second page; Bootstrap's 10rem min-width squashes the Call-off reason
+   label and textarea, so give it room to lay the form out. */
+.team-tasking-dropdown-menu {
+  min-width: 340px;
+  max-width: min(420px, 90vw);
+}
+
+.team-tasking-dropdown-menu .col-form-label {
+  white-space: nowrap;
+}
+
 /* Ensure key UI elements follow the smaller base size */
 button,
 input,


### PR DESCRIPTION
## What

Two issues with the team status pill dropdown in the job popup (expand a job → **Taskings**):

1. When it flips to the details / reason form on its second page (e.g. **Call off**), Bootstrap's default `.dropdown-menu` width crushed the **Reason** label ("Reaso / n") and textarea.
2. Popper positions the menu once when it opens (while it's the short status list) and never learns that picking an option swapped in the taller form — so a menu opened low on the screen spilled off the bottom of the page until the next open.

## Change (CSS + a wrapper class + a reposition hook)

- `.tasking-status-details-form` class on the details/reason page wrapper (job popup instance only): `min-width: 320px`, capped `min(400px, 78vw)`. The fixed, width-unconstrained menu grows to fit it. The status-option list and the teams-list dropdown are untouched.
- Form labels (Time / ETA / ETC / Reason) kept on one line.
- On open, a `ResizeObserver` on the menu calls the Bootstrap dropdown's `update()` (debounced to a frame) whenever it resizes, so Popper re-flips / re-shifts it into view when it grows. Also fires on the first frame, covering the occasional wrong initial placement.
- `data-bs-boundary="viewport"` so overflow is measured against the viewport.
- The observer self-disconnects if the menu is torn down via `closeStatusDropdown()` (which strips `.show` without a Bootstrap event).

Stacked on #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)