### PR TITLE
Teams: make the Recent Activations load button discoverable

### DIFF
--- a/src/lib/teamRecentActivations.js
+++ b/src/lib/teamRecentActivations.js
@@ -240,14 +240,17 @@ function initRecentActivationsFieldset(teamViewModel) {
       '<legend>' +
         '<img id="lighthouseRecentActivationsLogo" style="width:14px;vertical-align:middle;margin-right:5px" />' +
         'Recent myAvailability Activation Requests' +
-        '<button type="button" class="btn btn-xs btn-default lighthouse-recent-activations-refresh"' + (isProd ? '' : ' disabled') + '>' +
-          '<span class="fa fa-refresh"></span> Refresh' +
-        '</button>' +
       '</legend>' +
       '<div class="form-group"><div class="col-xs-12">' +
+        (isProd ?
+          '<div class="lighthouse-recent-activations-bar">' +
+            '<button type="button" class="btn btn-sm btn-primary lighthouse-recent-activations-refresh">' +
+              '<span class="fa fa-refresh"></span> <span class="lighthouse-recent-activations-refresh-label">Load activation requests</span>' +
+            '</button>' +
+          '</div>' : '') +
         '<div class="lighthouse-recent-activations-list">' +
           '<div class="lighthouse-recent-activations-empty">' +
-            (isProd ? 'Click Refresh to load recent activations for the assigned unit.' :
+            (isProd ? 'Load the recent myAvailability activation requests for the team’s assigned unit, then expand one to add its responders straight into the team.' :
               'myAvailability activation requests are only available on production Beacon (this is train/dev).') +
           '</div>' +
         '</div>' +
@@ -263,6 +266,19 @@ function initRecentActivationsFieldset(teamViewModel) {
   if (!isProd) return; // placeholder only - no mams data outside prod
 
   var $list = $fieldset.find('.lighthouse-recent-activations-list');
+  var $refreshBtn = $fieldset.find('.lighthouse-recent-activations-refresh');
+  var $refreshLabel = $refreshBtn.find('.lighthouse-recent-activations-refresh-label');
+
+  // Before the first load the button is a primary call-to-action sitting
+  // above the list ("Load activations"); after the first load it shrinks to
+  // a plain "Refresh" and tucks up next to the legend, out of the way.
+  function markLoaded() {
+    if ($refreshBtn.closest('legend').length) return;
+    $refreshBtn.removeClass('btn-primary btn-sm').addClass('btn-default btn-xs');
+    $refreshLabel.text('Refresh');
+    $fieldset.find('legend').append($refreshBtn);
+    $fieldset.find('.lighthouse-recent-activations-bar').remove();
+  }
 
   function loadForEntity(entity) {
     // Not every entityAssignedTo is an SES Unit (e.g. a Region or State HQ
@@ -297,8 +313,9 @@ function initRecentActivationsFieldset(teamViewModel) {
   // selected.
   var hasLoadedOnce = false;
 
-  $fieldset.find('.lighthouse-recent-activations-refresh').on('click', function () {
+  $refreshBtn.on('click', function () {
     hasLoadedOnce = true;
+    markLoaded();
     loadForEntity(teamViewModel.entityAssignedTo.peek());
   });
 

--- a/src/styles/teams.recent-activations.css
+++ b/src/styles/teams.recent-activations.css
@@ -1,4 +1,8 @@
-#lighthouseRecentActivationsFieldset .lighthouse-recent-activations-refresh {
+#lighthouseRecentActivationsFieldset .lighthouse-recent-activations-bar {
+  margin-bottom: 8px;
+}
+
+#lighthouseRecentActivationsFieldset legend .lighthouse-recent-activations-refresh {
   float: right;
   margin-top: -3px;
 }


### PR DESCRIPTION
The **Recent myAvailability Activation Requests** fieldset on the Team Create / Team Edit pages had one control: a tiny `btn-xs` "Refresh" floated into the `<legend>`, easy to miss. Its horizontal position also drifted between the two forms, since it was right-aligned to a bootstrap grid edge that sits differently on Create vs Edit.

## Change

- Before the first load: a full-size primary **Load activation requests** button sits above the list, aligned with the list content.
- After the first load: it shrinks to a plain **Refresh** and moves up next to the legend title, out of the way.
- Removed the divider rule under the button.
- Train/dev is unchanged bar the button being gone there (it was disabled and did nothing).

No change to what the button fetches or the responder click-to-add behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)