### PR TITLE
Tasking: refresh unresolved actions on opsLogUpdated push

### DIFF
--- a/src/pages/tasking/main.js
+++ b/src/pages/tasking/main.js
@@ -4062,6 +4062,17 @@ document.addEventListener('DOMContentLoaded', function () {
             if (openJob && modalVisible && openJob.id() === message.JobId) {
                 timelineVm.refreshCurrentJob({ silent: true });
             }
+
+            // An ops log entry being added, edited or resolved is the only
+            // thing that changes a job's unresolved action-required tags, and
+            // nothing in the jobUpdated payload reflects it -- so this push is
+            // the sole live signal for the action-required badges/alerts on
+            // the job card, marker and popup. Re-pull the unresolved actions
+            // log for the affected job whenever it's tracked locally,
+            // regardless of expanded state (the fetch is cheap and the badges
+            // show while collapsed).
+            const job = myViewModel.jobsById.get(message.JobId);
+            if (job) myViewModel.fetchUnresolvedActionsLog(job);
         });
 
         // ICEMS unaccepted-notifications refresh: refreshUnacceptedNotifications


### PR DESCRIPTION
## Problem

The `opsLogUpdated` SignalR handler in `main.js` only refreshed the job timeline modal's ops log lane. It never re-pulled the job's **unresolved actions log**, which is the only thing that repopulates `job.actionRequiredTags` — the data behind the action-required badges/alerts on the job card, map marker and job popup.

`fetchUnresolvedActionsLog` was reachable exclusively through `Job.refreshData()` (manual refresh button, job expand, or a `jobUpdated` push). An ops log entry with an action tag being added, edited or resolved by another operator pushes `opsLogUpdated` but nothing else — so on every other client the action-required badges stayed stale until an unrelated `jobUpdated` fired or the user manually refreshed / re-expanded the job.

## Fix

In the `opsLogUpdated` handler, also re-fetch the unresolved actions log for the affected job whenever it's tracked locally, independent of the timeline modal and independent of expanded state (the fetch is cheap and the badges render while collapsed).

## Notes

- `fetchUnresolvedActionsLog` shows a `danger` toast on failure (session-expired path), matching the existing `refreshData` behaviour. If `opsLogUpdated` pushes arrive in bursts with a stale token this could repeat toasts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)