### PR TITLE
Tasking: offer "open in a new window" when there's no Beacon Remote tab

### DIFF
--- a/src/pages/tasking/components/windowAlert.js
+++ b/src/pages/tasking/components/windowAlert.js
@@ -15,12 +15,16 @@ export function showAlert(message, type = "primary", timeout = 4000) {
     $("#alerts-container").append(html);
 
     if (timeout > 0) {
-        setTimeout(() => {
-            const el = document.getElementById(id);
-            if (el) {
-                // Bootstrap 5 native JS API
-                Alert.getOrCreateInstance(el).close();
-            }
-        }, timeout);
+        setTimeout(() => closeAlert(id), timeout);
+    }
+
+    return id;
+}
+
+export function closeAlert(id) {
+    const el = document.getElementById(id);
+    if (el) {
+        // Bootstrap 5 native JS API
+        Alert.getOrCreateInstance(el).close();
     }
 }

--- a/src/pages/tasking/utils/chromeRunTime.js
+++ b/src/pages/tasking/utils/chromeRunTime.js
@@ -1,13 +1,41 @@
-import { showAlert } from '../components/windowAlert.js';
+import { showAlert, closeAlert } from '../components/windowAlert.js';
+
+function escapeHtml(str) {
+    return String(str).replace(/[&<>"']/g, (c) => ({
+        "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    })[c]);
+}
 
 export function openURLInBeacon(url) {
-chrome.runtime.sendMessage({ type: "tasking-openURL", url: url }, function (response) {
-            if (response && response.success) {
-                showAlert(response.message || `Request ${url} opened successfully in Beacon.`, "success", 2000);
-                console.log("Job opened successfully");
-            } else {
-                console.error("Failed to open job");
-                showAlert(response.message || `Failed to open request ${url} in Beacon.`, "warning", 4000);
-            }
-        });
+    chrome.runtime.sendMessage({ type: "tasking-openURL", url: url }, function (response) {
+        if (response && response.success) {
+            showAlert(response.message || `Request ${url} opened successfully in Beacon.`, "success", 2000);
+            console.log("Job opened successfully");
+            return;
+        }
+
+        console.error("Failed to open job in Beacon Remote tab:", response);
+
+        // Lighthouse drives a single "Beacon Remote" tab so it can reuse your
+        // Beacon login. If that tab is missing we can't reuse it, so explain
+        // why and offer a link to open the page in a new window instead.
+        const code = (response && (response.error || response.message)) || "";
+        let reason;
+        if (/same tab/i.test(code)) {
+            reason = "This is the Beacon Remote tab, so it can't open the page in itself.";
+        } else if (/no remote tab|not? *registered/i.test(code)) {
+            reason = "Lighthouse has no Beacon Remote tab to open this in. Register Beacon in another tab, then try again.";
+        } else if (/failed|no tab with id/i.test(code)) {
+            reason = "Your Beacon Remote tab has closed. Register Beacon in another tab, then try again.";
+        } else {
+            reason = "Couldn't reach your Beacon Remote tab. Register Beacon in another tab, then try again.";
+        }
+
+        const link = `<a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer">Open this page in a new window</a>`;
+        // Persist (no timeout) so the user has time to read it and click the link.
+        const id = showAlert(`<div style="text-align:center;">${escapeHtml(reason)}<br>${link}</div>`, "warning", 0);
+
+        // Dismiss the alert once the user has followed the link.
+        document.getElementById(id)?.querySelector("a")?.addEventListener("click", () => closeAlert(id));
+    });
 }


### PR DESCRIPTION
## What

When Tasking tries to open a URL in the Beacon Remote tab (`openURLInBeacon`) and there's no tab to reuse — none registered, or it was closed — the warning alert now:

- Explains the specific cause (no remote tab / tab closed / sent from the remote tab itself / unknown) and what to do about it, instead of echoing the raw background-script string.
- Includes an **"Open this page in a new window"** link to the target URL (`target="_blank" rel="noopener noreferrer"`).
- Is centre-aligned and persists until dismissed, then auto-dismisses once the link is clicked.

Also guards against an undefined `sendMessage` response (previously threw on `response.message`).

## Changes

- `chromeRunTime.js` — reason mapping + link + click-to-dismiss.
- `windowAlert.js` — `showAlert` returns the alert id; new `closeAlert(id)` helper (the timeout path reuses it).

## Testing

- `npx eslint` clean on both files.
- Manual: not yet exercised in the extension — needs a check that the alert renders and the link opens/dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)