### PR TITLE
Tasking: fix per-instance timer leak causing map lag over long sessions

### DIFF
--- a/src/pages/tasking/models/Tasking.js
+++ b/src/pages/tasking/models/Tasking.js
@@ -8,6 +8,14 @@ import { Enum } from "../utils/enum.js";
 
 
 
+// Shared across every Tasking instance -- a single 5-minute interval for the
+// life of the module, rather than one per Tasking. Taskings are never pruned
+// from the registry (main.js taskingsById/taskings only grow), so a
+// per-instance timer would leak one live setInterval per tasking ever seen
+// for the whole session.
+const _tick = ko.observable(Date.now());
+setInterval(() => _tick(Date.now()), 300000);
+
 export function Tasking(data = {}) {
     const self = this;
 
@@ -47,11 +55,6 @@ export function Tasking(data = {}) {
 
     self.statusDropdownPage = ko.observable("details");
     self.newStatus = ko.observable(null);
-
-    //hacky way to make the time since tick up every 30 seconds
-    const _tick = ko.observable(Date.now());
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const _timer = setInterval(() => _tick(Date.now()), 300000);
 
     // status helpers
     self.statusSince = ko.pureComputed(() => (self.currentStatusTime() ? new Date(self.currentStatusTime()) : null));


### PR DESCRIPTION
## Summary
- Every `Tasking` model instance created its own permanent 5-minute `setInterval` (used only to force the "time since status" display to refresh).
- `Tasking` objects are pushed into `taskingsById`/`taskings` in main.js but, unlike jobs/teams, are never pruned/evicted — so the count of live intervals only ever grows for the life of a session.
- Left open for a long time (screen locked, idle tabs), this accumulates hundreds of live timers and retained closures, causing heap growth/GC pressure that manifests as laggy map panning. Pausing/resuming JS execution in DevTools (which forces a GC pass) temporarily "fixes" it — the symptom that led to this diagnosis.
- Fix: hoist the tick observable/interval to module scope so there's exactly one shared timer for the whole page, regardless of how many taskings are ever seen. Behavior (5-minute refresh of "time since" text) is unchanged.

## Test plan
- [ ] Load the tasking page, confirm "time since status" text still updates over a few 5-minute ticks.
- [ ] Leave the tasking page open for an extended period (or simulate by manually invoking `upsertTaskingFromPayload` many times) and confirm only one live interval exists (e.g. via DevTools performance/memory profiling), instead of one per tasking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)