### PR TITLE
Tasking: fix popup auto-pan not fitting overlays or settling after layout

### DIFF
--- a/src/pages/tasking/resize.js
+++ b/src/pages/tasking/resize.js
@@ -82,6 +82,18 @@ function restoreSizes() {
 applyLayoutPresetClass(currentLayoutPreset);
 restoreSizes();
 
+// The one-shot `setTimeout(invalidateMap, 0)` calls above assume layout has
+// settled by the next tick, but async content (KO bindings, web fonts, the
+// config-modal Data pane, ...) can still resize the map container after
+// that -- leaving Leaflet's cached size wrong until something else happens
+// to call invalidateSize() again (e.g. the user drags a splitter). Watch
+// the map container itself so any real size change -- however it happens --
+// keeps Leaflet's cached size correct without relying on a guessed delay.
+if (typeof ResizeObserver !== 'undefined') {
+  const mapContainerRO = new ResizeObserver(invalidateMap);
+  mapContainerRO.observe(map.getContainer());
+}
+
 // ===== Left↔Right (vertical splitter) =====
 let resizingLR = false, rafLR = 0;
 

--- a/src/pages/tasking/utils/popupAutoPan.js
+++ b/src/pages/tasking/utils/popupAutoPan.js
@@ -74,6 +74,30 @@ export const popupPadding = {
  *
  * Call once, right after the map is created.
  */
+// A corner wrapper's own getBoundingClientRect() misses descendants that
+// escape its layout box -- e.g. the layers-drawer flyout, which is
+// `position: absolute; left: 100%` so opening it doesn't push the other
+// top-left controls down. Union in every descendant's rect too, so an
+// overlay like that still counts as occupying screen space even though it
+// never grows its ancestor's own box.
+function cornerRect(corner) {
+    const rect = corner.getBoundingClientRect();
+    let top = rect.top, left = rect.left, right = rect.right, bottom = rect.bottom;
+    let any = rect.width > 0 && rect.height > 0;
+
+    corner.querySelectorAll('*').forEach((child) => {
+        const r = child.getBoundingClientRect();
+        if (r.width === 0 || r.height === 0) return;
+        any = true;
+        top = Math.min(top, r.top);
+        left = Math.min(left, r.left);
+        right = Math.max(right, r.right);
+        bottom = Math.max(bottom, r.bottom);
+    });
+
+    return any ? { top, left, right, bottom } : null;
+}
+
 export function initPopupAutoPan(map) {
     const { topLeft, bottomRight } = popupPadding;
 
@@ -84,14 +108,15 @@ export function initPopupAutoPan(map) {
     });
 
     const container = map.getContainer();
+    const corners = container.querySelectorAll('.leaflet-top, .leaflet-bottom');
 
     function recompute() {
         const mapRect = container.getBoundingClientRect();
         let left = MIN_PADDING, top = MIN_PADDING, right = MIN_PADDING, bottom = MIN_PADDING;
 
-        container.querySelectorAll('.leaflet-top, .leaflet-bottom').forEach((corner) => {
-            const rect = corner.getBoundingClientRect();
-            if (rect.width === 0 || rect.height === 0) return; // nothing docked in this corner
+        corners.forEach((corner) => {
+            const rect = cornerRect(corner);
+            if (!rect) return; // nothing docked in this corner
 
             if (corner.classList.contains('leaflet-top')) {
                 top = Math.max(top, rect.bottom - mapRect.top + EXTRA_MARGIN);
@@ -132,8 +157,24 @@ export function initPopupAutoPan(map) {
     // polling.
     if (typeof ResizeObserver !== 'undefined') {
         const ro = new ResizeObserver(recompute);
-        container.querySelectorAll('.leaflet-top, .leaflet-bottom').forEach((corner) => ro.observe(corner));
+        corners.forEach((corner) => ro.observe(corner));
     }
+
+    // Some overlays (e.g. the layers-drawer flyout) toggle open/closed via
+    // a class like `d-none` on an absolutely-positioned descendant, which
+    // never changes the corner wrapper's own box size -- so the
+    // ResizeObserver above never fires for them. Watch for that directly,
+    // scoped to just the corner controls (not the whole map/marker layer).
+    if (typeof MutationObserver !== 'undefined') {
+        const mo = new MutationObserver(recompute);
+        corners.forEach((corner) => mo.observe(corner, {
+            attributes: true,
+            attributeFilter: ['class', 'style'],
+            subtree: true,
+            childList: true,
+        }));
+    }
+
     window.addEventListener('resize', recompute);
 
     return { topLeft, bottomRight, recompute };


### PR DESCRIPTION
## Summary
- `popupAutoPan.js`'s corner padding measurement only read each Leaflet corner wrapper's own bounding box, missing descendants that escape it via `position: absolute` (e.g. the layers-drawer flyout) — and nothing recomputed padding when such a panel toggled open/closed anyway, since that only flips a class rather than resizing the wrapper.
- The map's cached size was only ever corrected by a single `setTimeout(invalidateSize, 0)` on load. If the container's real size hadn't settled by the next tick (async KO bindings, fonts, the config-modal Data pane, ...), popups opened against a stale size and never fit — until the user dragged a splitter, which calls `invalidateSize()` repeatedly. A `ResizeObserver` on the map container now keeps Leaflet's cached size correct continuously instead of guessing a delay.

## Test plan
- [x] Reloaded the tasking page and opened an incident popup near the right edge without touching the sidebar splitter first — map now pans to fit on the first try.
- [x] Opened the layers-drawer Data pane, then opened a popup that would otherwise sit under it — padding now accounts for the flyout.
- [x] `eslint` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)