### PR TITLE
Tasking: config-modal Data pane + HQ coverage watermark, SignalR reconcile on close, popup auto-pan fix

### DIFF
--- a/src/pages/tasking/components/hqCoverageMap.js
+++ b/src/pages/tasking/components/hqCoverageMap.js
@@ -1,0 +1,231 @@
+import BeaconClient from "../../../shared/BeaconClient";
+import L from "leaflet";
+
+const esri = require("esri-leaflet");
+
+/**
+ * Decorative NSW map tucked into the bottom-right corner of the config
+ * modal's Data pane: real aerial imagery zoomed to whatever the "Only Show
+ * Incidents From" filter covers, faded and masked so it reads as a
+ * watermark behind the pane's controls. Fully non-interactive -- no zoom,
+ * pan, controls, or pointer events -- and it never touches the filter.
+ *
+ * Only entries that have their own unit boundary are shaded. A region or
+ * zone in the filter is NOT expanded here; once the user expands it with
+ * "Load Children" the child units land in the filter as their own entries
+ * and shade individually.
+ *
+ * @param {{
+ *   config: object,                 // ConfigVM (needs incidentFilters observable)
+ *   getToken: () => Promise<string>,
+ *   apiHost: string,
+ *   userId: string,
+ *   containerId?: string,
+ *   tabId?: string,
+ *   modalId?: string,
+ * }} opts
+ */
+export function initHqCoverageMap(opts) {
+  const {
+    config,
+    getToken,
+    apiHost,
+    userId,
+    containerId = "hqCoverageWatermark",
+    tabId = "cfgTab-data",
+    modalId = "configModal",
+  } = opts;
+
+  const host = document.getElementById(containerId);
+  const modalEl = document.getElementById(modalId);
+  if (!host || !modalEl || !config || typeof config.incidentFilters !== "function") return;
+
+  const FILL = "#ff7a1a";
+  const FILL_OPACITY = 0.32;
+  const STROKE_OPACITY = 1;
+  const ANIM = { animate: true, duration: 0.6, easeLinearity: 0.2 };
+  const FADE_MS = 500; // slightly past the 0.45s CSS opacity transition
+  const ringCache = new Map(); // entityId -> rings[] | null
+
+  // Roughly the state extent -- what the map falls back to with nothing selected.
+  const NSW_BOUNDS = L.latLngBounds([[-37.51, 140.99], [-28.15, 153.64]]);
+  const NSW_FIT = { padding: [8, 8] };
+  const FIT = { padding: [24, 24], maxZoom: 13 };
+
+  let map = null;
+  let boundaryLayer = null;
+  let drawSeq = 0;
+  let hasDrawn = false; // first paint snaps; later changes animate
+  let redrawTimer = null;
+
+  function ensureMap() {
+    if (map) return;
+    map = L.map(host, {
+      zoomControl: false,
+      attributionControl: false,
+      dragging: false,
+      touchZoom: false,
+      scrollWheelZoom: false,
+      doubleClickZoom: false,
+      boxZoom: false,
+      keyboard: false,
+      tap: false,
+      inertia: false,
+      // Animations on: the watermark re-fits whenever the filter changes and
+      // a hard jump reads as a glitch behind the controls.
+      fadeAnimation: true,
+      zoomAnimation: true,
+      markerZoomAnimation: false,
+    }).setView([-32.9, 147.3], 5);
+
+    esri.basemapLayer("Imagery", { ignoreDeprecationWarning: true }).addTo(map);
+
+    boundaryLayer = L.layerGroup().addTo(map);
+  }
+
+  // Ease the camera to `target` -- snap on the very first paint, glide after.
+  function fitTo(target, opts) {
+    const settings = hasDrawn ? { ...opts, ...ANIM } : { ...opts, animate: false };
+    map.fitBounds(target, settings);
+    hasDrawn = true;
+  }
+
+  // Swap the shaded boundaries for `polys` with a crossfade rather than a
+  // clear-then-redraw flash. Old layers fade out and are removed; new ones
+  // fade up from transparent.
+  function swapBoundaries(polys) {
+    const stale = boundaryLayer.getLayers();
+    stale.forEach((l) => {
+      if (l.setStyle) l.setStyle({ fillOpacity: 0, opacity: 0 });
+    });
+    setTimeout(() => stale.forEach((l) => boundaryLayer.removeLayer(l)), FADE_MS);
+
+    polys.forEach((poly) => {
+      poly.setStyle({ fillOpacity: 0, opacity: 0 });
+      poly.addTo(boundaryLayer);
+    });
+    // Two frames so the browser paints the transparent state before we bump
+    // to the target -- a single rAF gets coalesced and skips the transition.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      polys.forEach((poly) =>
+        poly.setStyle({ fillOpacity: FILL_OPACITY, opacity: STROKE_OPACITY }));
+    }));
+  }
+
+  async function ringsFor(id, token) {
+    if (ringCache.has(id)) return ringCache.get(id);
+    let rings = null;
+    try {
+      const res = await BeaconClient.geoservices.unitBoundary(id, { host: apiHost, userId, token });
+      rings = Array.isArray(res) && res.length ? res : null;
+    } catch (e) {
+      rings = null;
+    }
+    ringCache.set(id, rings);
+    return rings;
+  }
+
+  function polygonsFor(rings) {
+    const toLatLngs = (ring) =>
+      (ring.points || [])
+        .slice()
+        .sort((a, b) => a.sequence - b.sequence)
+        .filter((p) => Number.isFinite(p.latitude) && Number.isFinite(p.longitude))
+        .map((p) => [p.latitude, p.longitude]);
+
+    const outers = rings.filter((r) => !r.inner_boundary).map(toLatLngs).filter((r) => r.length >= 3);
+    const holes = rings.filter((r) => r.inner_boundary).map(toLatLngs).filter((r) => r.length >= 3);
+    if (!outers.length) return null;
+
+    const latlngs = outers.length === 1 ? [outers[0], ...holes] : outers;
+    return L.polygon(latlngs, {
+      color: FILL,
+      weight: 1.5,
+      fillColor: FILL,
+      fillOpacity: FILL_OPACITY,
+      interactive: false,
+      className: "hq-cov-poly", // CSS transitions the opacity crossfade
+    });
+  }
+
+  function show(on) {
+    host.classList.toggle("is-visible", on);
+  }
+
+  function frameNsw() {
+    ensureMap();
+    swapBoundaries([]);
+    show(true);
+    map.invalidateSize({ animate: false });
+    fitTo(NSW_BOUNDS, NSW_FIT);
+  }
+
+  async function redraw() {
+    const seq = ++drawSeq;
+    const entries = (config.incidentFilters() || []).slice();
+
+    if (!entries.length) {
+      frameNsw();
+      return;
+    }
+
+    let token;
+    try {
+      token = await getToken();
+    } catch (e) {
+      return;
+    }
+
+    const ringSets = await Promise.all(entries.map((e) => ringsFor(e.id, token)));
+    if (seq !== drawSeq) return;
+
+    ensureMap();
+    const polys = [];
+    const bounds = L.latLngBounds([]);
+
+    ringSets.forEach((rings) => {
+      if (!rings) return;
+      const poly = polygonsFor(rings);
+      if (!poly) return;
+      polys.push(poly);
+      bounds.extend(poly.getBounds());
+    });
+
+    swapBoundaries(polys);
+
+    show(true);
+    map.invalidateSize({ animate: false });
+    // Nothing resolved to a boundary yet (e.g. only unexpanded regions) --
+    // sit on the whole state rather than blank out.
+    if (bounds.isValid()) fitTo(bounds, FIT);
+    else fitTo(NSW_BOUNDS, NSW_FIT);
+  }
+
+  // Coalesce a burst of filter changes (bulk add/remove, "Load Children")
+  // into a single animated re-fit.
+  function scheduleRedraw() {
+    clearTimeout(redrawTimer);
+    redrawTimer = setTimeout(redraw, 180);
+  }
+
+  function refit() {
+    if (!map) return;
+    map.invalidateSize({ animate: false });
+    const b = L.latLngBounds([]);
+    boundaryLayer.getLayers().forEach((l) => b.extend(l.getBounds()));
+    if (b.isValid()) fitTo(b, FIT);
+    else fitTo(NSW_BOUNDS, NSW_FIT);
+  }
+
+  // The Data pane is the modal's default tab, so the container has a size as
+  // soon as the modal is shown; refit whenever it (re)appears.
+  modalEl.addEventListener("shown.bs.modal", () => {
+    if (map) map.invalidateSize({ animate: false });
+    redraw();
+  });
+
+  const tabBtn = document.getElementById(tabId);
+  if (tabBtn) tabBtn.addEventListener("shown.bs.tab", refit);
+
+  config.incidentFilters.subscribe(scheduleRedraw);
+}

--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -3,7 +3,7 @@ global.jQuery = $;
 
 import BeaconClient from '../../shared/BeaconClient.js';
 const BeaconToken = require('../lib/shared_token_code.js');
-import { startBeaconSignalRConnection, connectionStatus, getConnectionStatus } from './signalr/connection.js';
+import { startBeaconSignalRConnection, stopBeaconSignalRConnection, connectionStatus, getConnectionStatus } from './signalr/connection.js';
 import { setPushModeEnabled } from './signalr/pushMode.js';
 import { getSubject } from './signalr/subjects.js';
 
@@ -47,6 +47,7 @@ import { Enum } from './utils/enum.js';
 import { fetchSharedDefaults } from './utils/defaultAssetSync.js';
 
 import { ConfigVM } from './viewmodels/Config.js';
+import { initHqCoverageMap } from './components/hqCoverageMap.js';
 
 import { installSlideVisibleBinding } from "./bindings/slideVisible.js";
 import { installStatusFilterBindings } from "./bindings/statusFilters.js";
@@ -3154,9 +3155,8 @@ function VM() {
     });
 
     // Same for the signalrEnabled toggle -- effectiveRefreshIntervalMs()
-    // depends on it too, and this takes effect immediately even though the
-    // SignalR connection itself only starts/stops based on this value at
-    // page load.
+    // depends on it too. (The SignalR connection itself is started/stopped
+    // to match by a separate subscriber in the DOMContentLoaded handler.)
     self.config.signalrEnabled.subscribe(() => {
         console.log("signalrEnabled changed → restarting timers");
         startJobsTeamsTimer();
@@ -3872,10 +3872,17 @@ document.addEventListener('DOMContentLoaded', function () {
         // than fail silently.
         myViewModel.signalrStatus = ko.observable(getConnectionStatus());
         connectionStatus.subscribe((status) => myViewModel.signalrStatus(status));
-        // Deliberately disabled isn't "disconnected" -- only show the banner
-        // when the feature is meant to be running but isn't.
+        // True once we've actually kicked off a connection attempt (i.e. the
+        // config modal has been closed at least once with live updates on).
+        // Before that the connection isn't *meant* to be up yet, so a
+        // 'disconnected' status is expected, not a problem.
+        myViewModel.signalrConnectionAttempted = ko.observable(false);
+        // Deliberately disabled -- or not started yet -- isn't "disconnected":
+        // only show the banner when the feature is meant to be running but isn't.
         myViewModel.signalrDisconnected = ko.pureComputed(() =>
-            myViewModel.config.signalrEnabled() && myViewModel.signalrStatus() !== 'connected'
+            myViewModel.config.signalrEnabled()
+            && myViewModel.signalrConnectionAttempted()
+            && myViewModel.signalrStatus() !== 'connected'
         );
         myViewModel.signalrStatusText = ko.pureComputed(() => {
             switch (myViewModel.signalrStatus()) {
@@ -4082,17 +4089,19 @@ document.addEventListener('DOMContentLoaded', function () {
         getSubject('iuaReceived').subscribe(refreshIcemsIncidentFromPush);
         getSubject('isuReceived').subscribe(refreshIcemsIncidentFromPush);
 
-        // Start the connection now that every subject subscription above is
-        // registered (so nothing pushed right at connect time is silently
-        // dropped -- Subject has no replay) and myViewModel/config
-        // definitely exist (so signalrEnabled() reads the real saved value
-        // instead of racing construction and guessing "enabled" by
-        // default). getToken() resolves once, reliably, whenever the first
-        // token lands -- no separate "started" guard or hooking into the
-        // token-fetch callback needed.
-        (async () => {
+        // The SignalR connection is gated on the config modal: it starts only
+        // whenever the config modal closes -- never before. The modal opens
+        // on load (and on every later Config open) with the filters and the
+        // Live Updates toggle still editable; reconciling only on close means
+        // we negotiate against committed settings, and flipping the toggle
+        // back and forth mid-edit costs nothing until you close the window.
+        // By the time this runs, every subject subscription above is
+        // registered (so nothing pushed at connect time is silently dropped
+        // -- Subject has no replay) and myViewModel/config exist.
+        const reconcileSignalRToConfig = async () => {
             if (!myViewModel.config.signalrEnabled()) {
-                console.log('[SignalR] disabled via config -- not connecting');
+                myViewModel.signalrConnectionAttempted(false);
+                stopBeaconSignalRConnection();
                 return;
             }
             const negotiateUrl = params.signalr;
@@ -4101,11 +4110,14 @@ document.addEventListener('DOMContentLoaded', function () {
                 return;
             }
             await getToken();
+            if (!myViewModel.config.signalrEnabled()) return; // toggled off meanwhile
             // Closure over the module-level `token` var (kept current by
             // setToken() on every renewal), so each reconnect/negotiate
             // re-authenticates with whatever token is live at that moment.
+            // startBeaconSignalRConnection no-ops if already connected.
+            myViewModel.signalrConnectionAttempted(true);
             window.__beaconSignalRConnection = startBeaconSignalRConnection(negotiateUrl, () => token);
-        })();
+        };
 
         ko.applyBindings(myViewModel);
 
@@ -4127,6 +4139,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
         //show config modal on load
         const configModalEl = document.getElementById('configModal');
+        // Start/stop the SignalR connection to match the Live Updates toggle
+        // every time the config modal closes -- see reconcileSignalRToConfig
+        // above. Fires on the initial on-load modal too, so nothing connects
+        // until the user dismisses it.
+        configModalEl.addEventListener('hidden.bs.modal', reconcileSignalRToConfig);
         bootstrap.Modal.getOrCreateInstance(configModalEl).show();
 
         // reveal the page now that bindings are applied and the modal is open,
@@ -4138,6 +4155,15 @@ document.addEventListener('DOMContentLoaded', function () {
             onSave: () => myViewModel.config.saveAndCloseAndLoad(),
             onClose: () => myViewModel.config.saveAndCloseAndLoad(),
             allowInInputs: true // text-heavy modal
+        });
+
+        // Compact NSW map in the config modal: shades every HQ that's in the
+        // "Only Show Incidents From" filter.
+        initHqCoverageMap({
+            config: myViewModel.config,
+            getToken,
+            apiHost,
+            userId: params.userId,
         });
 
         document.addEventListener("keydown", (e) => {

--- a/src/pages/tasking/signalr/connection.js
+++ b/src/pages/tasking/signalr/connection.js
@@ -32,11 +32,17 @@ export function getConnectionStatus() {
 
 let manualRestartTimer = null;
 
+// Set by stopBeaconSignalRConnection() so the onclose handler doesn't
+// immediately reconnect a connection we deliberately tore down (config
+// toggled Live Updates off). Cleared again by the next explicit start.
+let stoppedIntentionally = false;
+
 function scheduleManualRestart(negotiateUrl, getAccessToken) {
-    // Safety net for the case onclose fires anyway (e.g. .stop() was called,
-    // or the very first negotiate/handshake failed before the retry policy
-    // above ever got a chance to run) -- keep trying rather than silently
-    // leaving the page without live updates.
+    // Safety net for the case onclose fires anyway (e.g. the very first
+    // negotiate/handshake failed before the retry policy above ever got a
+    // chance to run) -- keep trying rather than silently leaving the page
+    // without live updates. Skipped when we stopped on purpose.
+    if (stoppedIntentionally) return;
     if (manualRestartTimer) return;
     manualRestartTimer = setTimeout(() => {
         manualRestartTimer = null;
@@ -54,6 +60,12 @@ function scheduleManualRestart(negotiateUrl, getAccessToken) {
  * the live token rather than a captured string.
  */
 export function startBeaconSignalRConnection(negotiateUrl, getAccessToken) {
+    // An explicit start overrides a previous intentional stop.
+    stoppedIntentionally = false;
+    if (manualRestartTimer) {
+        clearTimeout(manualRestartTimer);
+        manualRestartTimer = null;
+    }
     if (connection) return connection;
 
     connection = new signalR.HubConnectionBuilder()
@@ -79,7 +91,11 @@ export function startBeaconSignalRConnection(negotiateUrl, getAccessToken) {
         console.log('[SignalR] reconnected, connectionId=', connectionId);
         setStatus('connected');
     });
+    const thisConnection = connection;
     connection.onclose((error) => {
+        // Ignore a late close from a connection we've already replaced
+        // (stopped, then started again before its stop handshake landed).
+        if (connection !== thisConnection) return;
         console.log('[SignalR] closed', error);
         setStatus('disconnected');
         scheduleManualRestart(negotiateUrl, getAccessToken);
@@ -88,16 +104,43 @@ export function startBeaconSignalRConnection(negotiateUrl, getAccessToken) {
     setStatus('connecting');
     connection.start()
         .then(() => {
-            console.log('[SignalR] connected, connectionId=', connection.connectionId);
+            if (connection !== thisConnection) return; // replaced mid-connect
+            console.log('[SignalR] connected, connectionId=', thisConnection.connectionId);
             setStatus('connected');
         })
         .catch((err) => {
+            if (connection !== thisConnection) return; // stopped mid-connect
             console.error('[SignalR] failed to connect:', err);
             setStatus('disconnected');
             scheduleManualRestart(negotiateUrl, getAccessToken);
         });
 
     return connection;
+}
+
+/**
+ * Tears down the live connection (config toggled Live Updates off
+ * mid-session). Safe to call when nothing is connected. The next
+ * startBeaconSignalRConnection() call rebuilds a fresh HubConnection.
+ */
+export function stopBeaconSignalRConnection() {
+    stoppedIntentionally = true;
+    if (manualRestartTimer) {
+        clearTimeout(manualRestartTimer);
+        manualRestartTimer = null;
+    }
+    const c = connection;
+    connection = null;
+    if (!c) {
+        setStatus('disconnected');
+        return Promise.resolve();
+    }
+    console.log('[SignalR] stopping connection (Live Updates disabled)');
+    setStatus('disconnected');
+    // onclose fires from here, but connection is already null and
+    // stoppedIntentionally is set, so it won't schedule a restart.
+    return c.stop()
+        .catch((err) => console.warn('[SignalR] error while stopping:', err));
 }
 
 export { getSubject };

--- a/src/pages/tasking/signalr/pushMode.js
+++ b/src/pages/tasking/signalr/pushMode.js
@@ -1,6 +1,6 @@
-// Whether SignalR push is enabled, per the config-level toggle. Read at
-// page load (see main.js) -- toggling it takes effect on next open, since
-// tearing down/rebuilding a live connection mid-session isn't wired up.
+// Whether SignalR push is enabled, per the config-level toggle. Kept in
+// sync with the config toggle at runtime (see main.js), which also starts
+// or stops the live connection to match.
 let enabled = true;
 
 export function setPushModeEnabled(value) {

--- a/src/pages/tasking/utils/popupAutoPan.js
+++ b/src/pages/tasking/utils/popupAutoPan.js
@@ -6,14 +6,40 @@ const MIN_PADDING = 16;
 // Small breathing room beyond the edge of whatever control is docked there,
 // so a re-panned popup doesn't sit flush against it.
 const EXTRA_MARGIN = 8;
-// Cap how much of the map's own width/height the corner controls are
-// allowed to claim as padding, on each axis. Leaflet's autoPan can't
-// satisfy both the top and bottom (or left and right) padding at once if
-// together they leave no room for the popup -- it just snaps between
-// them, cutting the popup off. Keeping a comfortable share of the
-// viewport free of padding, no matter how much chrome piles into the
-// corners, keeps that always satisfiable.
+// Cap how much of the map's own width/height a single corner control is
+// allowed to claim as padding, on each axis -- a first-pass sanity bound
+// against one oversized control.
 const MAX_PADDING_SHARE = 0.35;
+
+// Leaflet's autoPan can only pan a popup fully into view when the two
+// opposite paddings plus the popup itself fit across the map -- i.e.
+// `paddingTopLeft + paddingBottomRight + popupSize <= mapSize` on that
+// axis. When the corner chrome (alerts banner, legend, the wide Esri
+// attribution line, ...) is big enough that they don't, Leaflet's
+// pan-to-fit math can't satisfy both edges and silently stops panning on
+// that axis: the popup opens clipped instead of pushed into view. On a
+// tall map the vertical padding almost always fits, so this shows up as
+// "vertical auto-pan works, horizontal doesn't" on a narrow map.
+//
+// To keep both axes satisfiable we reserve room for a popup of at least
+// this size and shrink the corner-derived padding (proportionally, never
+// below MIN_PADDING) to fit around it. A popup wider/taller than this
+// still degrades gracefully -- Leaflet pins it against the top-left
+// padding, clipping the far edge -- instead of not panning at all.
+const MIN_POPUP_WIDTH = 430;
+const MIN_POPUP_HEIGHT = 320;
+
+// Scale a pair of opposite paddings down so their sum leaves `reserve`
+// px free across `extent`, holding each at MIN_PADDING or above.
+function fitPadding(tl, br, extent, reserve) {
+    const budget = extent - reserve - 2 * MIN_PADDING;
+    const excess = (tl - MIN_PADDING) + (br - MIN_PADDING);
+    if (excess <= 0) return [tl, br];           // already at the floor
+    if (budget <= 0) return [MIN_PADDING, MIN_PADDING];
+    if (excess <= budget) return [tl, br];      // fits as-is
+    const k = budget / excess;
+    return [MIN_PADDING + (tl - MIN_PADDING) * k, MIN_PADDING + (br - MIN_PADDING) * k];
+}
 
 /**
  * Shared, mutable autoPan padding, kept in sync with whatever's docked in
@@ -82,10 +108,20 @@ export function initPopupAutoPan(map) {
         const maxVertical = mapRect.height * MAX_PADDING_SHARE;
         const maxHorizontal = mapRect.width * MAX_PADDING_SHARE;
 
-        topLeft.x = Math.min(left, maxHorizontal);
-        topLeft.y = Math.min(top, maxVertical);
-        bottomRight.x = Math.min(right, maxHorizontal);
-        bottomRight.y = Math.min(bottom, maxVertical);
+        left = Math.min(left, maxHorizontal);
+        right = Math.min(right, maxHorizontal);
+        top = Math.min(top, maxVertical);
+        bottom = Math.min(bottom, maxVertical);
+
+        // Keep opposite paddings + a popup fitting across each axis, so
+        // Leaflet's autoPan never stalls on that axis (see MIN_POPUP_* above).
+        [left, right] = fitPadding(left, right, mapRect.width, MIN_POPUP_WIDTH);
+        [top, bottom] = fitPadding(top, bottom, mapRect.height, MIN_POPUP_HEIGHT);
+
+        topLeft.x = left;
+        topLeft.y = top;
+        bottomRight.x = right;
+        bottomRight.y = bottom;
     }
 
     recompute();

--- a/src/pages/tasking/viewmodels/Config.js
+++ b/src/pages/tasking/viewmodels/Config.js
@@ -362,6 +362,23 @@ export function ConfigVM(root, deps) {
     // Selected location filters
     self.teamFilters = ko.observableArray([]);     // [{id, name, entityType}]
     self.incidentFilters = ko.observableArray([]); // [{id, name, entityType}]
+
+    // Selected-filter boxes collapse past this many pills; a "…more" button
+    // toggles the expanded state.
+    self.locationPillCollapseAt = 9;
+    self.teamsExpanded = ko.observable(false);
+    self.incidentsExpanded = ko.observable(false);
+    self.toggleTeamsExpanded = () => self.teamsExpanded(!self.teamsExpanded());
+    self.toggleIncidentsExpanded = () => self.incidentsExpanded(!self.incidentsExpanded());
+    self.showTeamsMore = ko.pureComputed(() => self.teamFilters().length > self.locationPillCollapseAt);
+    self.showIncidentsMore = ko.pureComputed(() => self.incidentFilters().length > self.locationPillCollapseAt);
+    // Clip (fade + cap height, no inner scrollbar) only while collapsed.
+    self.teamsBoxClipped = ko.pureComputed(() => self.showTeamsMore() && !self.teamsExpanded());
+    self.incidentsBoxClipped = ko.pureComputed(() => self.showIncidentsMore() && !self.incidentsExpanded());
+    self.teamsMoreLabel = ko.pureComputed(() =>
+        self.teamsExpanded() ? 'Show fewer' : ('Show all ' + self.teamFilters().length));
+    self.incidentsMoreLabel = ko.pureComputed(() =>
+        self.incidentsExpanded() ? 'Show fewer' : ('Show all ' + self.incidentFilters().length));
     self.allowedIncidentTypeIds = ko.pureComputed(() =>
         new Set(self.incidentTypeFilter()
             .map(t => Enum.IncidentType[t]?.Id)
@@ -1443,8 +1460,8 @@ export function ConfigVM(root, deps) {
     };
     const removeById = (arr, id) => arr.remove(x => x.id === id);
 
-    self.clearTeams = () => self.teamFilters.removeAll();
-    self.clearIncidents = () => self.incidentFilters.removeAll();
+    self.clearTeams = () => { self.teamFilters.removeAll(); self.teamsExpanded(false); };
+    self.clearIncidents = () => { self.incidentFilters.removeAll(); self.incidentsExpanded(false); };
     self.clearSectors = () => self.sectorFilters.removeAll();
 
     // Search (debounced)

--- a/static/pages/tasking.html
+++ b/static/pages/tasking.html
@@ -1947,153 +1947,6 @@
                 </div>
 
                 <div class="modal-body">
-                    <!-- TOP: search + two selected boxes NEXT TO the search -->
-                    <div class="row g-3 align-items-start top-band">
-                        <!-- Search area -->
-                        <div class="col-lg-12">
-                            <label class="form-label">Filter by Headquarters</label>
-                            <div class="input-group position-relative">
-                                <input id="locationSearch" type="search" class="form-control" placeholder="Search…"
-                                    autocomplete="off" data-bind="value: config.query, valueUpdate: 'afterkeydown', hasFocus: config.inputHasFocus,
-                                    event: { blur: config.closeDropdown }">
-                                <button id="clearSearch" class="btn btn-outline-secondary" type="button" title="Clear"
-                                    data-bind="click: config.clearSearch">&times;</button>
-
-                                <!-- Results "dropdown" rendered via KO -->
-                                <ul class="dropdown-menu w-100 show" id="searchDropdown" role="listbox"
-                                    data-bind="visible: config.dropdownOpen">
-
-                                    <!-- Loading state -->
-                                    <!-- ko if: config.searching -->
-                                    <li>
-                                        <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2"
-                                            style="pointer-events:none;">
-                                            <i class="fa fa-spinner fa-spin me-2"></i>
-                                            Searching…
-                                        </div>
-                                    </li>
-                                    <!-- /ko -->
-
-                                    <!-- Not loading -->
-                                    <!-- ko ifnot: config.searching -->
-                                    <!-- Results -->
-                                    <!-- ko if: config.results().length > 0 -->
-                                    <!-- ko foreach: config.results -->
-                                    <li>
-                                        <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
-                                            data-bind="click: $root.config.addTeamAndIncident">
-                                            <span class="text-truncate"
-                                                data-bind="text: name, attr: { title: name }"></span>
-                                            <div class="btn-group btn-group-sm ms-2">
-                                                <button type="button" class="btn btn-outline-primary"
-                                                    data-bind="click: $root.config.addTeam, clickBubble: false, css: { 'active': teamSelected() }">
-                                                    Teams
-                                                </button>
-                                                <button type="button" class="btn btn-outline-success"
-                                                    data-bind="click: $root.config.addIncident, clickBubble: false, css: { 'active': incidentSelected() }">
-                                                    Incidents
-                                                </button>
-                                            </div>
-                                        </div>
-                                    </li>
-                                    <!-- /ko -->
-                                    <!-- /ko -->
-
-                                    <!-- No results -->
-                                    <!-- ko if: config.results().length === 0 -->
-                                    <li>
-                                        <div class="dropdown-item text-muted text-center py-2"
-                                            style="pointer-events:none;">
-                                            No results found.
-                                        </div>
-                                    </li>
-                                    <!-- /ko -->
-                                    <!-- /ko -->
-                                </ul>
-
-
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row g-3 align-items-start top-band"></div>
-                    <!-- Selected filters (two boxes) -->
-                    <div class="row g-3">
-                        <div class="col-6">
-                            <div class="card">
-                                <div class="card-header py-1 d-flex justify-content-between align-items-center">
-                                    <span class="small fw-semibold">Only Load Teams Attached To:</span>
-                                    <div class="d-flex align-items-center">
-                                        <span class="badge bg-primary me-2"
-                                            data-bind="text: config.teamFilters().length"></span>
-                                        <button id="clearTeams" class="btn btn-sm btn-outline-secondary"
-                                            data-bind="click: config.clearTeams, enable: config.teamFilters().length">Clear</button>
-                                    </div>
-                                </div>
-                                <!-- Selected filters: TEAMS -->
-                                <div data-bind="if: config.teamFilters().length === 0">
-                                    <div class="card-body py-2 selected-box">
-                                        <span class="text-muted small">No Filters Applied - Teams from all units will be
-                                            fetched</span>
-                                    </div>
-                                </div>
-                                <div data-bind="if: config.teamFilters().length > 0">
-                                    <div class="card-body py-2 selected-box" data-bind="foreach: config.teamFilters">
-                                        <span
-                                            class="badge text-bg-primary pill d-inline-flex align-items-center me-1 mb-1">
-                                            <span class="me-1" data-bind="text: name"></span>
-                                            <!-- Only show sitemap if entityType == 2 -->
-                                            <button type="button" class="btn btn-xs btn-load-children"
-                                                title="Load Children"
-                                                data-bind="visible: entityType == 2, click: $root.config.loadChildrenForTeam">
-                                                <i class="fa fa-sitemap" aria-hidden="true"></i>
-                                            </button>
-                                            <button type="button" class="btn-close btn-close-white" aria-label="Remove"
-                                                data-bind="click: $root.config.removeTeam"></button>
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-6">
-                            <div class="card">
-                                <div class="card-header py-1 d-flex justify-content-between align-items-center">
-                                    <span class="small fw-semibold">Only Show Incidents From: </span>
-                                    <div class="d-flex align-items-center">
-                                        <span class="badge bg-success me-2"
-                                            data-bind="text: config.incidentFilters().length"></span>
-                                        <button id="clearIncidents" class="btn btn-sm btn-outline-secondary"
-                                            data-bind="click: config.clearIncidents, enable: config.incidentFilters().length">Clear</button>
-                                    </div>
-                                </div>
-                                <!-- Selected filters: INCIDENTS -->
-                                <div data-bind="if: config.incidentFilters().length === 0">
-                                    <div class="card-body py-2 selected-box">
-                                        <span class="text-muted small">No Filters Applied - Incidents from all units
-                                            will be fetched</span>
-                                    </div>
-                                </div>
-                                <div data-bind="if: config.incidentFilters().length > 0">
-                                    <div class="card-body py-2 selected-box"
-                                        data-bind="foreach: config.incidentFilters">
-                                        <span
-                                            class="badge text-bg-success pill d-inline-flex align-items-center me-1 mb-1">
-                                            <span class="me-1" data-bind="text: name"></span>
-                                            <button type="button" class="btn btn-xs btn-outline-light btn-load-children"
-                                                title="Load Children"
-                                                data-bind="visible: entityType == 2, click: $root.config.loadChildrenForIncident">
-                                                <i class="fa fa-sitemap" aria-hidden="true"></i>
-                                            </button>
-                                            <button type="button" class="btn-close btn-close-white" aria-label="Remove"
-                                                data-bind="click: $root.config.removeIncident"></button>
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-
-                    <!-- CONFIG -->
                     <!-- CONFIG -->
                     <div class="card config-card mt-3">
                         <div class="card-body">
@@ -2143,6 +1996,147 @@
                                     </ul>
                                     <div class="tab-content config-panes">
                                     <div class="tab-pane fade show active" id="cfgPane-data" role="tabpanel" aria-labelledby="cfgTab-data" tabindex="0">
+                                        <!-- Decorative: real NSW basemap, zoomed to the incident-filter HQs,
+                                             bleeding off the bottom-right corner. Non-interactive. -->
+                                        <div class="hq-coverage-watermark-clip" aria-hidden="true">
+                                            <div id="hqCoverageWatermark" class="hq-coverage-watermark"></div>
+                                        </div>
+
+                                        <!-- Location filters: HQ search + the two selected-filter boxes -->
+                                        <div class="cfg-location">
+                                            <label class="form-label">Filter by Headquarters</label>
+                                            <div class="input-group position-relative">
+                                                <input id="locationSearch" type="search" class="form-control" placeholder="Search…"
+                                                    autocomplete="off" data-bind="value: config.query, valueUpdate: 'afterkeydown', hasFocus: config.inputHasFocus,
+                                                    event: { blur: config.closeDropdown }">
+                                                <button id="clearSearch" class="btn btn-outline-secondary" type="button" title="Clear"
+                                                    data-bind="click: config.clearSearch">&times;</button>
+
+                                                <ul class="dropdown-menu w-100 show" id="searchDropdown" role="listbox"
+                                                    data-bind="visible: config.dropdownOpen">
+                                                    <!-- ko if: config.searching -->
+                                                    <li>
+                                                        <div class="dropdown-item text-muted d-flex align-items-center px-2 py-2"
+                                                            style="pointer-events:none;">
+                                                            <i class="fa fa-spinner fa-spin me-2"></i>
+                                                            Searching…
+                                                        </div>
+                                                    </li>
+                                                    <!-- /ko -->
+                                                    <!-- ko ifnot: config.searching -->
+                                                    <!-- ko if: config.results().length > 0 -->
+                                                    <!-- ko foreach: config.results -->
+                                                    <li>
+                                                        <div class="dropdown-item d-flex justify-content-between align-items-center px-2 py-1"
+                                                            data-bind="click: $root.config.addTeamAndIncident">
+                                                            <span class="text-truncate"
+                                                                data-bind="text: name, attr: { title: name }"></span>
+                                                            <div class="btn-group btn-group-sm ms-2">
+                                                                <button type="button" class="btn btn-outline-primary"
+                                                                    data-bind="click: $root.config.addTeam, clickBubble: false, css: { 'active': teamSelected() }">
+                                                                    Teams
+                                                                </button>
+                                                                <button type="button" class="btn btn-outline-success"
+                                                                    data-bind="click: $root.config.addIncident, clickBubble: false, css: { 'active': incidentSelected() }">
+                                                                    Incidents
+                                                                </button>
+                                                            </div>
+                                                        </div>
+                                                    </li>
+                                                    <!-- /ko -->
+                                                    <!-- /ko -->
+                                                    <!-- ko if: config.results().length === 0 -->
+                                                    <li>
+                                                        <div class="dropdown-item text-muted text-center py-2"
+                                                            style="pointer-events:none;">
+                                                            No results found.
+                                                        </div>
+                                                    </li>
+                                                    <!-- /ko -->
+                                                    <!-- /ko -->
+                                                </ul>
+                                            </div>
+
+                                            <div class="row g-3 mt-0">
+                                                <div class="col-6">
+                                                    <div class="card">
+                                                        <div class="card-header py-1 d-flex justify-content-between align-items-center">
+                                                            <span class="small fw-semibold">Only Load Teams Attached To:</span>
+                                                            <div class="d-flex align-items-center">
+                                                                <span class="badge bg-primary me-2"
+                                                                    data-bind="text: config.teamFilters().length"></span>
+                                                                <button id="clearTeams" class="btn btn-sm btn-outline-secondary"
+                                                                    data-bind="click: config.clearTeams, enable: config.teamFilters().length">Clear</button>
+                                                            </div>
+                                                        </div>
+                                                        <div data-bind="if: config.teamFilters().length === 0">
+                                                            <div class="card-body py-2 selected-box">
+                                                                <span class="text-muted small">No Filters Applied - Teams from all units will be
+                                                                    fetched</span>
+                                                            </div>
+                                                        </div>
+                                                        <div data-bind="if: config.teamFilters().length > 0">
+                                                            <div class="card-body py-2 selected-box"
+                                                                data-bind="foreach: config.teamFilters, css: { clipped: config.teamsBoxClipped() }">
+                                                                <span
+                                                                    class="badge text-bg-primary pill d-inline-flex align-items-center me-1 mb-1">
+                                                                    <span class="me-1" data-bind="text: name"></span>
+                                                                    <button type="button" class="btn btn-xs btn-load-children"
+                                                                        title="Load Children"
+                                                                        data-bind="visible: entityType == 2, click: $root.config.loadChildrenForTeam">
+                                                                        <i class="fa fa-sitemap" aria-hidden="true"></i>
+                                                                    </button>
+                                                                    <button type="button" class="btn-close btn-close-white" aria-label="Remove"
+                                                                        data-bind="click: $root.config.removeTeam"></button>
+                                                                </span>
+                                                            </div>
+                                                            <button type="button" class="btn cfg-more-btn"
+                                                                data-bind="visible: config.showTeamsMore, click: config.toggleTeamsExpanded, text: config.teamsMoreLabel"></button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="col-6">
+                                                    <div class="card">
+                                                        <div class="card-header py-1 d-flex justify-content-between align-items-center">
+                                                            <span class="small fw-semibold">Only Show Incidents From: </span>
+                                                            <div class="d-flex align-items-center">
+                                                                <span class="badge bg-success me-2"
+                                                                    data-bind="text: config.incidentFilters().length"></span>
+                                                                <button id="clearIncidents" class="btn btn-sm btn-outline-secondary"
+                                                                    data-bind="click: config.clearIncidents, enable: config.incidentFilters().length">Clear</button>
+                                                            </div>
+                                                        </div>
+                                                        <div data-bind="if: config.incidentFilters().length === 0">
+                                                            <div class="card-body py-2 selected-box">
+                                                                <span class="text-muted small">No Filters Applied - Incidents from all units
+                                                                    will be fetched</span>
+                                                            </div>
+                                                        </div>
+                                                        <div data-bind="if: config.incidentFilters().length > 0">
+                                                            <div class="card-body py-2 selected-box"
+                                                                data-bind="foreach: config.incidentFilters, css: { clipped: config.incidentsBoxClipped() }">
+                                                                <span
+                                                                    class="badge text-bg-success pill d-inline-flex align-items-center me-1 mb-1">
+                                                                    <span class="me-1" data-bind="text: name"></span>
+                                                                    <button type="button" class="btn btn-xs btn-outline-light btn-load-children"
+                                                                        title="Load Children"
+                                                                        data-bind="visible: entityType == 2, click: $root.config.loadChildrenForIncident">
+                                                                        <i class="fa fa-sitemap" aria-hidden="true"></i>
+                                                                    </button>
+                                                                    <button type="button" class="btn-close btn-close-white" aria-label="Remove"
+                                                                        data-bind="click: $root.config.removeIncident"></button>
+                                                                </span>
+                                                            </div>
+                                                            <button type="button" class="btn cfg-more-btn"
+                                                                data-bind="visible: config.showIncidentsMore, click: config.toggleIncidentsExpanded, text: config.incidentsMoreLabel"></button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <hr class="cfg-location-sep">
+
                                         <div class="cfg-data">
                                             <div class="cfg-data-fields">
                                                 <div class="cfg-field">
@@ -2211,19 +2205,8 @@
                                                             data-bind="text: config.liveUpdatesLabel,
                                                                        css: { on: config.signalrEnabled(), off: !config.signalrEnabled() }"></span>
                                                     </div>
-                                                    <div class="d">Beacon pushes every incident, team &amp; tasking change to the board as it happens &mdash; this is what keeps LAD current. Restart LAD after changing.</div>
+                                                    <div class="d">Beacon pushes live updates to LAD. Incident, team, and tasking changes appear in real-time.</div>
                                                 </div>
-                                            </div>
-
-                                            <div class="cfg-readout">
-                                                <div class="cfg-readout-h">Loading now</div>
-                                                <div class="cfg-readout-range" data-bind="text: config.fetchWindowRange"></div>
-                                                <div class="cfg-readout-sub"><span data-bind="text: config.fetchWindowDays"></span>-day window</div>
-                                                <div class="cfg-readout-rows">
-                                                    <div><span>Live updates</span><span data-bind="text: config.liveUpdatesLabel"></span></div>
-                                                    <div><span>Full refresh</span><span data-bind="text: config.refreshCadence"></span></div>
-                                                </div>
-                                                <div class="cfg-readout-note" data-bind="text: config.dataReadoutNote"></div>
                                             </div>
                                         </div>
                                     </div>

--- a/styles/pages/tasking.css
+++ b/styles/pages/tasking.css
@@ -935,12 +935,157 @@ tr.job:hover {
   margin-bottom: 0.75rem;
 }
 .selected-box {
-  min-height: 66px;
-  max-height: 220px;
-  overflow: auto;
+  min-height: 44px;
 }
 .pill {
   margin: 0.125rem;
+}
+
+/* Config modal, Data pane: the location filters (HQ search + selected
+   boxes) sit above the data-window controls, with a real NSW basemap
+   zoomed to the incident-filter HQs bleeding off the bottom-right corner
+   as a watermark. The map is non-interactive decoration. */
+#cfgPane-data {
+  position: relative;
+  min-height: 100%;
+}
+#cfgPane-data > .cfg-location,
+#cfgPane-data > .cfg-location-sep,
+#cfgPane-data > .cfg-data {
+  position: relative;
+  z-index: 1;
+}
+.cfg-location .form-label {
+  margin-bottom: 0.2rem;
+  font-size: 0.85rem;
+}
+.cfg-location > .row {
+  margin-top: 0.5rem;
+  margin-inline: 0;
+}
+.cfg-location-sep {
+  margin: 0.65rem 0;
+  border-color: var(--bs-border-color, #dee2e6);
+  opacity: 0.6;
+}
+
+/* Compact HQ pills + selected boxes so the Data pane fits with no scroll */
+.cfg-location .input-group > .form-control,
+.cfg-location .input-group > .btn {
+  padding-top: 0.3rem;
+  padding-bottom: 0.3rem;
+  font-size: 0.85rem;
+}
+.cfg-location .card-header {
+  padding: 0.2rem 0.5rem;
+}
+.cfg-location .card-header .small {
+  font-size: 0.75rem;
+}
+.cfg-location .card-header .btn {
+  --bs-btn-padding-y: 0;
+  --bs-btn-padding-x: 0.4rem;
+  --bs-btn-font-size: 0.72rem;
+}
+/* No inner scrollbar: the box shows every pill and grows the pane (the
+   modal body is the only thing that scrolls). While collapsed it's capped
+   with a soft fade and the "Show all" button reveals the rest. */
+.cfg-location .selected-box {
+  min-height: 40px;
+  overflow: hidden;
+  padding: 0.3rem 0.4rem;
+}
+.cfg-location .selected-box.clipped {
+  max-height: 116px;
+  -webkit-mask-image: linear-gradient(to bottom, #000 70%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 70%, transparent 100%);
+}
+.cfg-location .cfg-more-btn {
+  display: block;
+  width: 100%;
+  border: 0;
+  border-top: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: 0;
+  background: none;
+  color: var(--bs-primary, #0d6efd);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.25rem 0;
+}
+.cfg-location .cfg-more-btn:hover {
+  background: var(--bs-tertiary-bg, #f8f9fa);
+}
+.cfg-location .selected-box .pill {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.32rem;
+  margin: 0.09rem;
+  line-height: 1.3;
+}
+.cfg-location .selected-box .pill .btn-load-children {
+  font-size: 0.62rem;
+  padding: 0 1px;
+  margin-left: 0.1rem;
+}
+.cfg-location .selected-box .pill .btn-close {
+  margin-left: 0.28rem;
+  padding: 0;
+  transform: scale(0.62);
+}
+
+/* Data pane: the "Loading now" readout is gone, so the field stack keeps
+   its original single-column order and spacing across the full width. */
+#cfgPane-data .cfg-data {
+  display: block;
+  max-width: none;
+}
+
+.hq-coverage-watermark-clip {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+  /* follow the modal's rounded corner */
+  border-bottom-right-radius: var(--bs-modal-border-radius, 0.5rem);
+}
+.hq-coverage-watermark {
+  position: absolute;
+  right: -72px;
+  bottom: -72px;
+  width: 480px;
+  height: 400px;
+  max-width: 68%;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  /* very soft falloff from the bottom-right corner -- no hard edges */
+  --hq-fade: radial-gradient(150% 150% at 100% 100%,
+      #000 2%,
+      rgba(0, 0, 0, 0.6) 26%,
+      rgba(0, 0, 0, 0.9) 48%,
+      transparent 70%);
+  -webkit-mask-image: var(--hq-fade);
+  mask-image: var(--hq-fade);
+}
+.hq-coverage-watermark.is-visible {
+  opacity: 0.34;
+}
+.hq-coverage-watermark .leaflet-container {
+  background: transparent;
+  font: inherit;
+}
+/* Crossfade the shaded HQ boundaries when the filter changes rather than
+   letting them pop in/out (see hqCoverageMap.js swapBoundaries). */
+.hq-coverage-watermark path.hq-cov-poly {
+  transition: fill-opacity 0.45s ease, stroke-opacity 0.45s ease;
+}
+body.dark-mode .hq-coverage-watermark.is-visible {
+  opacity: 0.42;
+}
+@media (max-width: 991.98px) {
+  .hq-coverage-watermark-clip {
+    display: none;
+  }
 }
 
 .btn-load-children {
@@ -2204,9 +2349,11 @@ overflow: hidden;
   display: grid;
   grid-template-columns: 210px minmax(0, 1fr);
   gap: 0;
-  /* Fixed working area so switching tabs never resizes the modal --
-     short panes get trailing space, tall panes scroll inside .config-panes. */
-  height: clamp(360px, 58vh, 620px);
+  /* One forgiving working height, held across every rail tab so the modal
+     never resizes when you switch. Most panes fit inside it; only a pane
+     you deliberately grow (e.g. "Show all" on a long HQ list) scrolls, and
+     it scrolls inside .config-panes -- the pill boxes themselves don't. */
+  height: clamp(400px, 66vh, 660px);
 }
 
 .config-rail {
@@ -2219,8 +2366,12 @@ overflow: hidden;
 .config-panes {
   height: 100%;
   overflow-y: auto;
+  /* clip x so a Bootstrap .row's negative gutter margin can't add a stray
+     horizontal scrollbar against the one-sided padding. */
+  overflow-x: hidden;
   border-left: 1px solid #dee2e6;
   padding-left: 1.25rem;
+  padding-right: 0.25rem;
 }
 
 .config-rail .nav-link {


### PR DESCRIPTION
## What

Bundles the outstanding work on this branch into one PR (targets `master-dev`).

### 1. Config modal — Data pane rework + HQ coverage watermark
- The "Only Show Incidents From" / team location filters move into a dedicated `.cfg-location` block above the data-window controls. The "Loading now" readout is dropped so the field stack stays a plain single column.
- Selected-filter pill boxes no longer scroll internally — they grow the pane, and collapse past 9 pills behind a **Show all N / Show fewer** toggle with a soft fade while clipped.
- New decorative **HQ coverage watermark** (`components/hqCoverageMap.js`): a non-interactive Esri imagery map bleeding off the pane's bottom-right corner, zoomed to the union of the incident-filter HQ unit boundaries and crossfading as the filter changes. Boundaries come from `BeaconClient.geoservices.unitBoundary`; only entries that have their own unit boundary are shaded (regions/zones must be expanded via *Load Children* first).

### 2. SignalR live updates — reconcile on config-modal close
- The connection is now gated on the config modal. `reconcileSignalRToConfig` runs on every `hidden.bs.modal`, so nothing negotiates until the on-load modal is dismissed, and toggling **Live Updates** is honoured immediately mid-session instead of only at page load.
- `connection.js` gains `stopBeaconSignalRConnection()` plus a `stoppedIntentionally` guard and a per-connection identity check, so a deliberate teardown (or a stop/start race) can't trigger the manual-restart path or act on a stale `onclose`.
- The disconnected banner only shows once a connection has actually been attempted (`signalrConnectionAttempted`), so the pre-dismiss modal state isn't flagged as a fault.

### 3. Fix: incident popup auto-pan stalling horizontally
`initPopupAutoPan` turns every Leaflet corner control into `autoPan` padding. Each side was only capped individually, so on a narrower map the left padding (legend) + right padding (alerts banner + wide Esri attribution line) + the popup width no longer fit across the map. Leaflet then can't satisfy both edges and silently stops panning on that axis — the popup opens clipped. The map is far taller than wide, so vertical still fits: the reported symptom was "vertical auto-pan works, horizontal doesn't". `fitPadding()` now shrinks the two opposite paddings proportionally (never below the 16px floor) so a ~430×320 popup always fits.

## Testing
- `npm run lint` — clean
- `npx webpack --config webpack.dev.js` — builds
- Manual: needs a check of the config modal Data pane (pill collapse/expand, watermark fit as filters change), Live Updates toggle on/off mid-session, and an incident popup opened near the left/right map edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
