### PR TITLE
Tasking: fix dark-mode config-modal Layout presets and subtle badges

### DIFF
--- a/styles/pages/darkmode.css
+++ b/styles/pages/darkmode.css
@@ -1216,3 +1216,97 @@ body.dark-mode .fw-semibold,
 body.dark-mode .fw-normal {
   color: #e0e0e0;
 }
+
+/* Bootstrap 5.3 "subtle" background + "emphasis" text utilities.
+   These resolve to --bs-*-bg-subtle / --bs-*-text-emphasis, which only
+   flip to dark values under [data-bs-theme="dark"]. This app's dark mode
+   is a plain body class, so Bootstrap keeps serving the light values
+   (pale fill, dark text) -- and the base `body.dark-mode .badge` rule
+   above then forces the text to #e0e0e0, leaving unreadable pale-on-pale
+   chips (Search HQ chip, layer event/marker-count badges, "Subscribed").
+   Restate them with the same colours Bootstrap's own dark theme uses. */
+body.dark-mode .bg-primary-subtle {
+  background-color: #031633 !important;
+}
+
+body.dark-mode .bg-secondary-subtle {
+  background-color: #161719 !important;
+}
+
+body.dark-mode .bg-success-subtle {
+  background-color: #051b11 !important;
+}
+
+body.dark-mode .bg-info-subtle {
+  background-color: #032830 !important;
+}
+
+body.dark-mode .bg-warning-subtle {
+  background-color: #332701 !important;
+}
+
+body.dark-mode .bg-danger-subtle {
+  background-color: #2c0b0e !important;
+}
+
+body.dark-mode .text-primary-emphasis {
+  color: #6ea8fe !important;
+}
+
+body.dark-mode .text-secondary-emphasis {
+  color: #a7acb1 !important;
+}
+
+body.dark-mode .text-success-emphasis {
+  color: #75b798 !important;
+}
+
+body.dark-mode .text-info-emphasis {
+  color: #6edff6 !important;
+}
+
+body.dark-mode .text-warning-emphasis {
+  color: #ffda6a !important;
+}
+
+body.dark-mode .text-danger-emphasis {
+  color: #ea868f !important;
+}
+
+body.dark-mode .border-primary-subtle {
+  border-color: #084298 !important;
+}
+
+body.dark-mode .border-info-subtle {
+  border-color: #087990 !important;
+}
+
+/* Section Layout Preset picker (config modal -> Layout).
+   .layout-preset-card / -preview / .preview-block are styled off
+   --bs-body-bg / --bs-secondary-bg / --bs-border-color / --bs-emphasis-color,
+   which stay light without [data-bs-theme="dark"] -- so every card and its
+   mini mock-up rendered as a white block on the dark modal. */
+body.dark-mode .layout-preset-card {
+  background: #2d2d2d;
+  border-color: #444;
+}
+
+body.dark-mode .layout-preset-card.is-active {
+  border-color: #0d6efd;
+  box-shadow: inset 0 0 0 1px #0d6efd;
+}
+
+body.dark-mode .layout-preset-name {
+  color: #f0f0f0;
+}
+
+body.dark-mode .layout-preset-preview {
+  background: #1f1f1f;
+  border-color: #444;
+}
+
+body.dark-mode .layout-preset-preview .preview-block {
+  background: #383838;
+  border-color: #555;
+  color: #cfcfcf;
+}


### PR DESCRIPTION
## Problem

This page's dark mode is a plain `body.dark-mode` class, not Bootstrap 5.3's `[data-bs-theme="dark"]`. So every style that resolves through a Bootstrap theme token — the `*-subtle` backgrounds, `*-emphasis` text, and `--bs-body-bg` / `--bs-secondary-bg` / `--bs-border-color` / `--bs-emphasis-color` — kept serving its **light** value inside the dark config modal:

- **Layout pane → Section Layout Preset**: each card and its mini layout mock-up (`.layout-preset-card` / `.layout-preset-preview` / `.preview-block`) rendered as a **white block** on the dark modal.
- **Collaborative Layers**: the *Search HQ* chip and the layer event / marker-count / "Subscribed" badges (`bg-*-subtle text-*-emphasis`) came out **pale-on-pale** — a light subtle fill with text that the base `body.dark-mode .badge` rule then forced to `#e0e0e0`.

(Screenshots in the thread.)

## Fix

CSS-only, in `styles/pages/darkmode.css`:

- `body.dark-mode` overrides for the `.bg-*-subtle` / `.text-*-emphasis` / `.border-*-subtle` utilities, using the same colours Bootstrap's own dark theme uses.
- `body.dark-mode` overrides for `.layout-preset-card`, `.layout-preset-preview` and `.preview-block` (plus the `.is-active` ring and name text).

No markup or JS changes; light mode is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)